### PR TITLE
Feature/emphasis handling cleanup

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4063,11 +4063,22 @@ doOpcode:
 				&table->emphRules[i][wordStopOffset]);
 		}
 		else if (opcode == CTO_FirstLetterEmph) {
+		  /* fail if both begemph and any of begemphphrase or begemphword are defined */
+		  if (table->emphRules[i][wordOffset] || table->emphRules[i][firstWordOffset]) {
+		    compileError (nested, "Cannot define emphasis for both no context and word or phrase context, i.e. cannot have both begemph and begemphword or begemphphrase.");
+		    ok = 0;
+		    break;
+		  }
 			ok = compileBrailleIndicator (nested, "first letter",
 				CTO_SingleLetterItalRule + firstLetterOffset + (8 * i),
 				&table->emphRules[i][firstLetterOffset]);
 		}
 		else if (opcode == CTO_LastLetterEmph) {
+		  if (table->emphRules[i][wordStopOffset] || table->emphRules[i][lastWordBeforeOffset] || table->emphRules[i][lastWordAfterOffset]) {
+		    compileError (nested, "Cannot define emphasis for both no context and word or phrase context, i.e. cannot have both endemph and endemphword or endemphphrase.");
+		    ok = 0;
+		    break;
+		  }
 			ok = compileBrailleIndicator (nested, "last letter",
 				CTO_SingleLetterItalRule + lastLetterOffset + (8 * i),
 				&table->emphRules[i][lastLetterOffset]);

--- a/tables/da-dk-common6.uti
+++ b/tables/da-dk-common6.uti
@@ -88,18 +88,18 @@ emphclass bold
 
 begemphphrase italic 56
 endemphphrase italic after 56
-begemph italic 56
-endemph italic 56
+begemphword italic 56
+endemphword italic 56
 
 begemphphrase bold 56
 endemphphrase bold after 56
-begemph bold 56
-endemph bold 56
+begemphword bold 56
+endemphword bold 56
 
 begemphphrase underline 56
 endemphphrase underline after 56
-begemph underline 56
-endemph underline 56
+begemphword underline 56
+endemphword underline 56
 
 capsletter 46
 begcapsword 456

--- a/tables/da-dk-g18.utb
+++ b/tables/da-dk-g18.utb
@@ -40,18 +40,18 @@ emphclass bold
 
 begemphphrase italic 56
 endemphphrase italic after 56
-begemph italic 56
-endemph italic 56
+begemphword italic 56
+endemphword italic 56
 
 begemphphrase bold 56
 endemphphrase bold after 56
-begemph bold 56
-endemph bold 56
+begemphword bold 56
+endemphword bold 56
 
 begemphphrase underline 56
 endemphphrase underline after 56
-begemph underline 56
-endemph underline 56
+begemphword underline 56
+endemphword underline 56
 
 #always \x2013 36-36
 #always \x0096 36-36

--- a/tables/de-g0-core.uti
+++ b/tables/de-g0-core.uti
@@ -47,20 +47,20 @@ emphclass bold
 
 endemphphrase italic after 6-3
 lenemphphrase italic 1
-begemph italic 6-456
-endemph italic 6-3
+begemphword italic 6-456
+endemphword italic 6-3
 emphletter italic 456
 
 endemphphrase bold after 6-3
 lenemphphrase bold 1
-begemph bold 6-456
-endemph bold 6-3
+begemphword bold 6-456
+endemphword bold 6-3
 emphletter bold 456
 
 endemphphrase underline after 6-3
 lenemphphrase underline 1
-begemph underline 6-456
-endemph underline 6-3
+begemphword underline 6-456
+endemphword underline 6-3
 emphletter underline 456
 
 begcomp 6-46

--- a/tables/en-in-g1.ctb
+++ b/tables/en-in-g1.ctb
@@ -35,8 +35,8 @@ emphclass bold
 begemphphrase italic 46-46
 endemphphrase italic before 46
 lenemphphrase italic 4
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/en-ueb-g1.ctb
+++ b/tables/en-ueb-g1.ctb
@@ -160,29 +160,29 @@ emphletter italic 46-23
 begemphword italic 46-2
 endemphword italic 46-3
 lenemphphrase italic 3
-begemph italic 46-2356
-endemph italic 46-3
+begemphphrase italic 46-2356
+endemphphrase italic after 46-3
 
 emphletter bold 45-23
 begemphword bold 45-2
 endemphword bold 45-3
 lenemphphrase bold 3
-begemph bold 45-2356
-endemph bold 45-3
+begemphphrase bold 45-2356
+endemphphrase bold after 45-3
 
 emphletter underline 456-23
 begemphword underline 456-2
 endemphword underline 456-3
 lenemphphrase underline 3
-begemph underline 456-2356
-endemph underline 456-3
+begemphphrase underline 456-2356
+endemphphrase underline after 456-3
 
 emphletter script 4-23
 begemphword script 4-2
 endemphword script 4-3
 lenemphphrase script 3
-begemph script 4-2356
-endemph script 4-3
+begemphphrase script 4-2356
+endemphphrase script after 4-3
 
 begemph transnote 4-46-126
 endemph transnote 4-46-354
@@ -192,36 +192,36 @@ emphletter trans1 4-3456-23
 begemphword trans1 4-3456-2
 endemphword trans1 4-3456-3
 lenemphphrase trans1 3
-begemph trans1 4-3456-2356
-endemph trans1 4-3456-3
+begemphphrase trans1 4-3456-2356
+endemphphrase trans1 after 4-3456-3
 
 emphletter trans2 45-3456-23
 begemphword trans2 45-3456-2
 endemphword trans2 45-3456-3
 lenemphphrase trans2 3
-begemph trans2 45-3456-2356
-endemph trans2 45-3456-3
+begemphphrase trans2 45-3456-2356
+endemphphrase trans2 after 45-3456-3
 
 emphletter trans3 456-3456-23
 begemphword trans3 456-3456-2
 endemphword trans3 456-3456-3
 lenemphphrase trans3 3
-begemph trans3 456-3456-2356
-endemph trans3 456-3456-3
+begemphphrase trans3 456-3456-2356
+endemphphrase trans3 after 456-3456-3
 
 emphletter trans4 5-3456-23
 begemphword trans4 5-3456-2
 endemphword trans4 5-3456-3
 lenemphphrase trans4 3
-begemph trans4 5-3456-2356
-endemph trans4 5-3456-3
+begemphphrase trans4 5-3456-2356
+endemphphrase trans4 after 5-3456-3
 
 emphletter trans5 46-3456-23
 begemphword trans5 46-3456-2
 endemphword trans5 46-3456-3
 lenemphphrase trans5 3
-begemph trans5 46-3456-2356
-endemph trans5 46-3456-3
+begemphphrase trans5 46-3456-2356
+endemphphrase trans5 after 46-3456-3
 
 # display/passthrough for unicode braille
 include braille-patterns.cti

--- a/tables/en-us-g1.ctb
+++ b/tables/en-us-g1.ctb
@@ -47,8 +47,8 @@ emphclass underline
 emphclass bold
 emphclass transnote
 
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 
 begemphphrase bold 456-46-46

--- a/tables/en-us-g1.ctb.bak
+++ b/tables/en-us-g1.ctb.bak
@@ -44,8 +44,8 @@ emphclass bold
 begemphphrase italic 46-46
 endemphphrase italic before 46
 lenemphphrase italic 4
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/en-us-interline.ctb
+++ b/tables/en-us-interline.ctb
@@ -42,8 +42,8 @@ emphclass bold
 begemphphrase italic 46-46
 endemphphrase italic before 46
 lenemphphrase italic 4
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/fr-bfu-comp6.utb
+++ b/tables/fr-bfu-comp6.utb
@@ -229,7 +229,7 @@ emphclass underline
 emphclass bold
 begemphphrase italic 456-456
 endemphphrase italic before 456
-begemph italic 456
+begemphword italic 456
 emphletter italic 456
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -39,8 +39,8 @@ emphclass bold
 begemphphrase italic 46-46
 endemphphrase italic before 46
 lenemphphrase italic 4
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/ko-2006.cti
+++ b/tables/ko-2006.cti
@@ -43,8 +43,8 @@ emphclass bold
 begemphphrase italic 46-46
 endemphphrase italic before 46
 lenemphphrase italic 4
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/ko.cti
+++ b/tables/ko.cti
@@ -75,8 +75,8 @@ emphclass bold
 begemphphrase italic 46-46
 endemphphrase italic before 46
 lenemphphrase italic 4
-begemph italic 46-3
-endemph italic 46-36
+begemphword italic 46-3
+endemphword italic 46-36
 emphletter italic 46-25
 begemphphrase bold 456-456
 endemphphrase bold before 456

--- a/tables/nl-BE-g1.ctb
+++ b/tables/nl-BE-g1.ctb
@@ -42,22 +42,22 @@ emphclass bold
 
 lenemphphrase italic 3
 endemphphrase italic before 456
-begemph italic 456
-endemph italic 6
+begemphword italic 456
+endemphword italic 6
 begemphphrase italic 456-456
 
 # vet
 lenemphphrase bold 3
 endemphphrase bold before 456
-begemph bold 456
-endemph bold 6
+begemphword bold 456
+endemphword bold 6
 begemphphrase bold 456-456
 
 # onderstreept
 lenemphphrase underline 3
 endemphphrase underline before 456
-begemph underline 456
-endemph underline 6
+begemphword underline 456
+endemphword underline 6
 begemphphrase underline 456-456
 
 # ----------------------------------------------------------------------------------------------

--- a/tables/nl-BE-g1.ctb.bak
+++ b/tables/nl-BE-g1.ctb.bak
@@ -42,22 +42,22 @@ emphclass bold
 
 lenemphphrase italic 3
 endemphphrase italic before 456
-begemph italic 456
-endemph italic 6
+begemphword italic 456
+endemphword italic 6
 begemphphrase italic 456-456
 
 # vet
 lenemphphrase bold 3
 endemphphrase bold before 456
-begemph bold 456
-endemph bold 6
+begemphword bold 456
+endemphword bold 6
 begemphphrase bold 456-456
 
 # onderstreept
 lenemphphrase underline 3
 endemphphrase underline before 456
-begemph underline 456
-endemph underline 6
+begemphword underline 456
+endemphword underline 6
 begemphphrase underline 456-456
 
 # ----------------------------------------------------------------------------------------------

--- a/tables/nl-NL-g1.ctb
+++ b/tables/nl-NL-g1.ctb
@@ -46,20 +46,20 @@ emphclass bold
 
 lenemphphrase italic 3
 endemphphrase italic before 456
-begemph italic 456
-endemph italic 6
+begemphword italic 456
+endemphword italic 6
 begemphphrase italic 456-456
 
 lenemphphrase bold 3
 endemphphrase bold before 456
-begemph bold 456
-endemph bold 6
+begemphword bold 456
+endemphword bold 6
 begemphphrase bold 456-456
 
 lenemphphrase underline 3
 endemphphrase underline before 456
-begemph underline 456
-endemph underline 6
+begemphword underline 456
+endemphword underline 6
 begemphphrase underline 456-456
 
 # ----------------------------------------------------------------------------------------------

--- a/tables/nl-old-g0.utb
+++ b/tables/nl-old-g0.utb
@@ -141,19 +141,19 @@ emphclass bold
 lenemphphrase italic 3
 endemphphrase italic before 456
 begemph italic 456
-endemph italic 6
+endemphword italic 6
 begemphphrase italic 456-456
 
 lenemphphrase bold 3
 endemphphrase bold before 456
-begemph bold 456
-endemph bold 6
+begemphword bold 456
+endemphword bold 6
 begemphphrase bold 456-456
 
 lenemphphrase underline 3
 endemphphrase underline before 456
-begemph underline 456
-endemph underline 6
+begemphword underline 456
+endemphword underline 6
 begemphphrase underline 456-456
 
 # §2.12 Hoofdletters [1]

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -20,21 +20,12 @@ emphclass italic
 emphclass underline
 emphclass bold
 
-lenemphphrase italic 1
-lenemphphrase bold 1
-
-begemphphrase italic 23
 begemph italic 23
-begemphphrase bold 6-3
 begemph bold 6-3
-begemphphrase underline 456
 begemph underline 456
 
-endemphphrase italic after 56
 endemph italic 56
-endemphphrase bold after 6-3
 endemph bold 6-3
-endemphphrase underline after 456
 endemph underline 456
 
 midnum , 2

--- a/tables/sr-g1.ctb
+++ b/tables/sr-g1.ctb
@@ -46,20 +46,20 @@ emphclass bold
 
 endemphphrase italic after 6-3
 lenemphphrase italic 1
-begemph italic 6-456
-endemph italic 6-3
+begemphword italic 6-456
+endemphword italic 6-3
 emphletter italic 456
 
 endemphphrase bold after 6-3
 lenemphphrase bold 1
-begemph bold 6-456
-endemph bold 6-3
+begemphword bold 6-456
+endemphword bold 6-3
 emphletter bold 456
 
 endemphphrase underline after 6-3
 lenemphphrase underline 1
-begemph underline 6-456
-endemph underline 6-3
+begemphword underline 6-456
+endemphword underline 6-3
 emphletter underline 456
 
 #----------- SPECIAL SYLLABLES ------------------------------------------------

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -608,6 +608,10 @@ main(int argc, char *argv[]) {
   tables_list[0] = '\0';
   read_tables(&parser, tables_list);
 
+  if (!lou_getTable(tables_list)) {
+    error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line,
+		  "Table %s not valid", tables_list);
+  }
   if (!yaml_parser_parse(&parser, &event) ||
       (event.type != YAML_SCALAR_EVENT)) {
     yaml_error(YAML_SCALAR_EVENT, &event);


### PR DESCRIPTION
Hi all

One of the last regressions we have on the ueb_update branch has to to with emphasis ending.

I'm trying to fix this but it occurs to me that I have some kind of misunderstanding how emphasis is handled.

I previously thought (as [documented in the wiki](https://github.com/liblouis/liblouis/wiki/Emphasis-Opcodes)) that a table defines either (I'm just making the dot patterns up):

```
begemph italic 46
endemph italic 46-3
```
and then has basic emphasis handling where all emphasis is handled the same way regardless of phrase length, etc

or the table defines rules such as
```
begemphword italic 46
endemphword italic 46-3
begemphprase italic 46-46
endemphphrase italic before 46-3
lenemphphrase italic 3
```
and then liblouis would use these indicators depending on whether the phrase is long enough. Within a word it would also use the indicator defined with `begemphword` and `endemphword`.

So in my understanding it did not make any sense to define both `begemph` and `begemphword` as they were addressing different use cases.

As it turns out on the [ueb_update branch](https://github.com/liblouis/liblouis/tree/feature/ueb_update) quite a few tables do this. This might be an oversight when porting them to the new opcode syntax. The `en-ueb-g1.ctb` table even defines different dot patterns for `begemphword` and `begemph`.

So, the question is: Is my understanding of how emphasis is going to handled correct?

I have a branch ([feature/emphasis_handling_cleanup](https://github.com/liblouis/liblouis/tree/feature/emphasis_handling_cleanup)) where I tried to correct all tables to use the proper emphasis opcodes. I get one additional failure compared to the feature/ueb_update branch and it might be that it is the same problem end emphasis problem that shows up somewhere else.

Can you guys look at this and tell me if I'm going in the right direction?

Thanks
Christian
