### PR TITLE
Passrules with noback and nofor

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1172,7 +1172,7 @@ makeRuleChain (TranslationTableOffset * offsetPtr)
 }
 
 static int
-addPassRule (FileInfo * nested)
+add0PassRule (FileInfo * nested)
 {
   TranslationTableOffset *offsetPtr;
   switch (newRule->opcode)
@@ -1191,6 +1191,34 @@ addPassRule (FileInfo * nested)
       break;
     case CTO_Pass4:
       offsetPtr = &table->attribOrSwapRules[4];
+      break;
+    default:
+      return 0;
+    }
+  makeRuleChain (offsetPtr);
+  return 1;
+}
+
+static int
+add1PassRule (FileInfo * nested)
+{
+  TranslationTableOffset *offsetPtr;
+  switch (newRule->opcode)
+    {
+    case CTO_Correct:
+      offsetPtr = &table->backAttribOrSwapRules[0];
+      break;
+    case CTO_Context:
+      offsetPtr = &table->backAttribOrSwapRules[1];
+      break;
+    case CTO_Pass2:
+      offsetPtr = &table->backAttribOrSwapRules[2];
+      break;
+    case CTO_Pass3:
+      offsetPtr = &table->backAttribOrSwapRules[3];
+      break;
+    case CTO_Pass4:
+      offsetPtr = &table->backAttribOrSwapRules[4];
       break;
     default:
       return 0;
@@ -1240,7 +1268,7 @@ static int
   if (opcode == CTO_SwapCc || opcode == CTO_SwapCd || opcode == CTO_SwapDd)
     return 1;
   if (opcode >= CTO_Context && opcode <= CTO_Pass4 && newRule->charslen == 0)
-    return addPassRule (nested);
+    return add0PassRule (nested);
   if (newRule->charslen == 0 || nofor)
     direction = 1;
   while (direction < 2)

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1135,8 +1135,7 @@ add_1_multiple ()
 								charsdots
 								[newRule->
 								 charslen])];
-  if (newRule->opcode == CTO_NoBreak || newRule->opcode == CTO_SwapCc ||
-      (newRule->opcode >= CTO_Context && newRule->opcode <= CTO_Pass4))
+  if (newRule->opcode == CTO_NoBreak || newRule->opcode == CTO_SwapCc)
     return;
   while (*currentOffsetPtr)
     {

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1158,6 +1158,12 @@ add_1_multiple ()
   *currentOffsetPtr = newRuleOffset;
 }
 
+/* makeRuleChain()
+	Adds a rule to the rule chain in a given area.
+	(currently only used by addForPassrule() and addBackPassRule()).
+	Parameters: Offset pointer to table area.
+	Returns: None.
+*/
 static void
 makeRuleChain (TranslationTableOffset * offsetPtr)
 {
@@ -1171,8 +1177,13 @@ makeRuleChain (TranslationTableOffset * offsetPtr)
   *offsetPtr = newRuleOffset;
 }
 
+/* addForPassRule ()
+	Adds a forward multi-pass rule to table->attribOrSwapRules, i.e "correct", "context", and pass2-4 rules.
+	Parameters: Nested file info of table file.
+	Returns: 1 if successfull, otherwise 0.
+		*/
 static int
-add0PassRule (FileInfo * nested)
+addForPassRule (FileInfo * nested)
 {
   TranslationTableOffset *offsetPtr;
   switch (newRule->opcode)
@@ -1199,8 +1210,13 @@ add0PassRule (FileInfo * nested)
   return 1;
 }
 
+/* addBackPassRule ()
+	Adds a backward multi-pass rule to table->backAttribOrSwapRules, i.e "correct", "context", and pass2-4 rules.
+	Parameters: Nested file info of table file.
+	Returns: 1 if successfull, otherwise 0.
+		*/
 static int
