### PR TITLE
Table discovery through metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ TAGS
 /tests/typeform
 /tests/uplow_with_unicode
 /tests/logging
+/tests/findTable
 
 # /tests/doctests/
 /tests/doctests/Makefile

--- a/liblouis/Makefile.am
+++ b/liblouis/Makefile.am
@@ -24,7 +24,8 @@ liblouis_la_SOURCES = \
 	logging.c \
 	lou_translateString.c \
 	transcommon.ci \
-	wrappers.c
+	wrappers.c \
+	findTable.c
 
 # Don't include liblouis.h in dist, this will break subdir builds
 # when dist is configured with a different ucs-option than the build,

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4586,6 +4586,30 @@ resolveSubtable (const char *table, const char *base, const char *searchPath)
   return NULL;
 }
 
+char *
+getTablePath()
+{
+  char searchPath[MAXSTRING];
+  char *path;
+  char *cp;
+  cp = searchPath;
+  path = getenv ("LOUIS_TABLEPATH");
+  if (path != NULL && path[0] != '\0')
+    cp += sprintf (cp, ",%s", path);
+  path = lou_getDataPath ();
+  if (path != NULL && path[0] != '\0')
+    cp += sprintf (cp, ",%s%c%s%c%s", path, DIR_SEP, "liblouis", DIR_SEP,
+		   "tables");
+#ifdef _WIN32
+  path = lou_getProgramPath ();
+  if (path != NULL && path[0] != '\0')
+    cp += sprintf (cp, ",%s%s", path, "\\share\\liblouis\\tables");
+#else
+  cp += sprintf (cp, ",%s", TABLESDIR);
+#endif
+  return strdup(searchPath);
+}
+
 /**
  * The default table resolver
  *
@@ -4603,31 +4627,16 @@ resolveSubtable (const char *table, const char *base, const char *searchPath)
 static char **
 defaultTableResolver (const char *tableList, const char *base)
 {
-  char searchPath[MAXSTRING];
+  char * searchPath;
   char **tableFiles;
   char *subTable;
   char *tableList_copy;
   char *cp;
-  char *path;
   int last;
   int k;
   
   /* Set up search path */
-  cp = searchPath;
-  path = getenv ("LOUIS_TABLEPATH");
-  if (path != NULL && path[0] != '\0')
-    cp += sprintf (cp, ",%s", path);
-  path = lou_getDataPath ();
-  if (path != NULL && path[0] != '\0')
-    cp += sprintf (cp, ",%s%c%s%c%s", path, DIR_SEP, "liblouis", DIR_SEP,
-		   "tables");
-#ifdef _WIN32
-  path = lou_getProgramPath ();
-  if (path != NULL && path[0] != '\0')
-    cp += sprintf (cp, ",%s%s", path, "\\share\\liblouis\\tables");
-#else
-  cp += sprintf (cp, ",%s", TABLESDIR);
-#endif
+  searchPath = getTablePath();
   
   /* Count number of subtables in table list */
   k = 0;
@@ -4647,6 +4656,7 @@ defaultTableResolver (const char *tableList, const char *base)
       if (!(tableFiles[k++] = resolveSubtable (subTable, base, searchPath)))
 	{
 	  logMessage (LOG_ERROR, "Cannot resolve table '%s'", subTable);
+	  free(searchPath);
 	  free(tableList_copy);
 	  free (tableFiles);
 	  return NULL;
@@ -4656,6 +4666,7 @@ defaultTableResolver (const char *tableList, const char *base)
       if (last)
 	break;
     }
+  free(searchPath);
   free(tableList_copy);
   tableFiles[k] = NULL;
   return tableFiles;
@@ -4664,7 +4675,7 @@ defaultTableResolver (const char *tableList, const char *base)
 static char ** (* tableResolver) (const char *tableList, const char *base) =
   &defaultTableResolver;
 
