### PR TITLE
en-ueb-g2 and en-ueb-chardef fixed contractions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,7 @@ warnings. This can be used from programs that use liblouis to log
 warnings for example.
 
 ** Bug fixes
+
 - fix back translation problems when word gets split in unusual places
   causing back translation of whole words for example K5 back
   translates to Knowledgeen, M>k back translates to Moreark, and M5
@@ -34,6 +35,11 @@ warnings for example.
 - Fixes to the build system by Simon Aittamaa
 
 ** Braille table improvements
+   - UEB table fixes: Fix contraction for ability which was missing
+     the ity contraction, fixed the missing end word contraction ;n ;d
+     sign 46, the words that are
+     affected are: abeyance, abound, abrasion, abundance, and fatherless
+     thanks to Ken Perry.	 
 - Fix for Norwegian where letsign is affecting some extra characters
   thanks to Lars Bjørndal
 - Much improved hyphenation for Norwegian thanks to Lars Bjørndal

--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -40,6 +40,7 @@ include loweredDigits6Dots.uti
 
 include latinLetterDef8Dots.uti
 
+noback sign . 46
 punctuation ( 12356
 punctuation } 12456
 punctuation ] 124567

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -366,6 +366,7 @@ word it's 1346-3-234
 word it'd 1346-3-145
 word it'll 1346-3-123-123
 word its 1346-234
+midendword ity 56-13456 
 contraction xs
 word itself 1346-124
 


### PR DESCRIPTION
This commit fixes the following problems found when comparing the duxbury UEB translations to ours.  These were the only forward translation problems found:

abeyance - leaving out dots 46 before the e in the ance contraction.
ability --BB spells out ity. It should be contracted as dots 56y.
abound - BB is missing dots 46 before the d in the ound contraction.
abrasion - BB is missing dots 46 before the n in the sion contraction
abundance - BB is missing dots 46 before the e in the ance contraction
fatherless - BB is missing dots 46 before the s in the less contraction
