### PR TITLE
implicit declaration of function 'pattern_check'

### DIFF
--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -701,6 +701,10 @@ int backTranslateWithTracing(const char *tableList, const widechar *inbuf,
 
 char *getLastTableList();
 
+int pattern_check(const widechar *input, const int input_start, const int
+		  input_minmax, const int input_dir, const widechar *expr_data,
+		  const TranslationTableHeader *t);
+
 /* Can be inserted in code to be used as a breakpoint in gdb */
 void debugHook();
 


### PR DESCRIPTION
I am cross-compiling liblouis using clang to create javascript bindings for liblouis. While GCC only complains about the forward declaration, clang refuses to compile the code. This pull request adds "pattern_check" to the internal header file "louis.h".

---
Error messages for reference:

__CLANG/LLVM:__
```
lou_backTranslateString.c:809:10: error: implicit declaration of function 'pattern_check' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                                        if(!pattern_check(currentInput, src - 1, -1, -1, pattern, table))
```
__GCC:__
```
lou_backTranslateString.c:809:6: warning: implicit declaration of function ‘pattern_check’ [-Wimplicit-function-declaration]
      if(!pattern_check(currentInput, src - 1, -1, -1, pattern, table))
```