### PR TITLE
lou_backTranslateString.c fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,11 @@ liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 - Added a callback system for logging purposes.
 
 ** Bug fixes
+- fix back translation problems when word gets split in unusual places
+causeing back translation of whole words for example K5 back
+translates to Knowledgeen, M>k back translates to Moreark, and M5 back
+translates to Moren.  This caused over 8400 extra back translation errors in en-us-g2 and 5000 in en-ueb-g2..
+
 - Fixed bug to prevent removal of \xffff between largesign rules. This
   solves a LibLouisUTDML bug where \xffff is used as a segment delimiter.
 - Fixed a bug in backtranslation, when a letsign was encountered, the


### PR DESCRIPTION
This commit fixes back translation problems when words gets split in
unusual places causeing back translation of whole words for example K5
back translates to Knowledgeen, M>k back translates to Moreark, and M5
back translates to Moren.  This caused over 8400 extra back
translation problems.