-add1PassRule (FileInfo * nested)
+addBackPassRule (FileInfo * nested)
 {
   TranslationTableOffset *offsetPtr;
   switch (newRule->opcode)
@@ -1268,7 +1284,12 @@ static int
   if (opcode == CTO_SwapCc || opcode == CTO_SwapCd || opcode == CTO_SwapDd)
     return 1;
   if (opcode >= CTO_Context && opcode <= CTO_Pass4 && newRule->charslen == 0)
-    return add0PassRule (nested);
+  {
+    if (!nofor)
+      if (!addForPassRule (nested)) return 0;
+  if (!noback)
+      if (!addBackPassRule (nested)) return 0;
+  }
   if (newRule->charslen == 0 || nofor)
     direction = 1;
   while (direction < 2)

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -537,12 +537,12 @@ static int back_passDoTest ();
 static int back_passDoAction ();
 
 static int
-findAttribOrSwapRules ()
+findBackAttribOrSwapRules ()
 {
   TranslationTableOffset ruleOffset;
   if (src == previousSrc)
     return 0;
-  ruleOffset = table->attribOrSwapRules[currentPass];
+  ruleOffset = table->backAttribOrSwapRules[currentPass];
   currentCharslen = 0;
   while (ruleOffset)
     {
@@ -949,7 +949,7 @@ makeCorrections ()
 	(currentInput[src], 0);
       const TranslationTableCharacter *character2;
       int tryThis = 0;
-      if (!findAttribOrSwapRules ())
+      if (!findBackAttribOrSwapRules ())
 	while (tryThis < 3)
 	  {
 	    TranslationTableOffset ruleOffset = 0;
@@ -1535,7 +1535,7 @@ for_passSelectRule ()
   int tryThis;
   TranslationTableOffset ruleOffset = 0;
   unsigned long int makeHash = 0;
-  if (findAttribOrSwapRules ())
+  if (findBackAttribOrSwapRules ())
     return;
   dots = back_findCharOrDots (currentInput[src], 1);
   for (tryThis = 0; tryThis < 3; tryThis++)

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -963,7 +963,7 @@ makeCorrections ()
 		character2 = back_findCharOrDots (currentInput[src + 1], 0);
 		makeHash += (unsigned long int) character2->lowercase;
 		makeHash %= HASHNUM;
-		ruleOffset = table->forRules[makeHash];
+		ruleOffset = table->backRules[makeHash];
 		break;
 	      case 1:
 		if (!(length >= 1))
@@ -1550,7 +1550,7 @@ for_passSelectRule ()
 	  dots2 = back_findCharOrDots (currentInput[src + 1], 1);
 	  makeHash += (unsigned long int) dots2->lowercase;
 	  makeHash %= HASHNUM;
-	  ruleOffset = table->forRules[makeHash];
+	  ruleOffset = table->backRules[makeHash];
 	  break;
 	case 1:
 	  if (!(length >= 1))

--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -460,8 +460,9 @@ extern "C"
     TranslationTableOffset dotsToChar[HASHNUM];
     TranslationTableOffset compdotsPattern[256];
     TranslationTableOffset swapDefinitions[NUMSWAPS];
-    TranslationTableOffset attribOrSwapRules[5];
-    TranslationTableOffset forRules[HASHNUM];	/*chains of forward rules */
+    TranslationTableOffset attribOrSwapRules[5];	/* array of chains of forward multi-pass rules */
+        TranslationTableOffset backAttribOrSwapRules[5];	/* array of chains of backward multi-pass rules */
+TranslationTableOffset forRules[HASHNUM];	/*chains of forward rules */
     TranslationTableOffset backRules[HASHNUM];	/*Chains of backward rules */
     TranslationTableOffset ruleArea[1];	/*Space for storing all 
 					   rules and values */


### PR DESCRIPTION
Desperately need help with this one. Apparently, some rules go into swapOrAttribRules, and some go into forRules.
Made new backAttribOrSwapRules and sorted by nofor and noback.
Made back-translate function look in backAttribOrSwapRules.
Removed the pass rules filter in add_1_multiple(), and changed for_passSelectRule() look in backRules.

It seems like the two make hash algorithms must Work differently for forward and backward translation, even though they look the same.

Help needed!
