### PR TITLE
Corrected 'st' in 1st and 'th' e.g. 4th

### DIFF
--- a/tables/en-ueb-g1.ctb
+++ b/tables/en-ueb-g1.ctb
@@ -105,11 +105,11 @@ always > 4-345
 always + 5-235
 postpunc ? 236
 word ? 56-236
-endnum st 34
+endnum st 234-2345
 endnum nd 1345-145
 endnum rd 1235-145
 endnum 's 3-234
-endnum th 1456
+endnum th 2345-125
 endnum 's 3-234
 always % 46-356
 midnum ^ 4-26


### PR DESCRIPTION
Rules of UEB 2013 6.7.1

<!---
@huboard:{"milestone_order":78.0}
-->
