### PR TITLE
Fix vs warnings

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1426,7 +1426,7 @@ hexValue (FileInfo * nested, const widechar * digits, int length)
 }
 
 #define MAXBYTES 7
-static int first0Bit[MAXBYTES] = { 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0XFE };
+static unsigned int first0Bit[MAXBYTES] = { 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC, 0XFE };
 
 static int
 parseChars (FileInfo * nested, CharsString * result, CharsString * token)

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -162,13 +162,13 @@ typedef void (*logcallback)(int level, const char *message);
 
   typedef enum
   {
-    LOG_ALL = -2147483648,
+    LOG_ALL = 0,
     LOG_DEBUG = 10000,
     LOG_INFO = 20000,
     LOG_WARN = 30000,
     LOG_ERROR = 40000,
     LOG_FATAL = 50000,
-    LOG_OFF = 2147483647
+    LOG_OFF = 60000
   } logLevels;
   void EXPORT_CALL lou_setLogLevel(logLevels level);
 /* Set the level for logging callback to be called at */

--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -89,7 +89,7 @@ void logMessage(logLevels level, const char *format, ...)
   if (logCallbackFunction != NULL)
     {
 #ifdef _WIN32
-      float f = 2.3; // Needed to force VC++ runtime floating point support
+      double f = 2.3; // Needed to force VC++ runtime floating point support
 #endif
       char *s;
       size_t len;

--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -48,7 +48,7 @@ void logWidecharBuf(logLevels level, const char *msg, const widechar *wbuf, int 
     formatString = "0x%04X ";
   else
     formatString = "0x%08X ";
-  for (i = 0; i < strlen(msg); i++)
+  for (i = 0; i < (int) strlen(msg); i++)
     logMsg[i] = msg[i];
   p += strlen(msg);
   for (i = 0; i < wlen; i++)

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -398,7 +398,7 @@ hyphenate (const widechar * word, int wordSize, char *hyphens)
 	  /* Need to ensure that we don't overrun hyphens,
 	   * in some cases hyphenPattern is longer than the remaining letters,
 	   * and if we write out all of it we would have overshot our buffer. */
-	  limit = MIN (strlen (hyphenPattern), wordSize - patternOffset);
+	  limit = MIN ((int)strlen (hyphenPattern), wordSize - patternOffset);
 	  for (k = 0; k < limit; k++)
 	    {
 	      if (hyphens[patternOffset + k] < hyphenPattern[k])
@@ -721,7 +721,7 @@ static int
 checkMultCaps ()
 {
   int k;
-  for (k = 0; k < table->lenBeginCaps; k++)
+  for (k = 0; k < (int) table->lenBeginCaps; k++)
     if (k >= srcmax - src ||
 	!checkAttr (currentInput[src + k], CTC_UpperCase, 0))
       return 0;
@@ -1557,7 +1557,7 @@ undefinedCharacter (widechar c)
       return 1;
     }
   display = showString (&c, 1);
-  for (k = 0; k < strlen (display); k++)
+  for (k = 0; k < (int) strlen (display); k++)
     displayDots[k] = getDotsForChar (display[k]);
   if (!for_updatePositions (displayDots, 1, strlen(display)))
     return 0;

--- a/windows/Makefile.nmake
+++ b/windows/Makefile.nmake
@@ -6,7 +6,7 @@
 
 SRCDIR = ..\liblouis
 CC = cl.exe
-CFLAGS =  /nologo /O2 /W2 /c
+CFLAGS =  /nologo /O2 /W3 /c -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS
 CFLAGS = $(CFLAGS) /Iinclude
 HEADERS = $(SRCDIR)\louis.h include\liblouis.h include\config.h
 DLLFLAGS = /dll /nologo /DEF:liblouis.def /OUT:liblouis.dll

--- a/windows/Makefile.nmake
+++ b/windows/Makefile.nmake
@@ -6,7 +6,7 @@
 
 SRCDIR = ..\liblouis
 CC = cl.exe
-CFLAGS =  /nologo /O2 /W1 /c
+CFLAGS =  /nologo /O2 /W2 /c
 CFLAGS = $(CFLAGS) /Iinclude
 HEADERS = $(SRCDIR)\louis.h include\liblouis.h include\config.h
 DLLFLAGS = /dll /nologo /DEF:liblouis.def /OUT:liblouis.dll

--- a/windows/include/liblouis.h
+++ b/windows/include/liblouis.h
@@ -168,13 +168,13 @@ typedef void (*logcallback)(int level, const char *message);
 
   typedef enum
   {
-    LOG_ALL = -2147483648,
+    LOG_ALL = 0,
     LOG_DEBUG = 10000,
     LOG_INFO = 20000,
     LOG_WARN = 30000,
     LOG_ERROR = 40000,
     LOG_FATAL = 50000,
-    LOG_OFF = 2147483647
+    LOG_OFF = 60000
   } logLevels;
   void EXPORT_CALL lou_setLogLevel(logLevels level);
 


### PR DESCRIPTION
Solves issue #127. Fixed all warnings up to and including warning level 3. Still quite a few warnings on level 4, but they can probably be ignored. Warning level raised to 3 in makefile.nmake, so that future code modifications can be checked more closely.


