### PR TITLE
Move lou_checkTable() to the C API

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -167,6 +167,7 @@ Programming with liblouis
 * lou_setDataPath::
 * lou_getDataPath::
 * lou_getTable::
+* lou_checkTable::
 * lou_readCharFromFile::
 * lou_free::
 * Python bindings::
@@ -2199,6 +2200,7 @@ the doctest directory in the source distribution.
 * lou_setDataPath::
 * lou_getDataPath::
 * lou_getTable::
+* lou_checkTable::
 * lou_readCharFromFile::
 * lou_free::
 * Python bindings::
@@ -2237,9 +2239,10 @@ License along with Liblouis. If not, see
 
 You use the liblouis library by calling the following functions,
 @code{lou_translateString}, @code{lou_backTranslateString},
+@code{lou_translate}, @code{lou_backTranslate},
 @code{lou_registerLogCallback}, @code{lou_setLogLevel},
 @code{lou_logFile}, @code{lou_logPrint}, @code{lou_logEnd},
-@code{lou_getTable}, @code{lou_translate}, @code{lou_backTranslate},
+@code{lou_getTable}, @code{lou_checkTable},
 @code{lou_hyphenate}, @code{lou_charToDots}, @code{lou_dotsToChar},
 @code{lou_compileString}, @code{lou_readCharFromFile},
 @code{lou_version} and @code{lou_free}.  These are described
@@ -2261,7 +2264,7 @@ yet been compiled @file{compileTranslationTable.c} checks it for
 correctness and compiles it into an efficient internal representation.
 The main entry point is @code{lou_getTable}. Since it is the module
 that keeps track of memory usage, it also contains the @code{lou_free}
-function. In addition, it contains the @code{lou_registerLogCallback},
+function. In addition, it contains the @code{lou_checkTable}, @code{lou_registerLogCallback},
 @code{lou_setLogLevel}, @code{lou_logFile}, @code{lou_logPrint} and
 @code{lou_logEnd} functions, plus some utility functions which are
 used by the other modules.
@@ -2769,10 +2772,10 @@ This function returns a pointer to the path set by
 @findex lou_getTable
 
 @example
-void *lou_getTable (char *tablelist);
+void *lou_getTable (char *tableList);
 @end example
 
-@code{tablelist} is a list of names of table files separated by
+@code{tableList} is a list of names of table files separated by
 commas, as explained previously
 (@pxref{translation-tables,,@code{tableList} parameter in
 @code{lou_translateString}}). If no errors are found this function
@@ -2780,6 +2783,25 @@ returns a pointer to the compiled table. If errors are found error
 messages are logged to the log callback (see
 @code{lou_registerLogCallback}). Errors result in a @code{NULL}
 pointer being returned.
+
+@node lou_checkTable
+@section lou_checkTable
+@findex lou_checkTable
+
+@example
+int lou_checkTable (char *tableList);
+@end example
+
+This function does the same as @code{lou_getTable}
+but does not return a pointer to the resulting table.
+It is to be preferred if only the validity of a table needs to be checked.
+@code{tableList} is a list of names of table files separated by
+commas, as explained previously
+(@pxref{translation-tables,,@code{tableList} parameter in
+@code{lou_translateString}}). If no errors are found this function
+returns a non-zero. If errors are found error
+messages are logged to the log callback (see
+@code{lou_registerLogCallback}) and the return value is @code{0}.
 
 @node lou_readCharFromFile
 @section lou_readCharFromFile
@@ -2816,7 +2838,9 @@ tables every time they are used, resulting in great inefficiency.
 @section Python bindings
 
 There are Python bindings for @code{lou_translateString},
-@code{lou_translate}, @code{lou_backTranslateString}, @code{lou_backTranslate}, @code{lou_hyphenate}, @code{lou_getTable} (called @code{checkTable}), @code{lou_compileString} and @code{lou_version}. For installation
+@code{lou_translate}, @code{lou_backTranslateString},
+@code{lou_backTranslate}, @code{lou_hyphenate}, @code{checkTable},
+@code{lou_compileString} and @code{lou_version}. For installation
 instructions see the the @file{README} file in the @file{python}
 directory. Usage information is included in the Python module itself.
 