-static char **
+char **
 resolveTable (const char *tableList, const char *base)
 {
   return (*tableResolver) (tableList, base);

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -342,24 +342,6 @@ static const char *opcodeNames[CTO_None] = {
 };
 static short opcodeLengths[CTO_None] = { 0 };
 
-typedef enum
-{ noEncoding, bigEndian, littleEndian, ascii8 } EncodingType;
-
-
-typedef struct
-{
-  const char *fileName;
-  FILE *in;
-  int lineNumber;
-  EncodingType encoding;
-  int status;
-  int linelen;
-  int linepos;
-  int checkencoding[2];
-  widechar line[MAXSTRING];
-}
-FileInfo;
-
 static char scratchBuf[MAXSTRING];
 
 char *
@@ -578,7 +560,7 @@ getAChar (FileInfo * nested)
   return EOF;
 }
 
-static int
+int
 getALine (FileInfo * nested)
 {
 /*Read a line of widechar's from an input file */

--- a/liblouis/findTable.c
+++ b/liblouis/findTable.c
@@ -1,0 +1,564 @@
+/*
+ Copyright (C) 2015 Bert Frees
+ 
+ This file is free software; you can redistribute it and/or modify it under
+ the terms of the Lesser or Library GNU General Public License as published by
+ the Free Software Foundation; either version 3, or (at your option) any later
+ version.
+ 
+ This file is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ A PARTICULAR PURPOSE.  See the Library GNU General Public License for more
+ details.
+ 
+ You should have received a copy of the Library GNU General Public License
+ along with this program; see the file COPYING.  If not, write to the Free
+ Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ USA.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include "louis.h"
+
+/* =============================== LIST =================================== */
+
+typedef struct List
+{
+  void * head;
+  void (* free)(void *);
+  struct List * tail;
+} List;
+
+/*
+ * Returns a list with the element `x' added to `list'. Returns a sorted list
+ * if `cmp' is not NULL and if `list' is also sorted. New elements replace
+ * existing ones if they are equal according to `cmp'. If `cmp' is NULL,
+ * elements are simply prepended to the list. The function `dup' is used to
+ * duplicate elements before they are added to the list. If `free' function is
+ * used to free elements when they are removed from the list. The returned
+ * list must be freed by the caller.
+ */
+static List *
+list_conj(List * list,
+	  void * x,
+	  int (* cmp)(void *, void *),
+	  void * (* dup)(void *),
+	  void (* free)(void *))
+{
+  if (!list)
+    {
+      list = malloc(sizeof(List));
+      list->head = dup ? dup(x) : x;
+      list->free = free;
+      list->tail = NULL;
+      return list;
+    }
+  else if (!cmp)
+    {
+      List * l = malloc(sizeof(List));
+      l->head = dup ? dup(x) : x;
+      l->free = free;
+      l->tail = list;
+      return l;
+    }
+  else
+    {
+      List * l1 = list;
+      List * l2 = NULL;
+      while (l1)
+	{
+	  int c = cmp(l1->head, x);
+	  if (c > 0)
+	    break;
+	  else if (c < 0)
+	    {
+	      l2 = l1;
+	      l1 = l2->tail;
+	    }
+	  else
+	    {
+	      if (x != l1->head && !dup && free)
+		free(x);
+	      return list;
+	    }
+	}
+      List * l3 = malloc(sizeof(List));
+      l3->head = dup? dup(x) : x;
+      l3->free = free;
+      l3->tail = l1;
+      if (!l2)
+	list = l3;
+      else
+	l2->tail = l3;
+      return list;
+    }
+}
+
+/*
+ * Free an instance of type List.
+ */
+static void
+list_free(List * list)
+{
+  if (list)
+    {
+      if (list->free)
+	list->free(list->head);
+      list_free(list->tail);
+      free(list);
+    }
+}
+
+/*
+ * Sort a list based on a comparison function.
+ */
+static List *
+list_sort(List * list, int (* cmp)(void *, void *))
+{
+  List * newList = NULL;
+  List * l;
+  for (l = list; l; l = l->tail)
+    {
+      newList = list_conj(newList, l->head, cmp, NULL, l->free);
+      l->free = NULL;
+    }
+  list_free(list);
+  return newList;
+}
+
+/* ============================== FEATURE ================================= */
+
+typedef struct
+{
+  char * key;
+  char * val;
+} Feature;
+
+typedef struct
+{
+  Feature feature;
+  int importance;
+} FeatureWithImportance;
+
+typedef struct
+{
+  char * name;
+  List * features;
+} TableMeta;
+
+/*
+ * Create an instance of type Feature. The `key' and `val' strings are
+ * duplicated. Leaving out the `val' argument results in a value of "yes".
+ */
+static Feature
+feature_new(const char * key, const char * val)
+{
+  static char * YES = "yes";
+  Feature f;
+  f.key = strdup(key);
+  f.val = strdup(val ? val : YES);
+  return f;
+}
+
+/*
+ * Free an instance of type Feature
+ */
+static void
+feature_free(Feature * f)
+{
+  if (f)
+    {
+      free(f->key);
+      free(f->val);
+      free(f);
+    }
+}
+
+/* ======================================================================== */
+
+/*
+ * Sort features based on their keys.
+ */
+static int
+cmpKeys(Feature * f1, Feature * f2)
+{
+  return strcmp(f1->key, f2->key);
+}
+
+/*
+ * Compute the match quotient of the features in a query against the features
+ * in a table's metadata. The features are assumed to be sorted and to have no
+ * duplicate keys. The query's features must be of type
+ * FeatureWithImportance. How a feature contributes to the match quotient
+ * depends on its importance, on whether the feature is undefined, defined
+ * with the same value (positive match), or defined with a different value
+ * (negative match), and on the `fuzzy' argument. If the `fuzzy' argument
+ * evaluates to true, negative matches and undefined features get a lower
+ * penalty.
+ */
+static int
+matchFeatureLists(const List * query, const List * tableFeatures, int fuzzy)
+{
+  static int POS_MATCH = 10;
+  static int NEG_MATCH = -100;
+  static int UNDEFINED = -20;
+  static int EXTRA = -1;
+  static int POS_MATCH_FUZZY = 10;
+  static int NEG_MATCH_FUZZY = -25;
+  static int UNDEFINED_FUZZY = -5;
+  static int EXTRA_FUZZY = -1;
+  int posMatch, negMatch, undefined, extra;
+  if (!fuzzy)
+    {
+      posMatch = POS_MATCH;
+      negMatch = NEG_MATCH;
+      undefined = UNDEFINED;
+      extra = EXTRA;
+    }
+  else
+    {
+      posMatch = POS_MATCH_FUZZY;
+      negMatch = NEG_MATCH_FUZZY;
+      undefined = UNDEFINED_FUZZY;
+      extra = EXTRA_FUZZY;
+    }
+  int quotient = 0;
+  const List * l1 = query;
+  const List * l2 = tableFeatures;
+  while (1)
+    {
+      if (!l1)
+	{
+	  if (!l2)
+	    break;
+	  quotient += extra;
+	  l2 = l2->tail;
+	}
+      else if (!l2)
+	{
+	  quotient += undefined;
+	  l1 = l1->tail;
+	}
+      else
+	{
+	  int cmp = cmpKeys(l1->head, l2->head);
+	  if (cmp < 0)
+	    {
+	      quotient += undefined;
+	      l1 = l1->tail;
+	    }
+	  else if (cmp > 0)
+	    {
+	      quotient += extra;
+	      l2 = l2->tail;
+	    }
+	  else
+	    {
+	      if (strcmp(((Feature *)l1->head)->val, ((Feature *)l2->head)->val) == 0)
+		quotient += posMatch;
+	      else
+		quotient += negMatch;
+	      l1 = l1->tail;
+	      l2 = l2->tail;
+	    }
+	}
+    }
+  return quotient;
+}
+
+/*
+ * Return true if a character matches [0-9A-Za-z_-]
+ */
+static int
+isIdentChar(char c)
+{
+  return (c >= '0' && c <= '9')
+      || (c >= 'A' && c <= 'Z')
+      || (c >= 'a' && c <= 'z')
+      || c == '-'
+      || c == '_';
+}
+
+/*
+ * Parse a table query into a list of features. Features defined first get a
+ * higher importance.
+ */
+static List *
+parseQuery(const char * query)
+{
+  List * features = NULL;
+  const char * key = NULL;
+  const char * val = NULL;
+  size_t keySize = 0;
+  size_t valSize = 0;
+  const char * c;
+  int pos = 0;
+  while (1)
+    {
+      c = &query[pos++];
+      if (*c == ' ' || *c == '\t' || *c == '\n' | *c == '\0')
+	{
+	  if (key)
+	    {
+	      char * k = strndup(key, keySize);
+	      char * v = val ? strndup(val, valSize) : NULL;
+	      FeatureWithImportance f = { feature_new(k, v), 0 };
+	      logMessage(LOG_DEBUG, "Query has feature '%s:%s'", f.feature.key, f.feature.val);
+	      features = list_conj(features, memcpy(malloc(sizeof(f)), &f, sizeof(f)),
+				   NULL, NULL, (void (*)(void *))feature_free);
+	      free(k);
+	      free(v);
+	      key = val = NULL;
+	      keySize = valSize = 0;
+	    }
+	  if (*c == '\0')
+	    break;
+	}
+      else if (*c == ':')
+	{
+	  if (!key || val)
+	    goto compile_error;
+	  else
+	    {
+	      c = &query[pos++];
+	      if (isIdentChar(*c))
+		{
+		  val = c;
+		  valSize = 1;
+		}
+	      else
+		goto compile_error;
+	    }
+	}
+      else if (isIdentChar(*c))
+	{
+	  if (val)
+	    valSize++;
+	  else if (key)
+	    keySize++;
+	  else
+	    {
+	      key = c;
+	      keySize = 1;
+	    }
+	}
+      else
+	goto compile_error;
+    }
+  int k = 1;
+  List * l;
+  for (l = features; l; l = l->tail)
+    {
+      FeatureWithImportance * f = l->head;
+      f->importance = k++;
+    }
+  return list_sort(features, (int (*)(void *, void *))cmpKeys);
+ compile_error:
+  logMessage(LOG_ERROR, "Unexpected character '%c' at position %d", c, pos);
+  list_free(features);
+  return NULL;
+}
+
+/*
+ * Convert a widechar string to a normal string.
+ */
+static char *
+widestrToStr(const widechar * str, size_t n)
+{
+  char * result = malloc((1 + n) * sizeof(char));
+  int k;
+  for (k = 0; k < n; k++)
+    result[k] = str[k];
+  result[k] = '\0';
+  return result;
+}
+
+/*
+ * Extract a list of features from a file.
+ */
+static List *
+analyzeTable(const char * fileName)
+{
+  List * features = NULL;
+  FileInfo info;
+  info.fileName = fileName;
+  info.encoding = noEncoding;
+  info.status = 0;
+  info.lineNumber = 0;
+  if ((info.in = fopen(fileName, "rb")))
+    {
+      while (getALine(&info))
+	{
+	  if (info.linelen == 0);
+	  else if (info.line[0] == '#')
+	    {
+	      if (info.linelen >= 2 && info.line[1] == '+')
+		{
+		  widechar * key = NULL;
+		  widechar * val = NULL;
+		  size_t keySize = 0;
+		  size_t valSize = 0;
+		  info.linepos = 2;
+		  if (info.linepos < info.linelen && isIdentChar(info.line[info.linepos]))
+		    {
+		      key = &info.line[info.linepos];
+		      keySize = 1;
+		      info.linepos++;
+		      while (info.linepos < info.linelen && isIdentChar(info.line[info.linepos]))
+			{
+			  keySize++;
+			  info.linepos++;
+			}
+		      if (info.linepos < info.linelen && info.line[info.linepos] == ':')
+			{
+			  info.linepos++;
+			  while (info.linepos < info.linelen
+				 && (info.line[info.linepos] == ' ' || info.line[info.linepos] == '\t'))
+			    info.linepos++;
+			  if (info.linepos < info.linelen && isIdentChar(info.line[info.linepos]))
+			    {
+			      val = &info.line[info.linepos];
+			      valSize = 1;
+			      info.linepos++;
+			      while (info.linepos < info.linelen && isIdentChar(info.line[info.linepos]))
+				{
+				  valSize++;
+				  info.linepos++;
+				}
+			    }
+			  else
+			    goto compile_error;
+			}
+		      if (info.linepos == info.linelen)
+			{
+			  char * k = widestrToStr(key, keySize);
+			  char * v = val ? widestrToStr(val, valSize) : NULL;
+			  Feature f = feature_new(k, v);
+			  logMessage(LOG_DEBUG, "Table has feature '%s:%s'", f.key, f.val);
+			  features = list_conj(features, memcpy(malloc(sizeof(f)), &f, sizeof(f)),
+					       NULL, NULL, (void (*)(void *))feature_free);
+			  free(k);
+			  free(v);
+			}
+		      else
+			goto compile_error;
+		    }
+		  else
+		    goto compile_error;
+		}
+	    }
+	  else
+	    break;
+	}
+      fclose(info.in);
+    }
+  else
+    logMessage (LOG_ERROR, "Cannot open table '%s'", fileName);
+  return list_sort(features, (int (*)(void *, void *))cmpKeys);
+ compile_error:
+  if (info.linepos < info.linelen)
+    logMessage(LOG_ERROR, "Unexpected character '%c' on line %d, column %d",
+	       info.line[info.linepos],
+	       info.lineNumber,
+	       info.linepos);
+  else
+    logMessage(LOG_ERROR, "Unexpected newline on line %d", info.lineNumber);
+  list_free(features);
+  return NULL;
+}
+
+static List * tableIndex = NULL;
+
+#ifdef _WIN32
+#define DIR_SEP '\\'
+#else
+#define DIR_SEP '/'
+#endif
+
+void EXPORT_CALL
+lou_indexTables(const char * searchPath)
+{
+  char * dirName;
+  DIR * dir;
+  struct dirent * file;
+  static char fileName[MAXSTRING];
+  struct stat info;
+  int pos = 0;
+  int n;
+  list_free(tableIndex);
+  tableIndex = NULL;
+  while (1)
+    {
+      for (n = 0; searchPath[pos + n] != '\0' && searchPath[pos + n] != ','; n++);
+      dirName = strndup(&searchPath[pos], n);
+      if ((dir = opendir(dirName)))
+	{
+	  while ((file = readdir(dir)))
+	    {
+	      sprintf(fileName, "%s%c%s", dirName, DIR_SEP, file->d_name);
+	      if (stat(fileName, &info) == 0 && !(info.st_mode & S_IFDIR))
+		{
+		  logMessage(LOG_DEBUG, "Analyzing table %s", fileName);
+		  List * features = analyzeTable(fileName);
+		  if (features)
+		    {
+		      TableMeta m = { strdup(fileName), features };
+		      tableIndex = list_conj(tableIndex, memcpy(malloc(sizeof(m)), &m, sizeof(m)), NULL, NULL, free);
+		    }
+		}
+	    }
+	  closedir(dir);
+	}
+      else
+	{
+	  logMessage(LOG_WARN, "%s is not a directory", dirName);
+	}
+      free(dirName);
+      pos += n;
+      if (searchPath[pos] == '\0')
+	break;
+      else
+	pos++;
+    }
+  if (!tableIndex)
+    logMessage(LOG_WARN, "No tables were indexed");
+}
+
+char * EXPORT_CALL
+lou_findTable(const char * query)
+{
+  if (tableIndex)
+    {
+      List * queryFeatures = parseQuery(query);
+      int bestQuotient = 0;
+      char * bestMatch = NULL;
+      List * l;
+      for (l = tableIndex; l; l = l->tail)
+	{
+	  TableMeta * table = l->head;
+	  int q = matchFeatureLists(queryFeatures, table->features, 0);
+	  if (q > bestQuotient)
+	    {
+	      bestQuotient = q;
+	      bestMatch = strdup(table->name);
+	    }
+	}
+      logMessage(LOG_INFO, "Best match: %s (%d)", bestMatch, bestQuotient);
+      if (bestMatch)
+	return bestMatch;
+      else
+	{
+	  logMessage(LOG_INFO, "No table could be found for query '%s'", query);
+	  return NULL;
+	}
+    }
+  else
+    {
+      logMessage(LOG_ERROR, "Tables have not been indexed yet. Call lou_indexTables first.");
+      return NULL;
+    }
+}

--- a/liblouis/findTable.c
+++ b/liblouis/findTable.c
@@ -130,6 +130,36 @@ list_sort(List * list, int (* cmp)(void *, void *))
   return newList;
 }
 
