### PR TITLE
removed spaced dash from g2 table

### DIFF
--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -901,8 +901,6 @@ always zwinglian 1356-2456-346-123-24-1-1345
 sufword thorn 1456-135-1235-1345
 word hearths 125-15-345-1456-234
 word hearth 125-15-345-1456
-always  \s\x2013\s 36-36 # 8211  en dash
-always \s\x2014\s 36-36 # em dash
 # nobreak 6-46-56-e,6-46-56
 
 # Problems handled with context


### PR DESCRIPTION
IMO this shouldn't be in this table anyway, but with UEB section 7.2.1 of the Rules of UEB require the spaces to be left in AFAIK.

<!---
@huboard:{"milestone_order":57.5,"order":82}
-->