@@ -2845,7 +2869,8 @@ directory. Usage information is included in the Python module itself.
 @c  LocalWords:  liblouis opcode args BRLTTY ViewPlus Abilitiessoft LGPL lou
 @c  LocalWords:  checktable allround checkhyphens Opcodes Multipass dotsToChar
 @c  LocalWords:  translateString backTranslateString backTranslate charToDots
-@c  LocalWords:  compileString logFile logPrint getTable readCharFromFile itemx
+@c  LocalWords:  compileString logFile logPrint
+@c  LocalWords:  getTable checkTable readCharFromFile itemx
 @c  LocalWords:  README liblouisxml pindex samp kbd opcodes opcoderef numsign
 @c  LocalWords:  FIXME ctb nemeth filename multipass suboperand uplow litdigit
 @c  LocalWords:  capsign begcaps endcaps letsign noletsign largesign typeform

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4815,9 +4815,7 @@ getTable (const char *tableList)
   /*See if this is the last table used. */
   if (lastTrans != NULL)
     if (tableListLen == lastTrans->tableListLength && (memcmp
-						       (&lastTrans->
-							tableList
-							[0],
+						       (&lastTrans->tableList[0],
 							tableList,
 							tableListLen)) == 0)
       return (table = lastTrans->table);
@@ -4826,9 +4824,7 @@ getTable (const char *tableList)
   while (currentEntry != NULL)
     {
       if (tableListLen == currentEntry->tableListLength && (memcmp
-							    (&currentEntry->
-							     tableList
-							     [0],
+							    (&currentEntry->tableList[0],
 							     tableList,
 							     tableListLen))
 	  == 0)
@@ -4857,6 +4853,7 @@ getTable (const char *tableList)
       lastTrans = newEntry;
       return newEntry->table;
     }
+  logMessage (LOG_ERROR, "%s could not be found", tableList);
   return NULL;
 }
 
@@ -4873,14 +4870,7 @@ getLastTableList ()
 void *EXPORT_CALL
 lou_getTable (const char *tableList)
 {
-  void *table = NULL;
-  if (tableList == NULL || tableList[0] == 0)
-    return NULL;
-  errorCount = fileCount = 0;
-  table = getTable (tableList);
-  if (!table)
-    logMessage (LOG_ERROR, "%s could not be found", tableList);
-  return table;
+  return getTable(tableList);
 }
 
 static unsigned char *destSpacing = NULL;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4873,6 +4873,14 @@ lou_getTable (const char *tableList)
   return getTable(tableList);
 }
 
+int EXPORT_CALL
+lou_checkTable (const char *tableList)
+{
+  if (getTable(tableList))
+    return 1;
+  return 0;
+}
+
 static unsigned char *destSpacing = NULL;
 static int sizeDestSpacing = 0;
 static unsigned short *typebuf = NULL;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4800,7 +4800,7 @@ cleanup:
 }
 
 static ChainEntry *lastTrans = NULL;
-static void *
+void *
 getTable (const char *tableList)
 {
 /*Keep track of which tables have already been compiled */
@@ -5049,7 +5049,7 @@ lou_charSize ()
 int EXPORT_CALL
 lou_compileString (const char *tableList, const char *inString)
 {
-  if (!lou_getTable (tableList))
+  if (!getTable (tableList))
     return 0;
   return compileString (inString);
 }

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -140,6 +140,11 @@ mode);
 * and by the tools.
 */
 
+  int EXPORT_CALL lou_checkTable (const char *tableList);
+/* This function checks a table for errors. If none are found it loads 
+* the table into memory and returns a non-zero value. Else the return value is 0.
+*/
+
 void EXPORT_CALL lou_registerTableResolver (char ** (* resolver) (const char *table, const char *base));
 /* Register a new table resolver. Overrides the default resolver. */
 

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -134,9 +134,10 @@ mode);
 
   void *EXPORT_CALL lou_getTable (const char *tableList);
 /* This function checks a table for errors. If none are found it loads 
-* the table into memory and returns a pointer to it. if errors are found 
+* the table into memory and returns a pointer to it. If errors are found 
 * it returns a null pointer. It is called by lou_translateString and 
 * lou_backTranslateString and also by functions in liblouisxml
+* and by the tools.
 */
 
 void EXPORT_CALL lou_registerTableResolver (char ** (* resolver) (const char *table, const char *base));

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -83,7 +83,7 @@ lou_backTranslate (const char *tableList, const
 				inlen, outbuf, outlen,
 				typeform, spacing, outputPos, inputPos,
 				cursorPos, modex);
