### PR TITLE
Use gnulibs unistr.h to convert ucs to utf8 in the tools

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,10 +7,11 @@ AM_CPPFLAGS =					\
 	-I$(top_builddir)/gnulib		\
 	-I$(top_builddir)/tools
 
-LDADD =						\
-	$(top_builddir)/liblouis/liblouis.la	\
-	$(top_builddir)/gnulib/libgnu.la	\
-	$(top_builddir)/tools/libbrlcheck.la	\
+LDADD =							\
+	$(top_builddir)/liblouis/liblouis.la		\
+	$(top_builddir)/gnulib/libgnu.la		\
+	$(top_builddir)/tools/libbrlcheck.la		\
+	$(top_builddir)/tools/gnulib/libgnutools.la	\
 	$(LTLIBINTL)
 
 backtranslate_SOURCES = backtranslate.c

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -25,7 +25,9 @@ libbrlcheck_la_SOURCES =			\
 # following is needed to make sure the symbols are resolved from the
 # liblouis library. Otherwise we get missing symbol errors when
 # compiling the test suite, which depends on libbrlcheck.
-libbrlcheck_la_LIBADD = $(top_builddir)/liblouis/liblouis.la
+libbrlcheck_la_LIBADD =					\
+	$(top_builddir)/liblouis/liblouis.la		\
+	$(top_builddir)/tools/gnulib/libgnutools.la
 
 bin_PROGRAMS =					\
 	lou_allround				\

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -27,6 +27,7 @@
 #include "liblouis.h"
 #include "louis.h"
 #include "brl_checks.h"
