### PR TITLE
Stop buffer overrun in lou_getProgramPath, and also free memory after…

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -84,7 +84,9 @@ lou_getProgramPath ()
 	  buffer = reallocWrapper (buffer, size <<= 1);
 
 	  {
-	    DWORD length = GetModuleFileName (handle, buffer, size);
+		// As the "UNICODE" Windows define may have been set at compilation,
+		// This call must be specifically GetModuleFilenameA as further code expects it to be single byte chars.
+		DWORD length = GetModuleFileNameA (handle, buffer, size);
 
 	    if (!length)
 	      {
@@ -4552,8 +4554,11 @@ getTablePath()
 		   "tables");
 #ifdef _WIN32
   path = lou_getProgramPath ();
-  if (path != NULL && path[0] != '\0')
-    cp += sprintf (cp, ",%s%s", path, "\\share\\liblouis\\tables");
+  if (path != NULL) {
+    if(path[0] != '\0')
+      cp += sprintf (cp, ",%s%s", path, "\\share\\liblouis\\tables");
+    free(path);
+  }
 #else
   cp += sprintf (cp, ",%s", TABLESDIR);
 #endif


### PR DESCRIPTION
As compilation on Windows could  define "UNICODE", GetModuleFilename may provide a unicode path, yet,  further code in lou_getProgramPath expects it to be single-byte chars.
Therefore, explicitly use GetModuleFilenameA.

This has been the source of a long-standing crash in NVDA on first use of lou_translate.
Specifically in lou_getProgramPath:
As NVDA compiles on Windows with UNICODE defined, GetModuleFilename resolves to GetModuleFilenameW.
Therefore buffer ends up containing a unicode path after GetModuleFilename is called.
But then, the call to strdup only allocates and copies the first character as the second character would be a \0 (first part of a unicode character).
The code then continues to play with this path thinking it is longer than it is, but the fianl bad part is the call to strncpy, which copies up to length character from path to path. But, because only one byte was allocated, this causes a major buffer overrun. In NVDA's case, of about 36 bytes. 