+/*
+ * Get the size of a list.
+ */
+static int
+list_size(List * list)
+{
+  int len = 0;
+  List * l;
+  for (l = list; l; l = l->tail)
+    len++;
+  return len;
+}
+
+/*
+ * Convert a list into a NULL terminated array.
+ */
+static void **
+list_toArray(List * list, void * (* dup)(void *))
+{
+  void ** array;
+  List * l;
+  int i;
+  array = malloc((1 + list_size(list)) * sizeof(void *));
+  i = 0;
+  for (l = list; l; l = l->tail)
+    array[i++] = dup ? dup(l->head) : l->head;
+  array[i] = NULL;
+  return array;
+}
+
 /* ============================== FEATURE ================================= */
 
 typedef struct
@@ -378,18 +408,30 @@ widestrToStr(const widechar * str, size_t n)
 }
 
 /*
- * Extract a list of features from a file.
+ * Extract a list of features from a table.
  */
 static List *
-analyzeTable(const char * fileName)
+analyzeTable(const char * table)
 {
+  char ** fileName;
   List * features = NULL;
   FileInfo info;
-  info.fileName = fileName;
+  fileName = resolveTable(table, NULL);
+  if (fileName == NULL)
+    {
+      logMessage(LOG_ERROR, "Cannot resolve table '%s'", table);
+      return NULL;
+    }
+  if (fileName[1] != NULL)
+    {
+      logMessage(LOG_ERROR, "Table '%s' resolves to more than one file", table);
+      return NULL;
+    }
+  info.fileName = *fileName;
   info.encoding = noEncoding;
   info.status = 0;
   info.lineNumber = 0;
-  if ((info.in = fopen(fileName, "rb")))
+  if ((info.in = fopen(info.fileName, "rb")))
     {
       while (getALine(&info))
 	{
@@ -457,7 +499,7 @@ analyzeTable(const char * fileName)
       fclose(info.in);
     }
   else
-    logMessage (LOG_ERROR, "Cannot open table '%s'", fileName);
+    logMessage (LOG_ERROR, "Cannot open table '%s'", info.fileName);
   return list_sort(features, (int (*)(void *, void *))cmpKeys);
  compile_error:
   if (info.linepos < info.linelen)
@@ -473,15 +515,40 @@ analyzeTable(const char * fileName)
 
 static List * tableIndex = NULL;
 
+void EXPORT_CALL
+lou_indexTables(const char ** tables)
+{
+  const char ** table;
+  list_free(tableIndex);
+  tableIndex = NULL;
+  for (table = tables; *table; table++)
+    {
+      logMessage(LOG_DEBUG, "Analyzing table %s", *table);
+      List * features = analyzeTable(*table);
+      if (features)
+	{
+	  TableMeta m = { strdup(*table), features };
+	  tableIndex = list_conj(tableIndex, memcpy(malloc(sizeof(m)), &m, sizeof(m)), NULL, NULL, free);
+	}
+    }
+  if (!tableIndex)
+    logMessage(LOG_WARN, "No tables were indexed");
+}
+
 #ifdef _WIN32
 #define DIR_SEP '\\'
 #else
 #define DIR_SEP '/'
 #endif
 
-void EXPORT_CALL
-lou_indexTables(const char * searchPath)
+/*
+ * Returns the list of files found on searchPath, where searchPath is a
+ * comma-separated list of directories.
+ */
+static List *
+listFiles(char * searchPath)
 {
+  List * list;
   char * dirName;
   DIR * dir;
   struct dirent * file;
@@ -489,8 +556,6 @@ lou_indexTables(const char * searchPath)
   struct stat info;
   int pos = 0;
   int n;
-  list_free(tableIndex);
-  tableIndex = NULL;
   while (1)
     {
       for (n = 0; searchPath[pos + n] != '\0' && searchPath[pos + n] != ','; n++);
@@ -502,13 +567,7 @@ lou_indexTables(const char * searchPath)
 	      sprintf(fileName, "%s%c%s", dirName, DIR_SEP, file->d_name);
 	      if (stat(fileName, &info) == 0 && !(info.st_mode & S_IFDIR))
 		{
-		  logMessage(LOG_DEBUG, "Analyzing table %s", fileName);
-		  List * features = analyzeTable(fileName);
-		  if (features)
-		    {
-		      TableMeta m = { strdup(fileName), features };
-		      tableIndex = list_conj(tableIndex, memcpy(malloc(sizeof(m)), &m, sizeof(m)), NULL, NULL, free);
-		    }
+		  list = list_conj(list, strdup(fileName), NULL, NULL, free);
 		}
 	    }
 	  closedir(dir);
@@ -524,41 +583,48 @@ lou_indexTables(const char * searchPath)
       else
 	pos++;
     }
-  if (!tableIndex)
-    logMessage(LOG_WARN, "No tables were indexed");
+  return list;
 }
 
 char * EXPORT_CALL
 lou_findTable(const char * query)
 {
-  if (tableIndex)
+  if (!tableIndex)
     {
-      List * queryFeatures = parseQuery(query);
-      int bestQuotient = 0;
-      char * bestMatch = NULL;
-      List * l;
-      for (l = tableIndex; l; l = l->tail)
+      char * searchPath;
+      List * tables;
+      const char ** tablesArray;
+      logMessage(LOG_WARN, "Tables have not been indexed yet. Indexing LOUIS_TABLEPATH.");
+      searchPath = getTablePath();
+      tables = listFiles(searchPath);
+      tablesArray = list_toArray(tables, NULL);
+      lou_indexTables(tablesArray);
+      free(searchPath);
+      list_free(tables);
+      free(tablesArray);
+    }
+  List * queryFeatures = parseQuery(query);
+  int bestQuotient = 0;
+  char * bestMatch = NULL;
+  List * l;
+  for (l = tableIndex; l; l = l->tail)
+    {
+      TableMeta * table = l->head;
+      int q = matchFeatureLists(queryFeatures, table->features, 0);
+      if (q > bestQuotient)
 	{
-	  TableMeta * table = l->head;
-	  int q = matchFeatureLists(queryFeatures, table->features, 0);
-	  if (q > bestQuotient)
-	    {
-	      bestQuotient = q;
-	      bestMatch = strdup(table->name);
-	    }
-	}
-      logMessage(LOG_INFO, "Best match: %s (%d)", bestMatch, bestQuotient);
-      if (bestMatch)
-	return bestMatch;
-      else
-	{
-	  logMessage(LOG_INFO, "No table could be found for query '%s'", query);
-	  return NULL;
+	  bestQuotient = q;
+	  bestMatch = strdup(table->name);
 	}
     }
+  if (bestMatch)
+     {
+       logMessage(LOG_INFO, "Best match: %s (%d)", bestMatch, bestQuotient);
+       return bestMatch;
+     }
   else
     {
-      logMessage(LOG_ERROR, "Tables have not been indexed yet. Call lou_indexTables first.");
+      logMessage(LOG_INFO, "No table could be found for query '%s'", query);
       return NULL;
     }
 }

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -174,11 +174,10 @@ typedef void (*logcallback)(int level, const char *message);
   void EXPORT_CALL lou_setLogLevel(logLevels level);
 /* Set the level for logging callback to be called at */
 
-void EXPORT_CALL lou_indexTables(const char * searchPath);
-/* Parses, analyzes and indexes table on searchPath. searchPath is a
- * colon-separated list of directories to search for tables. This function
- * must be called prior to lou_findTable(). An error message is given when a
- * table contains invalid or duplicate metadata fields.
+void EXPORT_CALL lou_indexTables(const char ** tables);
+/* Parses, analyzes and indexes tables. This function must be called prior to
+ * lou_findTable(). An error message is given when a table contains invalid or
+ * duplicate metadata fields.
  */
 char * EXPORT_CALL lou_findTable(const char * query);
 /* Finds the best match for a query. Returns a string with the table

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -173,6 +173,19 @@ typedef void (*logcallback)(int level, const char *message);
   } logLevels;
   void EXPORT_CALL lou_setLogLevel(logLevels level);
 /* Set the level for logging callback to be called at */
+
+void EXPORT_CALL lou_indexTables(const char * searchPath);
+/* Parses, analyzes and indexes table on searchPath. searchPath is a
+ * colon-separated list of directories to search for tables. This function
+ * must be called prior to lou_findTable(). An error message is given when a
+ * table contains invalid or duplicate metadata fields.
+ */
+char * EXPORT_CALL lou_findTable(const char * query);
+/* Finds the best match for a query. Returns a string with the table
+ * name. Returns NULL when no match can be found. An error message is given
+ * when the query is invalid.
+ */
+
   void EXPORT_CALL lou_free ();
 /* This function should be called at the end of 
 * the application to free all memory allocated by liblouis. */

--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -501,6 +501,12 @@ extern "C"
   int getALine (FileInfo * info);
 /* Read a line of widechar's from an input file */
 
+  char * getTablePath();
+/* Comma separated list of directories to search for tables. */
+
+  char ** resolveTable(const char *tableList, const char *base);
+/* Resolve tableList against base. */
+
   widechar getDotsForChar (widechar c);
 /* Returns the single-cell dot pattern corresponding to a character. */
 

--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -477,9 +477,29 @@ extern "C"
     alloc_srcMapping,
     alloc_prevSrcMapping
   } AllocBuf;
