### PR TITLE
Make dependency on makeinfo 5 optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,9 @@
-SUBDIRS = gnulib liblouis tools tables doc man tests python m4 windows
+SUBDIRS = gnulib liblouis tools tables man tests python m4 windows
+
+# only build the documentation if we have makeinfo 5
+if HAVE_MAKEINFO_5
+SUBDIRS += doc
+endif
 
 ACLOCAL_AMFLAGS = -I m4 -I gnulib/m4
 

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 ** Bug fixes
 
 ** Other changes
-- The build dependency on makeinfo 5 is now optional. If it is not
+- The build dependency on makeinfo is now optional. If it is not
   installed we simply do not build the documentation.
 
 ** Braille table improvements

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 
 ** Bug fixes
 
+** Other changes
+- The build dependency on makeinfo 5 is now optional. If it is not
+  installed we simply do not build the documentation.
+
 ** Braille table improvements
 
 * Noteworthy changes in release 2.6.2 (2015-03-02)

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,7 @@ fi
 AM_CONDITIONAL([HAVE_HELP2MAN], [test x$HELP2MAN = xhelp2man])
 
 # Check for makeinfo version >= 5, required for building documentation.
+have_makeinfo_5=false
 AC_PROG_SED
 AC_CHECK_PROG([MAKEINFO_FOUND], [makeinfo], [yes])
 if test x"${MAKEINFO_FOUND}" = xyes
@@ -102,13 +103,12 @@ then
   then
     AC_MSG_RESULT([no])
     AC_MSG_WARN([Program 'makeinfo' version >= $MAKEINFO_VERSION_REQ is required. Documentation will not be built.])
-    have_makeinfo_5=false
   else
     AC_MSG_RESULT([yes])
     have_makeinfo_5=true
   fi
 else
-  AC_MSG_ERROR([Missing program 'makeinfo', please install.)])
+  AC_MSG_WARN([Missing program 'makeinfo', Documentation will not be built.)])
 fi
 AM_CONDITIONAL([HAVE_MAKEINFO_5], [test x$have_makeinfo_5 = xtrue])
 

--- a/configure.ac
+++ b/configure.ac
@@ -101,13 +101,16 @@ then
   if test x$MAKEINFO_VERSION = x -o 0$MAKEINFO_VERSION -lt $MAKEINFO_VERSION_REQ
   then
     AC_MSG_RESULT([no])
-    AC_MSG_ERROR([Program 'makeinfo' version >= $MAKEINFO_VERSION_REQ is required.])
+    AC_MSG_WARN([Program 'makeinfo' version >= $MAKEINFO_VERSION_REQ is required. Documentation will not be built.])
+    have_makeinfo_5=false
   else
     AC_MSG_RESULT([yes])
+    have_makeinfo_5=true
   fi
 else
   AC_MSG_ERROR([Missing program 'makeinfo', please install.)])
 fi
+AM_CONDITIONAL([HAVE_MAKEINFO_5], [test x$have_makeinfo_5 = xtrue])
 
 # Check if we have Python installed
 AM_PATH_PYTHON([2.6],, [:])


### PR DESCRIPTION
If we cannot find makeinfo 5 simply do not build the documentation

<!---
@huboard:{"milestone_order":41.625}
-->