-  table = lou_getTable (tableList);
+  table = getTable (tableList);
   if (table == NULL)
     return 0;
   srcmax = 0;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -84,7 +84,7 @@ trace_translate (const char *tableList, const widechar * inbufx,
 			    inlen, outbuf, outlen,
 			    typeform, spacing, outputPos, inputPos, cursorPos,
 			    modex);
-  table = lou_getTable (tableList);
+  table = getTable (tableList);
   if (table == NULL || *inlen < 0 || *outlen < 0)
     return 0;
   currentInput = (widechar *) inbufx;
@@ -2090,7 +2090,7 @@ lou_hyphenate (const char *tableList, const widechar
   int k, kk;
   int wordStart;
   int wordEnd;
-  table = lou_getTable (tableList);
+  table = getTable (tableList);
   if (table == NULL || inbuf == NULL || hyphens
       == NULL || table->hyphenStatesArray == 0 || inlen >= HYPHSTRING)
     return 0;
@@ -2174,7 +2174,7 @@ lou_dotsToChar (const char *tableList, widechar * inbuf, widechar * outbuf,
     return 0;
   if ((mode & otherTrans))
     return other_dotsToChar (tableList, inbuf, outbuf, length, mode);
-  table = lou_getTable (tableList);
+  table = getTable (tableList);
   if (table == NULL || length <= 0)
     return 0;
   for (k = 0; k < length; k++)
@@ -2197,7 +2197,7 @@ lou_charToDots (const char *tableList, const widechar * inbuf, widechar *
   if ((mode & otherTrans))
     return other_charToDots (tableList, inbuf, outbuf, length, mode);
 
-  table = lou_getTable (tableList);
+  table = getTable (tableList);
   if (table == NULL || length <= 0)
     return 0;
   for (k = 0; k < length; k++)

--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -484,6 +484,9 @@ extern "C"
   char ** resolveTable(const char *tableList, const char *base);
 /* Resolve tableList against base. */
 
+  void * getTable(const char *tableList);
+/* Checks and loads tableList. */
+
   widechar getDotsForChar (widechar c);
 /* Returns the single-cell dot pattern corresponding to a character. */
 

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -92,8 +92,7 @@ liblouis.lou_backTranslate.argtypes = (
 liblouis.lou_hyphenate.argtypes = (
          c_char_p, c_wchar_p, c_int, POINTER(c_char), c_int)
 
-liblouis.lou_getTable.argtypes = (c_char_p,)
-liblouis.lou_getTable.restype = c_void_p
+liblouis.lou_checkTable.argtypes = (c_char_p,)
 
 liblouis.lou_compileString.argtypes = (c_char_p, c_char_p)
 
@@ -281,11 +280,10 @@ def checkTable(tableList):
     @param tableList: A list of translation tables.
     @type tableList: list of str
     @raise RuntimeError: If compilation failed.
-    @see: lou_getTable in the liblouis documentation
+    @see: lou_checkTable in the liblouis documentation
     """
-    # TODO: Add this function to the C API and use that instead.
     tablesString = _createTablesString(tableList)
-    if not liblouis.lou_getTable(tablesString):
+    if not liblouis.lou_checkTable(tablesString):
         raise RuntimeError("Can't compile: tables %s"%tableList)
 
 def compileString(tableList, inString):

--- a/tests/checkTable.c
+++ b/tests/checkTable.c
@@ -1,0 +1,44 @@
+/* liblouis Braille Translation and Back-Translation Library
+
+Copyright (C) 2012 James Teh <jamie@nvaccess.org>
+Copyright (C) 2015 Davy Kager <mail@davykager.nl>
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved. This file is offered as-is,
+without any warranty. */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "liblouis.h"
+
+int
+main(int argc, char **argv)
+{
+  const char *goodTable = "en-us-g1.ctb";
+  const char *badTable = "bad.ctb";
+  int result = 0;
+
+  if (lou_checkTable(goodTable) == 0)
+  {
+    printf("Getting %s failed, expected success\n", goodTable);
+    result = 1;
+  }
+
+  if (lou_checkTable(badTable) != 0)
+  {
+    printf("Getting %s succeeded, expected failure\n", badTable);
+    result = 1;
+  }
+
+  if (lou_checkTable(goodTable) == 0)
+  {
+    printf("Getting %s failed, expected success\n", goodTable);
+    result = 1;
+  }
+
+  lou_free();
+
+  return result;
+}

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -143,7 +143,7 @@ getCommands (void)
 	      getInput ();
 	      strcpy (table, inputBuffer);
 	    }
-	  while ((validTable = lou_getTable (table)) == NULL);
+	  while ((validTable = getTable (table)) == NULL);
 	  break;
 	case 'r':
 	  if (validTable == NULL)

--- a/tools/lou_checkhyphens.c
+++ b/tools/lou_checkhyphens.c
@@ -114,7 +114,7 @@ getCommands (void)
 	      printf ("Enter the name of a table or a list: ");
 	      getInput ();
 	      strcpy (table, inputBuffer);
-	      validTable = lou_getTable (table);
+	      validTable = getTable (table);
 	      if (validTable != NULL && validTable->hyphenStatesArray == 0)
 		{
 		  printf ("No hyphenation table.\n");

--- a/tools/lou_checktable.c
+++ b/tools/lou_checktable.c
@@ -77,7 +77,6 @@ option.\n", stdout);
 int
 main (int argc, char **argv)
 {
-  const TranslationTableHeader *table;
   int optc;
 
   set_program_name (argv[0]);
@@ -118,7 +117,7 @@ main (int argc, char **argv)
       exit (EXIT_FAILURE);
     }
 
-  if (!(table = lou_getTable (argv[optind])))
+  if (!lou_checkTable (argv[optind]))
     {
       lou_free ();
       exit (EXIT_FAILURE);

--- a/tools/lou_debug.c
+++ b/tools/lou_debug.c
@@ -731,7 +731,7 @@ main (int argc, char **argv)
       exit (EXIT_FAILURE);
     }
 
-  if (!(table = lou_getTable (argv[optind])))
+  if (!(table = getTable (argv[optind])))
     {
       lou_free ();
       exit (EXIT_FAILURE);

--- a/tools/lou_trace.c
+++ b/tools/lou_trace.c
@@ -288,7 +288,7 @@ main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
   table = argv[optind];
-  if (!lou_getTable(table)) {
+  if (!getTable(table)) {
     lou_free();
     exit(EXIT_FAILURE);
   }

--- a/windows/include/liblouis.h
+++ b/windows/include/liblouis.h
@@ -142,9 +142,14 @@ formtype *typeform, char *spacing, int
 
   void * EXPORT_CALL lou_getTable (const char *tableList);
 /* This function checks a table for errors. If none are found it loads 
-* the table into memory and returns a pointer to it. if errors are found 
+* the table into memory and returns a pointer to it. If errors are found 
 * it returns a null pointer. It is called by lou_translateString and 
 * lou_backTranslateString and also by functions in liblouisxml
+*/
+
+  int EXPORT_CALL lou_checkTable (const char *tableList);
+/* This function checks a table for errors. If none are found it loads 
+* the table into memory and returns a non-zero value. Else the return value is 0.
 */
 
 void EXPORT_CALL lou_registerTableResolver (char ** (* resolver) (const char *table, const char *base));

--- a/windows/liblouis.def
+++ b/windows/liblouis.def
@@ -17,6 +17,7 @@ EXPORTS
 	lou_compileString
 	lou_setDataPath
 	lou_getTable
+	lou_checkTable
 	lou_getDataPath
 	lou_registerLogCallback
 	lou_setLogLevel


### PR DESCRIPTION
Follow-up of liblouis/liblouis#89.

* Turn `lou_getTable` into a simple wrapper for `getTable`.
* Use `getTable` instead of `lou_getTable` in internal code where possible.
* Add `lou_checkTable` based on the Python implementation.
* In Python, simply call the C function.
* Update docs and tests.