### PR TITLE
Move internal definitions for findtable in a separate header file

### DIFF
--- a/liblouis/Makefile.am
+++ b/liblouis/Makefile.am
@@ -17,14 +17,15 @@ liblouis_la_LDFLAGS =	\
 	-version-info $(LIBLOUIS_CURRENT):$(LIBLOUIS_REVISION):$(LIBLOUIS_AGE) -no-undefined \
 	$(LTLIBINTL)
 
-liblouis_la_SOURCES = \
-	lou_backTranslateString.c \
-	compileTranslationTable.c \
-	louis.h	\
-	logging.c \
-	lou_translateString.c \
-	transcommon.ci \
-	wrappers.c \
+liblouis_la_SOURCES =				\
+	lou_backTranslateString.c		\
+	compileTranslationTable.c		\
+	louis.h					\
+	logging.c				\
+	lou_translateString.c			\
+	transcommon.ci				\
+	wrappers.c				\
+	findTable.h				\
 	findTable.c
 
 # Don't include liblouis.h in dist, this will break subdir builds

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -37,6 +37,7 @@
 //#include <unistd.h>
 
 #include "louis.h"
+#include "findTable.h"
 #include "config.h"
 
 #define QUOTESUB 28		/*Stand-in for double quotes in strings */
@@ -496,7 +497,7 @@ getAChar (FileInfo * nested)
 * 16- or 32-bit unsigned integers */
   int ch1 = 0, ch2 = 0;
   widechar character;
-  if (nested->encoding == ascii8Encoding)
+  if (nested->encoding == ascii8)
     if (nested->status == 2)
       {
 	nested->status++;
@@ -511,14 +512,14 @@ getAChar (FileInfo * nested)
 	{
 	  if (nested->checkencoding[0] == 0xfe
 	      && nested->checkencoding[1] == 0xff)
-	    nested->encoding = bigEndianEncoding;
+	    nested->encoding = bigEndian;
 	  else if (nested->checkencoding[0] == 0xff
 		   && nested->checkencoding[1] == 0xfe)
-	    nested->encoding = littleEndianEncoding;
+	    nested->encoding = littleEndian;
 	  else if (nested->checkencoding[0] < 128
 		   && nested->checkencoding[1] < 128)
 	    {
-	      nested->encoding = ascii8Encoding;
+	      nested->encoding = ascii8;
 	      return nested->checkencoding[0];
 	    }
 	  else
@@ -534,17 +535,17 @@ getAChar (FileInfo * nested)
 	{
 	case noEncoding:
 	  break;
-	case ascii8Encoding:
+	case ascii8:
 	  return ch1;
 	  break;
-	case bigEndianEncoding:
+	case bigEndian:
 	  ch2 = fgetc (nested->in);
 	  if (ch2 == EOF)
 	    break;
 	  character = (ch1 << 8) | ch2;
 	  return (int) character;
 	  break;
-	case littleEndianEncoding:
+	case littleEndian:
 	  ch2 = fgetc (nested->in);
 	  if (ch2 == EOF)
 	    break;

--- a/liblouis/findTable.c
+++ b/liblouis/findTable.c
@@ -23,6 +23,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include "louis.h"
+#include "findTable.h"
 
 /* =============================== LIST =================================== */
 

--- a/liblouis/findTable.h
+++ b/liblouis/findTable.h
@@ -1,0 +1,55 @@
+/* liblouis Braille Translation and Back-Translation Library
+
+   Based on the Linux screenreader BRLTTY, copyright (C) 1999-2006 by
+   The BRLTTY Team
+
+   Copyright (C) 2015 Bert Frees <bertfrees@gmail.com>
+
+   This file is free software; you can redistribute it and/or modify
+   it under the terms of the Lesser or Library GNU General Public
+   License as published by the Free Software Foundation; either
+   version 3, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   Library GNU General Public License for more details.
+
+   You should have received a copy of the Library GNU General Public
+   License along with this program; see the file COPYING. If not,
+   write to the Free Software Foundation, 51 Franklin Street, Fifth
+   Floor, Boston, MA 02110-1301, USA.
+
+   */
+
+#ifndef __FINDTABLE_H_
+#define __FINDTABLE_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif				/* __cplusplus */
+
+  typedef enum { noEncoding, bigEndian, littleEndian, ascii8 } EncodingType;
+
+  typedef struct
+  {
+    const char *fileName;
+    FILE *in;
+    int lineNumber;
+    EncodingType encoding;
+    int status;
+    int linelen;
+    int linepos;
+    int checkencoding[2];
+    widechar line[MAXSTRING];
+  } FileInfo;
+
+  /* Read a line of widechar's from an input file */
+  int getALine (FileInfo * info);
+
+#ifdef __cplusplus
+}
+#endif				/* __cplusplus */
+
+#endif				/* __LOUIS_H */

--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -476,33 +476,9 @@ extern "C"
     alloc_prevSrcMapping
   } AllocBuf;
 
-  typedef enum
-  {
-    noEncoding,
-    bigEndianEncoding,
-    littleEndianEncoding,
-    ascii8Encoding
-  } EncodingType;
-
-  typedef struct
-  {
-    const char *fileName;
-    FILE *in;
-    int lineNumber;
-    EncodingType encoding;
-    int status;
-    int linelen;
-    int linepos;
-    int checkencoding[2];
-    widechar line[MAXSTRING];
-  } FileInfo;
-
 /* The following function definitions are hooks into 
 * compileTranslationTable.c. Some are used by other library modules. 
 * Others are used by tools like lou_allround.c and lou_debug.c. */
-
-  int getALine (FileInfo * info);
-/* Read a line of widechar's from an input file */
 
   char * getTablePath();
 /* Comma separated list of directories to search for tables. */


### PR DESCRIPTION
which is not exported and not visible in liblouisutdml. This should
avoid problems in liblouisutdml and should fix #92.