### PR TITLE
runHarness.py: fix decoding of JSON files

### DIFF
--- a/tests/harness/runHarness.py
+++ b/tests/harness/runHarness.py
@@ -27,6 +27,7 @@ Please see the liblouis documentation for information of how to add a new harnes
 @author: Hammer Attila <hammera@pickup.hu>
 """
 
+import codecs
 import argparse
 import json
 import os
@@ -223,9 +224,9 @@ def test_allCases():
         # Process all *_harness.txt files in the harness directory.
         testfiles=iglob(os.path.join(harness_dir, '*_harness.txt'))
     for harness in testfiles:
-        f = open(harness, 'r')
+        f = codecs.open(harness, 'r', encoding='utf-8')
         try:
-            harnessModule = json.load(f, encoding="UTF-8")
+            harnessModule = json.load(f)
         except ValueError as e:
             raise ValueError("%s doesn't look like a harness file, %s" %(harness, e.message))
         f.close()


### PR DESCRIPTION
According to the documentation of json.load the encoding argument is ignored and deprecated: https://docs.python.org/3/library/json.html

I noticed the problem on a Windows machine.

Please check if this change doesn't break things on other platforms.