+
+  typedef enum
+  { noEncoding, bigEndian, littleEndian, ascii8 } EncodingType;
+
+  typedef struct
+  {
+    const char *fileName;
+    FILE *in;
+    int lineNumber;
+    EncodingType encoding;
+    int status;
+    int linelen;
+    int linepos;
+    int checkencoding[2];
+    widechar line[MAXSTRING];
+  } FileInfo;
+
 /* The following function definitions are hooks into 
 * compileTranslationTable.c. Some are used by other library modules. 
 * Others are used by tools like lou_allround.c and lou_debug.c. */
+
+  int getALine (FileInfo * info);
+/* Read a line of widechar's from an input file */
 
   widechar getDotsForChar (widechar c);
 /* Returns the single-cell dot pattern corresponding to a character. */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -130,6 +130,9 @@ resolve_table_SOURCES =				\
 logging_SOURCES =				\
 	logging.c
 
+findTable_SOURCES =				\
+	findTable.c
+
 # Note that this is not currently included in check_programs below
 # otherwise make check would never complete.
 infiniteTranslationLoop_SOURCES =				\
@@ -164,7 +167,8 @@ check_PROGRAMS =				\
 	pass0_typebuf				\
 	hash_collision                          \
 	resolve_table                          \
-	logging
+	logging                          \
+	findTable
 
 
 dist_check_SCRIPTS =		\

