### PR TITLE
Clearing up definition of DASHs and long dash

### DIFF
--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -91,8 +91,9 @@ punctuation \x00A1 235 INVERTED EXCLAMATION MARK
 punctuation \x00ad 36
 punctuation \x00BF 236 INVERTED QUESTION MARK 
 punctuation \x2011 36
-punctuation \x2013 6-36
-punctuation \x2014 5-6-36
+punctuation \x2013 6-36 N-DASH
+punctuation \x2014 6-36 M-DASH
+punctuation \x2015 5-6-36 HORIZONTAL BAR
 noback punctuation \x2018 6-236
 noback punctuation \x2019 3
 noback punctuation \x2019 356-3


### PR DESCRIPTION
On page 304 and 308 it gives the unicode \x2014 and \x2015 and the corresponding braille code. I have changed the table to what it says but not convinced it's necessarily right!

<!---
@huboard:{"milestone_order":56.0,"order":81}
-->
