### PR TITLE
Hungarian braille tables related files: Use a standard license header

### DIFF
--- a/tables/hu-backtranslate-correction.dis
+++ b/tables/hu-backtranslate-correction.dis
@@ -1,26 +1,25 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014, IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
+#  Copyright (C) 2011-2016, Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
 #  All rights reserved
 #
-#  This file is free software; you can redistribute it and/or modify it
-#   under the terms of the Lesser or Library GNU General Public License
-#  as published by the
-#  Free Software Foundation; version 2.1
+#  This file is part of liblouis.
 #
-#  This file is distributed in the hope that it will be useful, but
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  Library GNU General Public License for more details.
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
 #
-#  You should have received a copy of the Library GNU General Public
-#  License along with this program; see the file COPYING.  If not, write
-#  to
-#  the Free Software Foundation, 51 Franklin Street, Fifth Floor,
-#  Boston, MA 02110-1301, USA.
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
 #
-#  Maintained by Attila Hammer  hammer.attila@infoalap.hu
-#
+#  Table maintainer: Attila Hammer  <hammer.attila@infoalap.hu>
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin

--- a/tables/hu-chardefs.cti
+++ b/tables/hu-chardefs.cti
@@ -1,26 +1,25 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014, IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
+#  Copyright (C) 2011-2016, Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
 #  All rights reserved
 #
-#  This file is free software; you can redistribute it and/or modify it
-#   under the terms of the Lesser or Library GNU General Public License
-#  as published by the
-#  Free Software Foundation; version 2.1
+#  This file is part of liblouis.
 #
-#  This file is distributed in the hope that it will be useful, but
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  Library GNU General Public License for more details.
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
 #
-#  You should have received a copy of the Library GNU General Public
-#  License along with this program; see the file COPYING.  If not, write
-#  to
-#  the Free Software Foundation, 51 Franklin Street, Fifth Floor,
-#  Boston, MA 02110-1301, USA.
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
 #
-#  Maintained by Attila Hammer  hammer.attila@infoalap.hu
-#
+#  Table maintainer: Attila Hammer <hammer.attila@infoalap.hu>
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -1,26 +1,25 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014, IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
+#  Copyright (C) 2011-2016, Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
 #  All rights reserved
 #
-#  This file is free software; you can redistribute it and/or modify it
-#   under the terms of the Lesser or Library GNU General Public License
-#  as published by the
-#  Free Software Foundation; version 2.1
+#  This file is part of liblouis.
 #
-#  This file is distributed in the hope that it will be useful, but
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  Library GNU General Public License for more details.
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
 #
-#  You should have received a copy of the Library GNU General Public
-#  License along with this program; see the file COPYING.  If not, write
-#  to
-#  the Free Software Foundation, 51 Franklin Street, Fifth Floor,
-#  Boston, MA 02110-1301, USA.
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
 #
-#  Maintained by Attila Hammer  hammer.attila@infoalap.hu
-#
+#  Table maintainer: Attila Hammer < hammer.attila@infoalap.hu>
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin

--- a/tables/hu-hu-comp8.ctb
+++ b/tables/hu-hu-comp8.ctb
@@ -2,27 +2,26 @@
 #
 #  Based on the Linux screenreader BRLTTY, copyright (C) 1999-2011 by the BRLTTY Team
 #
-#  Copyright (C) 2012 IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
+#  Copyright (C) 2012 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
 #  All rights reserved
 #
-#  This file is free software; you can redistribute it and/or modify it
-#   under the terms of the Lesser or Library GNU General Public License
-#  as published by the
-#  Free Software Foundation; version 2.1
+#  This file is part of liblouis.
 #
-#  This file is distributed in the hope that it will be useful, but
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  Library GNU General Public License for more details.
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
 #
-#  You should have received a copy of the Library GNU General Public
-#  License along with this program; see the file COPYING.  If not, write
-#  to
-#  the Free Software Foundation, 51 Franklin Street, Fifth Floor,
-#  Boston, MA 02110-1301, USA.
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
 #
-#  Maintained by Attila Hammer  hammer.attila@infoalap.hu
-#
+#  Table maintainer: Attila Hammer < hammer.attila@infoalap.hu>
 # If you found bugs with hungarian computer braille table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu>
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin

--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -1,26 +1,25 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014, IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
+#  Copyright (C) 2011-2016, Attila hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu 
 #  All rights reserved
 #
-#  This file is free software; you can redistribute it and/or modify it
-#   under the terms of the Lesser or Library GNU General Public License
-#  as published by the
-#  Free Software Foundation; version 2.1
+#  This file is part of liblouis.
 #
-#  This file is distributed in the hope that it will be useful, but
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  Library GNU General Public License for more details.
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
 #
-#  You should have received a copy of the Library GNU General Public
-#  License along with this program; see the file COPYING.  If not, write
-#  to
-#  the Free Software Foundation, 51 Franklin Street, Fifth Floor,
-#  Boston, MA 02110-1301, USA.
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
 #
-#  Maintained by Attila Hammer  hammer.attila@infoalap.hu
-#
+#  Table maintainer: Attila Hammer  <hammer.attila@infoalap.hu>
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin


### PR DESCRIPTION
Hi Chris,

I doed required changes with hungarian braille tables related files to licensechecker shows right statement.
I copyed proper parts from standard Liblouis license header.
I actualized the copyright statements too.

Now hungarian braille table related files licensechecker shows following result after I committed this change my forked Liblouis repository, when I type licensecheck --copyright --check='\.(ctb|utb|cti|uti|dis)'  --machine * -l 30 | sort -k2 command:
hu-hu-comp8.ctb	LGPL (v2.1 or later)	1999-2011 by the BRLTTY Team / 2012 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu
hu-hu-g1.ctb	LGPL (v2.1 or later)	2011-2016, Attila hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu
hu-backtranslate-correction.dis	LGPL (v2.1 or later)	2011-2016, Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu
hu-chardefs.cti	LGPL (v2.1 or later)	2011-2016, Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu
hu-exceptionwords.cti	LGPL (v2.1 or later)	2011-2016, Attila Hammer from IT Foundation for the Visually Impaired - Hungary. Homepage: www.infoalap.hu

Please review these changes, and merge this commit with proper Liblouis branches if all changes good your openion.

Attila