+#include "unistr.h"
 
 int check_with_mode(const char *tableList, const char *str,
                     const formtype *typeform, const char *expected, int mode,
@@ -46,129 +47,17 @@ void print_typeform(const formtype *typeform, int len) {
   fprintf(stderr, "\n");
 }
 
-#define UTF8_BUFSIZE 32
-#define UNICODE_SURROGATE_PAIR -1
-#define UNICODE_BAD_INPUT -1
+void print_widechars(widechar *buffer, int length) {
+  uint8_t *result_buf;
+  size_t result_len;
 
-/* Input: a Unicode code point, "ucs".
-
-   Output: UTF-8 characters in buffer "utf8".
-
-   Return value: the number of bytes written into "utf8", or -1 if
-   there was an error.
-
-   This adds a zero byte to the end of the string. It assumes that the
-   buffer "utf8" has at least seven bytes of space to write to. */
-
-/* from http://std.dkuug.dk/jtc1/sc2/WG2/docs/n1335.html
-
-R.4 Mapping from UCS-4 form to UTF-8 form
-
-Table 4 defines in mathematical notation the mapping from the UCS-4
-coded representation form to the UTF-8 coded representation form.
-
-In the left column (UCS-4) the notation x indicates the four-octet
-coded representation of a single character of the UCS. In the right
-column (UTF-8) x indicates the corresponding integer value.
-
-NOTE 3 - Values of x in the range 0000 D800 .. 0000 DFFF are reserved
-for the UTF-16 form and do not occur in UCS-4. The values 0000 FFFE
-and 0000 FFFF also do not occur (see clause 8). The mappings of these
-code positions in UTF-8 are undefined.
-
-NOTE 4 - The algorithm for converting from UCS-4 to UTF-8 can be
-summarised as follows.
-
-For each coded character in UCS-4 the length of octet sequence in
-UTF-8 is determined by the entry in the right column of Table 1. The
-bits in the UCS-4 coded representation, starting from the least
-significant bit, are then distributed across the free bit positions in
-order of increasing significance until no more free bit positions are
-available.
-
-Table 4 - Mapping from UCS-4 to UTF-8
-
-Range of values			Sequence of
-in UCS-4  			octets in UTF-8
-
-x = 0000 0000 .. 0000 007F;	x;
-x = 0000 0080 .. 0000 07FF;	C0 + x/2**6;
-                                80 + x%2**6;
-x = 0000 0800 .. 0000 FFFF;	E0 + x/2**12;
-        (see Note 3)		80 + x/2**6%2**6;
-                                80 + x%2**6;
-x = 0001 0000 .. 001F FFFF;	F0 + x/2**18;
-                                80 + x/2**12%2**6;
-                                80 + x/2**6%2**6;
-                                80 + x%2**6;
-x = 0020 0000 .. 03FF FFFF;	F8 + x/2**24;
-                                80 + x/2**18%2**6;
-                                80 + x/2**12%2**6;
-                                80 + x/2**6%2**6;
-                                80 + x%2**6;
-x = 0400 0000 .. 7FFF FFFF;	FC + x/2**30;
-                                80 + x/2**24%2**6;
-                                80 + x/2**18%2**6;
-                                80 + x/2**12%2**6;
-                                80 + x/2**6%2**6;
-                                80 + x%2**6; */
-
-int ucs_to_utf8(widechar ucs, unsigned char *utf8) {
-  if (ucs < 0x80) {
-    utf8[0] = (unsigned char)ucs;  // Safe cast to 7-bit value
-    utf8[1] = '\0';
-    return 1;
-  } else if (ucs < 0x800) {
-    utf8[0] = (ucs >> 6) | 0xC0;
-    utf8[1] = (ucs & 0x3F) | 0x80;
-    utf8[2] = '\0';
-    return 2;
-  } else if (ucs < 0xFFFF) {
-    if (ucs >= 0xD800 && ucs <= 0xDFFF) {
-      /* Ill-formed. */
-      return UNICODE_SURROGATE_PAIR;
-    }
-    utf8[0] = ((ucs >> 12)) | 0xE0;
-    utf8[1] = ((ucs >> 6) & 0x3F) | 0x80;
-    utf8[2] = ((ucs)&0x3F) | 0x80;
-    utf8[3] = '\0';
-    return 3;
-  } else if (ucs < 0x1FFFFF) {
-    utf8[0] = 0xF0 | ((ucs >> 18));
-    utf8[1] = 0x80 | ((ucs >> 12) & 0x3F);
-    utf8[2] = 0x80 | ((ucs >> 6) & 0x3F);
-    utf8[3] = 0x80 | ((ucs & 0x3F));
-    utf8[4] = '\0';
-    return 4;
-  } else if (ucs < 0x3FFFFFF) {
-    utf8[0] = 0xF0 | ((ucs >> 24));
-    utf8[1] = 0x80 | ((ucs >> 18) & 0x3F);
-    utf8[2] = 0x80 | ((ucs >> 12) & 0x3F);
-    utf8[3] = 0x80 | ((ucs >> 6) & 0x3F);
-    utf8[4] = 0x80 | ((ucs & 0x3F));
-    utf8[5] = '\0';
-    return 5;
-  } else if (ucs < 0x7FFFFFFF) {
-    utf8[0] = 0xF0 | ((ucs >> 30));
-    utf8[1] = 0x80 | ((ucs >> 24) & 0x3F);
-    utf8[2] = 0x80 | ((ucs >> 18) & 0x3F);
-    utf8[3] = 0x80 | ((ucs >> 12) & 0x3F);
-    utf8[4] = 0x80 | ((ucs >> 6) & 0x3F);
-    utf8[5] = 0x80 | ((ucs & 0x3F));
-    utf8[6] = '\0';
-    return 6;
-  }
-  return UNICODE_BAD_INPUT;
-}
-
-void print_widechars(widechar *buf, int len) {
-  int i;
-  unsigned char utf8[UTF8_BUFSIZE];
-
-  for (i = 0; i < len; i++) {
-    ucs_to_utf8(buf[i], utf8);
-    fprintf(stderr, "%s", utf8);
-  }
+#ifdef WIDECHARS_ARE_UCS4
+  result_buf = u32_to_u8(buffer, length, NULL, &result_len);
+#else
+  result_buf = u16_to_u8(buffer, length, NULL, &result_len);
+#endif
+  fprintf(stderr, "%.*s", result_len, result_buf);
+  free(result_buf);
 }
 
 /* Helper function to convert a typeform string of '0's, '1's, '2's etc.
@@ -280,27 +169,32 @@ int check_with_mode(const char *tableList, const char *str,
       print_widechars(outbuf, outlen);
       fprintf(stderr, "' (length %d)\n", outlen);
 
-      if (i < outlen && i < expectedlen) {
-	unsigned char expected_utf8[UTF8_BUFSIZE];
-	unsigned char out_utf8[UTF8_BUFSIZE];
+      uint8_t *expected_utf8;
+      uint8_t *out_utf8;
+      size_t expected_utf8_len;
+      size_t out_utf8_len;
+#ifdef WIDECHARS_ARE_UCS4
+      expected_utf8 = u32_to_u8(expectedbuf, expectedlen, NULL, &expected_utf8_len);
+      out_utf8 = u32_to_u8(outbuf, outlen, NULL, &out_utf8_len);
+#else
+      expected_utf8 = u16_to_u8(expectedbuf, expectedlen, NULL, &expected_utf8_len);
+      out_utf8 = u16_to_u8(outbuf, outlen, NULL, &out_utf8_len);
+#endif
 
-	ucs_to_utf8(expectedbuf[i], expected_utf8);
-	ucs_to_utf8(outbuf[i], out_utf8);
-	fprintf(stderr, "Diff: Expected '%s' but received '%s' in index %d\n",
-	        expected_utf8, out_utf8, i);
+      if (i < outlen && i < expectedlen) {
+	fprintf(stderr, "Diff: Expected '%c' but received '%c' in index %d\n",
+	        expected_utf8[i], out_utf8[i], i);
       } else if (i < expectedlen) {
-	unsigned char expected_utf8[UTF8_BUFSIZE];
-	ucs_to_utf8(expectedbuf[i], expected_utf8);
 	fprintf(stderr,
-	        "Diff: Expected '%s' but received nothing in index %d\n",
-	        expected_utf8, i);
+	        "Diff: Expected '%c' but received nothing in index %d\n",
+	        expected_utf8[i], i);
       } else {
-	unsigned char out_utf8[UTF8_BUFSIZE];
-	ucs_to_utf8(outbuf[i], out_utf8);
 	fprintf(stderr,
-	        "Diff: Expected nothing but received '%s' in index %d\n",
-	        out_utf8, i);
+	        "Diff: Expected nothing but received '%c' in index %d\n",
+	        out_utf8[i], i);
       }
+      free(expected_utf8);
+      free(out_utf8);
     }
   }
 

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -30,6 +30,7 @@
 #include "louis.h"
 #include <getopt.h>
 #include "progname.h"
+#include "unistr.h"
 #include "version-etc.h"
 
 static const struct option longopts[] =
@@ -263,6 +264,7 @@ int
 main (int argc, char **argv)
 {
   char *charbuf;
+  int charlen;
   widechar inbuf[BUFSIZE];
   widechar transbuf[BUFSIZE];
   widechar outbuf[BUFSIZE];
@@ -331,20 +333,26 @@ main (int argc, char **argv)
 	      break;
 	    transbuf[translen] = 0;
 	    printf ("Translation:\n");
-	    charbuf = showString (transbuf, translen);
-	    k = strlen (charbuf) - 1;
-	    charbuf[k] = 0;
-	    printf ("%s\n", &charbuf[1]);
+#ifdef WIDECHARS_ARE_UCS4
+	    charbuf = u32_to_u8(transbuf, translen, NULL, &charlen);
+#else
+	    charbuf = u16_to_u8(transbuf, translen, NULL, &charlen);
+#endif
+	    printf ("%.*s\n", charlen, charbuf);
+	    free(charbuf);
 	    if (showSizes)
 	      printf ("input length = %d; output length = %d\n", inlen,
 		      translen);
 	    lou_backTranslateString (table, transbuf, &translen, outbuf,
 				     &outlen, NULL, NULL, 0);
 	    printf ("Back-translation:\n");
-	    charbuf = showString (outbuf, outlen);
-	    k = strlen (charbuf) - 1;
-	    charbuf[k] = 0;
-	    printf ("%s\n", &charbuf[1]);
+#ifdef WIDECHARS_ARE_UCS4
+	    charbuf = u32_to_u8(outbuf, outlen, NULL, &charlen);
+#else
+	    charbuf = u16_to_u8(outbuf, outlen, NULL, &charlen);
+#endif
+	    printf ("%.*s\n", charlen, charbuf);
+	    free(charbuf);
 	    if (showSizes)
 	      printf ("input length = %d; output length = %d.\n", translen,
 		      outlen);
@@ -396,10 +404,13 @@ main (int argc, char **argv)
 		else
 		  {
 		    printf ("Translation:\n");
-		    charbuf = showString (transbuf, translen);
-		    k = strlen (charbuf) - 1;
-		    charbuf[k] = 0;
-		    printf ("%s\n", &charbuf[1]);
+#ifdef WIDECHARS_ARE_UCS4
+		    charbuf = u32_to_u8(transbuf, translen, NULL, &charlen);
+#else
+		    charbuf = u16_to_u8(transbuf, translen, NULL, &charlen);
+#endif
+		    printf ("%.*s\n", charlen, charbuf);
+		    free(charbuf);
 		    if (showSizes)
 		      printf ("input length = %d; output length = %d\n",
 			      inlen, translen);
@@ -428,10 +439,13 @@ main (int argc, char **argv)
 					&inputPos[0], &cursorPos, mode))
 		  break;
 		printf ("Back-translation:\n");
-		charbuf = showString (outbuf, outlen);		k = 
-		strlen (charbuf) - 1;
-		charbuf[k] = 0;
-		printf ("%s\n", &charbuf[1]);
+#ifdef WIDECHARS_ARE_UCS4
+		charbuf = u32_to_u8(outbuf, outlen, NULL, &charlen);
+#else
+		charbuf = u16_to_u8(outbuf, outlen, NULL, &charlen);
+#endif
+		printf ("%.*s\n", charlen, charbuf);
+		free(charbuf);
 		if (showSizes)
 		  printf ("input length = %d; output length = %d\n",
 			  translen, outlen);

--- a/tools/lou_debug.c
+++ b/tools/lou_debug.c
@@ -29,6 +29,7 @@
 #include "louis.h"
 #include <getopt.h>
 #include "progname.h"
+#include "unistr.h"
 #include "version-etc.h"
 
 static const struct option longopts[] =
@@ -91,6 +92,19 @@ getInput (void)
   return inputLength;
 }
 
+static char*
+print_chars(const widechar *buffer, int length) {
+  static uint8_t result_buf[BUFSIZE];
+  size_t result_len = BUFSIZE - 1;
+#ifdef WIDECHARS_ARE_UCS4
+  u32_to_u8(buffer, length, &result_buf, &result_len);
+#else
+  u16_to_u8(buffer, length, &result_buf, &result_len);
+#endif
+  result_buf[result_len] = 0;
+  return result_buf;
+}
+
 static int
 printRule (TranslationTableRule * thisRule, int mode)
 {
@@ -109,13 +123,13 @@ printRule (TranslationTableRule * thisRule, int mode)
     case CTO_Pass2:
     case CTO_Pass3:
     case CTO_Pass4:
-      printf ("code=%s ", showString (thisRule->charsdots, thisRule->charslen
+      printf ("code=%s ", print_chars(thisRule->charsdots, thisRule->charslen
 				      + thisRule->dotslen));
       break;
     default:
       if (mode == 0)
 	{
-	  printf ("chars=%s, ", showString (thisRule->charsdots,
+	  printf ("chars=%s, ", print_chars(thisRule->charsdots,
 					    thisRule->charslen));
 	  printf ("dots=%s, ",
 		  showDots (&thisRule->charsdots[thisRule->charslen],
@@ -126,7 +140,7 @@ printRule (TranslationTableRule * thisRule, int mode)
 	  printf ("dots=%s, ",
 		  showDots (&thisRule->charsdots[thisRule->charslen],
 			    thisRule->dotslen));
-	  printf ("chars=%s, ", showString (thisRule->charsdots,
+	  printf ("chars=%s, ", print_chars(thisRule->charsdots,
 					    thisRule->charslen));
 	}
       break;
@@ -142,9 +156,9 @@ printCharacter (TranslationTableCharacter * thisChar, int mode)
   if (mode == 0)
     {
       printf ("Char: ");
-      printf ("real=%s, ", showString (&thisChar->realchar, 1));
-      printf ("upper=%s, ", showString (&thisChar->uppercase, 1));
-      printf ("lower=%s, ", showString (&thisChar->lowercase, 1));
+      printf ("real=%s, ", print_chars(&thisChar->realchar, 1));
+      printf ("upper=%s, ", print_chars(&thisChar->uppercase, 1));
+      printf ("lower=%s, ", print_chars(&thisChar->lowercase, 1));
     }
   else
     printf ("Dots: real=%s, ", showDots (&thisChar->realchar, 1));
@@ -388,11 +402,11 @@ show_misc (void)
   printf ("'syllable' opcodes: %s\n", pickYN (table->syllables));
   printf ("'capsnocont' opcode: %s\n", pickYN (table->capsNoCont));
   printf ("Hyphenation table: %s\n", pickYN (table->hyphenStatesArray));
-  printf ("noletsignbefore %s\n", showString (&table->noLetsignBefore[0],
+  printf ("noletsignbefore %s\n", print_chars(&table->noLetsignBefore[0],
 					      table->noLetsignBeforeCount));
-  printf ("noletsign %s\n", showString (&table->noLetsign[0],
+  printf ("noletsign %s\n", print_chars(&table->noLetsign[0],
 					table->noLetsignCount));
-  printf ("noletsignafter %s\n", showString (&table->noLetsignAfter[0],
+  printf ("noletsignafter %s\n", print_chars(&table->noLetsignAfter[0],
 					     table->noLetsignAfterCount));
   return 1;
 }
@@ -416,7 +430,7 @@ show_charMap (int startHash)
 	while (nextChar)
 	  {
 	    thisChar = (CharOrDots *) & table->ruleArea[nextChar];
-	    printf ("Char: %s ", showString (&thisChar->lookFor, 1));
+	    printf ("Char: %s ", print_chars(&thisChar->lookFor, 1));
 	    printf ("dots=%s\n", showDots (&thisChar->found, 1));
 	    printf ("=> ");
 	    getInput ();
@@ -450,7 +464,7 @@ show_dotsMap (int startHash)
 	  {
 	    thisDots = (CharOrDots *) & table->ruleArea[nextDots];
 	    printf ("Dots: %s ", showDots (&thisDots->lookFor, 1));
-	    printf ("char=%s\n", showString (&thisDots->found, 1));
+	    printf ("char=%s\n", print_chars(&thisDots->found, 1));
 	    printf ("=> ");
 	    getInput ();
 	    if (*inputBuffer == 'h')
@@ -477,7 +491,7 @@ show_compDots (int startChar)
       {
 	TranslationTableRule *thisRule = (TranslationTableRule *)
 	  & table->ruleArea[table->compdotsPattern[k]];
-	printf ("Char: %s ", showString (&k, 1));
+	printf ("Char: %s ", print_chars(&k, 1));
 	printf ("dots=%s\n",
 		showDots (&thisRule->charsdots[1], thisRule->dotslen));
 	printf ("=> ");

--- a/tools/lou_translate.c
+++ b/tools/lou_translate.c
@@ -22,7 +22,7 @@
 
    */
 
-# include <config.h>
+#include <config.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -30,6 +30,7 @@
 #include "liblouis.h"
 #include "louis.h"
 #include "progname.h"
+#include "unistr.h"
 #include "version-etc.h"
 
 #define BUFSIZE MAXSTRING - 4
@@ -58,6 +59,7 @@ translate_input (int forward_translation, char *table_name)
 {
   char charbuf[BUFSIZE];
   char *outputbuf;
+  int outlen;
   widechar inbuf[BUFSIZE];
   widechar transbuf[BUFSIZE];
   int inlen;
@@ -83,10 +85,13 @@ translate_input (int forward_translation, char *table_name)
 					  transbuf, &translen, NULL, NULL, 0);
       if (!result)
 	break;
-      outputbuf = showString (transbuf, translen);
-      k = strlen (outputbuf) - 1;
-      outputbuf[k] = 0;
-      printf ("%s\n", &outputbuf[1]);
+#ifdef WIDECHARS_ARE_UCS4
+      outputbuf = u32_to_u8(transbuf, translen, NULL, &outlen);
+#else
+      outputbuf = u16_to_u8(transbuf, translen, NULL, &outlen);
+#endif
+      printf ("%.*s\n", outlen, outputbuf);
+      free(outputbuf);
     }
   lou_free ();
 }


### PR DESCRIPTION
All the tools should now be able to emit utf8. The home-made (aka copied
from stackoverflow) code to comvert to utf8 in brl_checks.c has also
been replaced with u32_to_u8 and u16_to_u8 from unistr.h