### PR TITLE
Fix unresolved external symbol errors when building on windows

### DIFF
--- a/README.windows
+++ b/README.windows
@@ -21,7 +21,7 @@ Now type
 
 nmake /f Makefile.nmake
 
-The directory will contain liblouis-2.dll and liblouis-2.lib, along with 
+The directory will contain liblouis.dll and liblouis.lib, along with 
 object files.
 
 

--- a/windows/liblouis.def
+++ b/windows/liblouis.def
@@ -36,5 +36,3 @@ EXPORTS
 	lou_readCharFromFile
 	lou_registerTableResolver
 	lou_translatePrehyphenated
-	lou_indexTables
-	lou_findTable


### PR DESCRIPTION
This commit removes 2 beta api symbols from the module definition file
(windows/liblouis.def) and allows liblouis to be built on windows by
using nmake.
Liblouis wasn't built on windows due to 2 unresolved external symbol
errors. These errors were caused by having a reference to beta-api
functions defined on findTable.c (lou_indexTables and lou_findTable),
which still have some platform-specific dependencies (dirent.h,
strndup.c).
The object file for findTable was already not being built on
Makefile.nmake, so this change simply makes it able to link against only
the supported objects and successfully produce liblouis binaries on
windows (liblouis.dll, liblouis.lib, liblouis.exp).