### PR TITLE
Hungarian braille tables: completed and actualized the year column in copyright header

### DIFF
--- a/tables/hu-backtranslate-correction.dis
+++ b/tables/hu-backtranslate-correction.dis
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014 IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2011-2016 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #

--- a/tables/hu-chardefs.cti
+++ b/tables/hu-chardefs.cti
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014 IT Foundation for the Visually Impaired - Hungary. /www.infoalap.hu
+#  Copyright (C) 2011-2016 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014 IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2011-2016 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #

--- a/tables/hu-hu-comp8.ctb
+++ b/tables/hu-hu-comp8.ctb
@@ -2,7 +2,7 @@
 #
 #  Based on the Linux screenreader BRLTTY, copyright (C) 1999-2011 by the BRLTTY Team
 #
-#  Copyright (C) 2012 IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2012 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #

--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2014 IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2011-2016 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #


### PR DESCRIPTION
Hi Chris,

Based an another pull request consultation for you, I completed hungarian braille tables  the copyright header with following form:
Attila Hammer from IT Foundation for the Visually Impaired - Hungary.

I increased the second year column in copyright header with 2016,  except the hu-hu-comp8.ctb table, because this table doesn't happened modifications since 2012.
Please review this change, and if all looks good your openion, please merge this pull request into Liblouis proper branches.
If I need doing next years any modifications with hungarian braille tables and the included files (for example the hu-exceptionwords.cti included file), I will updating the second year column the actual year when the modification is happened.
Sorry to previous forgot this since 2014.

Attila