### PR TITLE
Add function lou_getTypeformForEmphClass

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -170,6 +170,7 @@ Programming with liblouis
 * lou_backTranslate::
 * lou_hyphenate::
 * lou_compileString::
+* lou_getTypeformForEmphClass::
 * lou_dotsToChar::
 * lou_charToDots::
 * lou_registerLogCallback::
@@ -2187,6 +2188,7 @@ the doctest directory in the source distribution.
 * lou_backTranslate::
 * lou_hyphenate::
 * lou_compileString::
+* lou_getTypeformForEmphClass::
 * lou_dotsToChar::
 * lou_charToDots::
 * lou_registerLogCallback::
@@ -2213,7 +2215,7 @@ You use the liblouis library by calling the following functions,
 @code{lou_logFile}, @code{lou_logPrint}, @code{lou_logEnd},
 @code{lou_getTable}, @code{lou_checkTable},
 @code{lou_hyphenate}, @code{lou_charToDots}, @code{lou_dotsToChar},
-@code{lou_compileString}, @code{lou_readCharFromFile},
+@code{lou_compileString}, @code{lou_getTypeformForEmphClass}, @code{lou_readCharFromFile},
 @code{lou_version} and @code{lou_free}.  These are described
 below. The header file, @file{liblouis.h}, also contains brief
 descriptions. Liblouis is written in straight C. It has four code
@@ -2233,9 +2235,7 @@ yet been compiled @file{compileTranslationTable.c} checks it for
 correctness and compiles it into an efficient internal representation.
 The main entry point is @code{lou_getTable}. Since it is the module
 that keeps track of memory usage, it also contains the @code{lou_free}
-function. In addition, it contains the @code{lou_checkTable}, @code{lou_registerLogCallback},
-@code{lou_setLogLevel}, @code{lou_logFile}, @code{lou_logPrint} and
-@code{lou_logEnd} functions, plus some utility functions which are
+function. In addition, it contains the @code{lou_checkTable} function, plus some utility functions which are
 used by the other modules.
 
 By default, liblouis handles all characters internally as 16-bit
@@ -2594,6 +2594,24 @@ table entry to be added. It may be anything valid. Error messages
 will be produced if it is invalid. The function returns 1 on success and 
 0 on failure.
 
+@node lou_getTypeformForEmphClass
+@section lou_getTypeformForEmphClass
+@findex lou_getTypeformForEmphClass
+
+@example
+int lou_getTypeformForEmphClass (const char *tableList, const char *emphClass);
+@end example
+
+This function returns the typeform bit associated with the given emphasis
+class. If the emphasis class is undefined this function returns @code{0}. If
+errors are found error messages are logged to the log callback (see
+@code{lou_registerLogCallback}) and the return value is @code{0}.
+@code{tableList} is a list of names of table files separated by
+commas, as explained previously
+(@pxref{translation-tables,,@code{tableList} parameter in
+@code{lou_translateString}}). @code{emphClass} is the name of an emphasis
+class.
+
 @node lou_dotsToChar
 @section lou_dotsToChar
 @findex lou_dotsToChar
@@ -2776,7 +2794,7 @@ pointer being returned.
 @findex lou_checkTable
 
 @example
-int lou_checkTable (char *tableList);
+int lou_checkTable (const char *tableList);
 @end example
 
 This function does the same as @code{lou_getTable}

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5278,6 +5278,17 @@ lou_checkTable (const char *tableList)
   return 0;
 }
 
