### PR TITLE
add new Beta APIs

### DIFF
--- a/windows/liblouis.def
+++ b/windows/liblouis.def
@@ -31,6 +31,9 @@ EXPORTS
 	extParseChars
 	extParseDots
 	getLastTableList
-lou_readCharFromFile
-lou_registerTableResolver
-lou_translatePrehyphenated
+	lou_readCharFromFile
+	lou_registerTableResolver
+	lou_translatePrehyphenated
+	lou_log
+	lou_indexTables
+	lou_findTable


### PR DESCRIPTION
These seem to be missing from the windows def file which was stopping windows building liblouis dll