--- a/tests/findTable.c
+++ b/tests/findTable.c
@@ -9,8 +9,9 @@ main(int argc, char **argv)
 {
   int success = 0;
   char * match;
+  const char * tables[] = {"tablesWithMetadata/foo","tablesWithMetadata/bar"};
   lou_setLogLevel(LOG_DEBUG);
-  lou_indexTables("tablesWithMetadata");
+  lou_indexTables(tables);
   match = lou_findTable("id:foo");
   success |= (!match || strcmp(match, "tablesWithMetadata/foo"));
   match = lou_findTable("language:en");

--- a/tests/findTable.c
+++ b/tests/findTable.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "louis.h"
+
+int
+main(int argc, char **argv)
+{
+  int success = 0;
+  char * match;
+  lou_setLogLevel(LOG_DEBUG);
+  lou_indexTables("tablesWithMetadata");
+  match = lou_findTable("id:foo");
+  success |= (!match || strcmp(match, "tablesWithMetadata/foo"));
+  match = lou_findTable("language:en");
+  success |= (!match || strcmp(match, "tablesWithMetadata/bar"));
+  return success;
+}

--- a/tests/tablesWithMetadata/bar
+++ b/tests/tablesWithMetadata/bar
@@ -1,0 +1,2 @@
+#+id: bar
+#+language:en

--- a/tests/tablesWithMetadata/foo
+++ b/tests/tablesWithMetadata/foo
@@ -1,0 +1,3 @@
+#+id: foo
+#+language:en
+#+type: contracted


### PR DESCRIPTION
In [todo:Including metadata in table headers](http://liblouis.org/todo/table_header) I propose a table header format that can contain metadata about the table, for two use cases:

- table discovery
- metadata for user interfaces and localization

This issue addresses the first use case only.

To do:
- [x] basic feature parsing and match algorithm
- [ ] key and value normalization
- [ ] give features that are defined first in a query more weight
- [ ] support "!" for marking important features 
- [ ] special handling of "locale"
- [ ] special handling of "min-grade" etc.
- [ ] fuzzy matching
- [ ] decide on standard field names and add metadata to tables

Related:
- [ ] https://github.com/liblouis/liblouis/issues/43

<!---
@huboard:{"order":0.515625,"milestone_order":41,"custom_state":""}
-->