+formtype EXPORT_CALL
+lou_getTypeformForEmphClass(const char *tableList, const char *emphClass) {
+	int i;
+	if (!getTable(tableList))
+		return 0;//perensap
+	for (i = 0; table->emphClasses[i]; i++)
+		if (strcmp(emphClass, table->emphClasses[i]) == 0)
+			return italic << i;
+	return 0;
+}
+
 static unsigned char *destSpacing = NULL;
 static int sizeDestSpacing = 0;
 static unsigned short *typebuf = NULL;

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -190,6 +190,14 @@ void EXPORT_CALL lou_registerTableResolver(
 int EXPORT_CALL lou_compileString(const char *tableList, const char *inString);
 
 /**
+ * Get the typeform bit for the named emphasis class.
+ *
+ * If the table defines the specified emphasis class the corresponding
+ * typeform is returned. Else the return value is 0.
+ */
+formtype EXPORT_CALL lou_getTypeformForEmphClass(const char *tableList, const char *emphClass);
+
+/**
  * Set the path used for searching for tables and liblouisutdml files.
  *
  * Overrides the installation path. */

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -101,6 +101,8 @@ liblouis.lou_checkTable.argtypes = (c_char_p,)
 
 liblouis.lou_compileString.argtypes = (c_char_p, c_char_p)
 
+liblouis.lou_getTypeformForEmphClass.argtypes = (c_char_p, c_char_p)
+
 def version():
     """Obtain version information for liblouis.
     @return: The version of liblouis, plus other information, such as
@@ -304,6 +306,17 @@ def compileString(tableList, inString):
     inBytes = inString.encode("ASCII") if isinstance(inString, str) else bytes(inString)
     if not liblouis.lou_compileString(tablesString, inString):
         raise RuntimeError("Can't compile entry: tables %s, inString %s"%(tableList, inString))
+
+def getTypeformForEmphClass(tableList, emphClass):
+    """Get the typeform bit for the named emphasis class.
+    @param tableList: A list of translation tables.
+    @type tableList: list of str
+    @param emphClass: An emphasis class name.
+    @type emphClass: str
+    @see: lou_getTypeformForEmphClass in the liblouis documentation
+    """
+    tablesString = _createTablesString(tableList)
+    return liblouis.lou_getTypeformForEmphClass(tablesString, emphClass)
 
 #{ Typeforms
 plain_text = 0x0000

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ present_progressive_SOURCES = default_table.h present_progressive.c
 resolve_table_SOURCES = resolve_table.c
 squash_space_SOURCES = squash_space.c
 typeform_SOURCES = typeform.c
+typeform_for_emphclass_SOURCES = typeform_for_emphclass.c
 uplow_with_unicode_SOURCES = uplow_with_unicode.c
 
 # Note that this is not currently included in check_programs below
@@ -74,6 +75,7 @@ program_TESTS =					\
 	outpos					\
 	getTable				\
 	typeform				\
+	typeform_for_emphclass			\
 	pass0_typebuf				\
 	hash_collision				\
 	resolve_table				\

--- a/tests/tables/emphclass/emphclass_valid.utb
+++ b/tests/tables/emphclass/emphclass_valid.utb
@@ -1,7 +1,7 @@
 emphclass italic     // typeform 0x1
 emphclass underline  // typeform 0x2
 emphclass bold       // typeform 0x4
-emphclass foo        // typeform 0x40
+emphclass foo        // typeform 0x8
 
 uplow Aa 1
 uplow Bb 12

--- a/tests/typeform_for_emphclass.c
+++ b/tests/typeform_for_emphclass.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "liblouis.h"
+
+int
+main (int argc, char **argv)
+{
+	int result = 0;
+	const char *table = "emphclass_valid.utb";
+	const char *class;
+	class = "italic";
+	formtype typeform = italic;
+	if (lou_getTypeformForEmphClass(table, class) != typeform) {
+		fprintf(stderr, "%s should have typeform %x\n", class, typeform);
+		result = 1;
+	}
+	class = "underline";
+	typeform = underline;
+	if (lou_getTypeformForEmphClass(table, class) != typeform) {
+		fprintf(stderr, "%s should have typeform %x\n", class, typeform);
+		result = 1;
+	}
+	class = "bold";
+	typeform = bold;
+	if (lou_getTypeformForEmphClass(table, class) != typeform) {
+		fprintf(stderr, "%s should have typeform %x\n", class, typeform);
+		result = 1;
+	}
+	class = "foo";
+	typeform = emph_4;
+	if (lou_getTypeformForEmphClass(table, class) != typeform) {
+		fprintf(stderr, "%s should have typeform %x\n", class, typeform);
+		result = 1;
+	}
+	class = "bar";
+	if (lou_getTypeformForEmphClass(table, class) != 0) {
+		fprintf(stderr, "%s should not be defined\n", class);
+		result = 1;
+	}
+	lou_free();
+	return result;
+}

--- a/windows/include/liblouis.h
+++ b/windows/include/liblouis.h
@@ -195,6 +195,14 @@ void EXPORT_CALL lou_registerTableResolver(
 int EXPORT_CALL lou_compileString(const char *tableList, const char *inString);
 
 /**
+ * Get the typeform bit for the named emphasis class.
+ *
+ * If the table defines the specified emphasis class the corresponding
+ * typeform is returned. Else the return value is 0.
+ */
+formtype EXPORT_CALL lou_getTypeformForEmphClass(const char *tableList, const char *emphClass);
+
+/**
  * Set the path used for searching for tables and liblouisutdml files.
  *
  * Overrides the installation path. */

--- a/windows/liblouis.def
+++ b/windows/liblouis.def
@@ -18,6 +18,7 @@ EXPORTS
 	lou_setDataPath
 	lou_getTable
 	lou_checkTable
+	lou_getTypeformForEmphClass
 	lou_getDataPath
 	lou_registerLogCallback
 	lou_setLogLevel


### PR DESCRIPTION
For example to find out if tables define commonly used class names such as transnote, prodnote, strikethrough, superscript, etc.