### PR TITLE
Update output positions during multi pass (forward translation only)

### DIFF
--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -91,6 +91,11 @@ void logMessage(logLevels level, const char *format, ...)
 #ifdef _WIN32
       float f = 2.3; // Needed to force VC++ runtime floating point support
 #endif
+#ifdef _MSC_VER
+	#if _MSC_VER < 1500
+		#define vsnprintf _vsnprintf
+	#endif
+#endif
       char *s;
       size_t len;
       va_list argp;
@@ -110,7 +115,7 @@ void logMessage(logLevels level, const char *format, ...)
 
 
 static FILE *logFile = NULL;
-static char initialLogFileName[256];
+static char initialLogFileName[256] = "";
 
 void EXPORT_CALL
 lou_logFile (const char *fileName)

--- a/liblouis/transcommon.ci
+++ b/liblouis/transcommon.ci
@@ -1,5 +1,7 @@
 /* This file contains code common to the translator and back-translator. 
-* It is included immediately after the headr files. */
+* It is included immediately after the header files. 
+* Since some time ago this file is used only in forward translation (lou_translateString).
+*/
 
 /* liblouis Braille Translation and Back-Translation Library
 
@@ -1047,15 +1049,35 @@ passSelectRule ()
   return;
 }
 
+void correctOutputPositions(int* srcReplace, int dest1, int src1)
+{
+	// October 2015 make corrections in output positions during multi pass (called in translatePass)
+	int i;
+	int i1 = *srcReplace;
+	if (outputPositions == NULL)
+		return;
+	for (i = *srcReplace; i < realInlen; i++)
+	{
+		if (outputPositions[i] == (src1))
+		{
+			outputPositions[i] = (dest1);
+			i1 = i+1;
+		}
+	}
+	*srcReplace = i1; // avoid replacing twice
+}
+
 static int
 translatePass ()
 {
+  int srcReplace = 0; // for multi pass correction
   prevTransOpcode = CTO_None;
   src = dest = 0;
   srcIncremented = 1;
   memset (passVariables, 0, sizeof(int) * NUMVAR);
   while (src < srcmax)
     {				/*the main multipass translation loop */
+      int j;
       passSelectRule ();
       srcIncremented = 1;
       switch (transOpcode)
@@ -1066,16 +1088,25 @@ translatePass ()
 	case CTO_Pass4:
 	  if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 	    appliedRules[appliedRulesCount++] = transRule;
+	  for (j = 0; j < (startReplace - startMatch); j++)
+	  {
+		if (dest != src) // correct output position for multi pass
+			correctOutputPositions(&srcReplace, dest+j, src+j);
+	  }
 	  if (!passDoAction ())
 	    goto failure;
 	  if (endReplace == src)
 	    srcIncremented = 0;
 	  src = endReplace;
+	  if (dest != src) // correct output position for multi pass
+			correctOutputPositions(&srcReplace, dest, src);
 	  break;
 	case CTO_Always:
 	  if ((dest + 1) > destmax)
 	    goto failure;
 	  srcMapping[dest] = prevSrcMapping[src];
+	  if (dest != src) // correct output position for multi pass
+			correctOutputPositions(&srcReplace, dest, src);
 	  currentOutput[dest++] = currentInput[src++];
 	  break;
 	default:


### PR DESCRIPTION
trace_translate , the general translation function in
lou_translateString.c calls translatePass for pass2, 3 and 4.
translatePass does currently not update the output positions. This
modification tries to handle this.
This may affect cursor position too.
