### PR TITLE
Add noUndefinedDots and partialTrans modes for back-translation of input being typed on a braille keyboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ TAGS
 /tests/Makefile.in
 /tests/backtranslate
 /tests/backtranslate_noUndefinedDots
+/tests/backtranslate_partialTrans
 /tests/backtranslate_with_letsign
 /tests/capitalization
 /tests/capitalized_with_sentance

--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ TAGS
 /tests/Makefile
 /tests/Makefile.in
 /tests/backtranslate
+/tests/backtranslate_noUndefinedDots
 /tests/backtranslate_with_letsign
 /tests/capitalization
 /tests/capitalized_with_sentance

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2195,7 +2195,7 @@ A list of translation modes that should be used for this test. If not
 defined defaults to 0. Valid mode values are @samp{noContractions},
 @samp{compbrlAtCursor}, @samp{dotsIO}, @samp{comp8Dots},
 @samp{pass1Only}, @samp{compbrlLeftCursor}, @samp{otherTrans},
-@samp{ucBrl} or @samp{noUndefinedDots}.
+@samp{ucBrl}, @samp{noUndefinedDots} or @samp{partialTrans}.
 @end table
 
 @end table
@@ -2602,11 +2602,16 @@ spacing between the input and output strings. The @code{typeform} and
 not needed. @code{mode} again specifies how the back-translation
 should be done.
 
-The additional @code{noUndefinedDots} mode only applies to
-back-translation. By default, if a dot pattern in the input is
-undefined, the dot numbers will be included in the output. If this mode
-is set, this does not occur; an undefined dot pattern simply produces no
-output.
+There are two additional modes that only apply to back-translation. By
+default, if a dot pattern in the input is undefined, the dot numbers
+will be included in the output. If the @code{noUndefinedDots} mode is
+set, this does not occur; an undefined dot pattern simply produces no
+output. The @code{partialTrans} mode specifies that the input should be
+treated as an incomplete word. That is, rules that apply only for
+complete words or at the end of a word will not take effect. This is
+intended to be used when translating input typed on a braille keyboard
+to provide a rough idea to the user of the characters they are typing
+before the word is complete.
 
 @node lou_backTranslate
 @section lou_backTranslate
@@ -3062,6 +3067,6 @@ directory. Usage information is included in the Python module itself.
 @c  LocalWords:  abrege decrement pre cornf comf scano cornm cornp po
 @c  LocalWords:  h's brl testtrans UCS asis libyaml doctests url yaml
 @c  LocalWords:  testmode iftex unicode ueb xfail eo noContractions
-@c  LocalWords:  dotsIO otherTrans ucBrl noUndefinedDots abc doctest
-@c  LocalWords:  inString enum cp outbufbuf logcallback fprint lbu EOF
-@c  LocalWords:  checkTable fn ispell
+@c  LocalWords:  dotsIO otherTrans ucBrl noUndefinedDots partialTrans
+@c  LocalWords:  abc doctest inString enum cp outbufbuf logcallback fprint
+@c  LocalWords:  lbu EOF heckTable fn ispell

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2194,8 +2194,8 @@ passed in using the ``flow style'' notation.
 A list of translation modes that should be used for this test. If not
 defined defaults to 0. Valid mode values are @samp{noContractions},
 @samp{compbrlAtCursor}, @samp{dotsIO}, @samp{comp8Dots},
-@samp{pass1Only}, @samp{compbrlLeftCursor}, @samp{otherTrans}or
-@samp{ucBrl}.
+@samp{pass1Only}, @samp{compbrlLeftCursor}, @samp{otherTrans},
+@samp{ucBrl} or @samp{noUndefinedDots}.
 @end table
 
 @end table
@@ -2601,6 +2601,12 @@ spacing between the input and output strings. The @code{typeform} and
 @code{spacing} parameters may be @code{NULL} if this information is
 not needed. @code{mode} again specifies how the back-translation
 should be done.
+
+The additional @code{noUndefinedDots} mode only applies to
+back-translation. By default, if a dot pattern in the input is
+undefined, the dot numbers will be included in the output. If this mode
+is set, this does not occur; an undefined dot pattern simply produces no
+output.
 
 @node lou_backTranslate
 @section lou_backTranslate
@@ -3056,6 +3062,6 @@ directory. Usage information is included in the Python module itself.
 @c  LocalWords:  abrege decrement pre cornf comf scano cornm cornp po
 @c  LocalWords:  h's brl testtrans UCS asis libyaml doctests url yaml
 @c  LocalWords:  testmode iftex unicode ueb xfail eo noContractions
-@c  LocalWords:  dotsIO otherTrans ucBrl abc doctest inString enum cp
-@c  LocalWords:  outbufbuf logcallback fprint lbu EOF checkTable fn
-@c  LocalWords:  ispell
+@c  LocalWords:  dotsIO otherTrans ucBrl noUndefinedDots abc doctest
+@c  LocalWords:  inString enum cp outbufbuf logcallback fprint lbu EOF
+@c  LocalWords:  checkTable fn ispell

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -77,7 +77,8 @@ typedef enum {
   pass1Only = 16,
   compbrlLeftCursor = 32,
   otherTrans = 64,
-  ucBrl = 128
+  ucBrl = 128,
+  noUndefinedDots = 256
 } translationModes;
 
 char *EXPORT_CALL lou_version();

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -78,7 +78,8 @@ typedef enum {
   compbrlLeftCursor = 32,
   otherTrans = 64,
   ucBrl = 128,
-  noUndefinedDots = 256
+  noUndefinedDots = 256,
+  partialTrans = 512
 } translationModes;
 
 char *EXPORT_CALL lou_version();

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -896,7 +896,9 @@ back_updatePositions (const widechar * outChars, int inLength, int outLength)
 static int
 undefinedDots (widechar dots)
 {
-/*Print out dot numbers */
+  if (mode & noUndefinedDots)
+    return 1;
+  /*Print out dot numbers */
   widechar buffer[20];
   int k = 1;
   buffer[0] = '\\';

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -440,7 +440,9 @@ isBegWord ()
 static int
 isEndWord ()
 {
-/*See if this is really the end of a word. */
+  if (mode & partialTrans)
+    return 0;
+  /*See if this is really the end of a word. */
   int k;
   const TranslationTableCharacter *dots;
   TranslationTableOffset testRuleOffset;
@@ -700,6 +702,8 @@ back_selectRule ()
 		    case CTO_LargeSign:
 		      return;
 		    case CTO_WholeWord:
+		      if (mode & partialTrans)
+			break;
 		      if (itsALetter || itsANumber)
 			break;
 		    case CTO_Contraction:
@@ -708,6 +712,8 @@ back_selectRule ()
 			return;
 		      break;
 		    case CTO_LowWord:
+		      if (mode & partialTrans)
+			break;
 		      if ((beforeAttributes & CTC_Space) && (afterAttributes
 							     & CTC_Space) &&
 			  (previousOpcode != CTO_JoinableWord))
@@ -717,7 +723,7 @@ back_selectRule ()
 		    case CTO_JoinableWord:
 		      if ((beforeAttributes & (CTC_Space |
 					       CTC_Punctuation))
-			  && !((afterAttributes & CTC_Space)))
+			  && (!(afterAttributes & CTC_Space) || mode & partialTrans))
 			return;
 		      break;
 		    case CTO_SuffixableWord:

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -344,6 +344,7 @@ pass1Only = 16
 compbrlLeftCursor = 32
 otherTrans = 64
 ucBrl = 128
+noUndefinedDots = 256
 #}
 
 if __name__ == '__main__':

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -345,6 +345,7 @@ compbrlLeftCursor = 32
 otherTrans = 64
 ucBrl = 128
 noUndefinedDots = 256
+partialTrans = 512
 #}
 
 if __name__ == '__main__':

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ LDADD =							\
 
 backtranslate_SOURCES = backtranslate.c
 backtranslate_noUndefinedDots_SOURCES = backtranslate_noUndefinedDots.c
+backtranslate_partialTrans_SOURCES = backtranslate_noUndefinedDots.c
 backtranslate_with_letsign_SOURCES = backtranslate_with_letsign.c
 capitalization_SOURCES = capitalization.c
 capitalized_word_SOURCES = default_table.h capitalized_word.c
@@ -73,6 +74,7 @@ program_TESTS =					\
 	hyphenate_xxx				\
 	backtranslate_with_letsign		\
 	backtranslate_noUndefinedDots	\
+	backtranslate_partialTrans	\
 	backtranslate				\
 	pass1Only				\
 	outpos					\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,7 @@ LDADD =							\
 	$(LTLIBINTL)
 
 backtranslate_SOURCES = backtranslate.c
+backtranslate_noUndefinedDots_SOURCES = backtranslate_noUndefinedDots.c
 backtranslate_with_letsign_SOURCES = backtranslate_with_letsign.c
 capitalization_SOURCES = capitalization.c
 capitalized_word_SOURCES = default_table.h capitalized_word.c
@@ -71,6 +72,7 @@ program_TESTS =					\
 	hyphenate_straightforward		\
 	hyphenate_xxx				\
 	backtranslate_with_letsign		\
+	backtranslate_noUndefinedDots	\
 	backtranslate				\
 	pass1Only				\
 	outpos					\

--- a/tests/backtranslate_noUndefinedDots.c
+++ b/tests/backtranslate_noUndefinedDots.c
@@ -1,0 +1,27 @@
+/* liblouis Braille Translation and Back-Translation Library
+
+Copyright (C) 2016 NV Access Limited
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved. This file is offered as-is,
+without any warranty. */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "liblouis.h"
+#include "brl_checks.h"
+
+#define TRANSLATION_TABLE "tables/en-ueb-g1.ctb"
+#define UNDEFINED_DOTS "_"
+
+int main(int argc, char **argv) {
+  int result = 0;
+
+  result |= check_backtranslation(TRANSLATION_TABLE, UNDEFINED_DOTS, NULL, "\\\\456/");
+  result |= check_backtranslation_with_mode(TRANSLATION_TABLE, UNDEFINED_DOTS, NULL, "", noUndefinedDots);
+
+  lou_free();
+  return result;
+}

--- a/tests/backtranslate_partialTrans.c
+++ b/tests/backtranslate_partialTrans.c
@@ -1,0 +1,43 @@
+/* liblouis Braille Translation and Back-Translation Library
+
+Copyright (C) 2016 NV Access Limited
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved. This file is offered as-is,
+without any warranty. */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "liblouis.h"
+#include "default_table.h"
+#include "brl_checks.h"
+
+typedef struct test {
+  char *input;
+  char *normalExpected;
+  char *partialExpected;
+} test_s;
+
+test_s tests[] = {
+  {"ab", "about", "ab"}, /* word */
+  {"7", "were", "("}, /* lowword */
+  {"0", "was", "by"}, /* joinword */
+  {"unnec", "unnecessary", "unnec"}, /* prfword */
+  {"abb", "a;", "abb"}, /* midword */
+  {"a4", "a.", "add"}, /* postpunc */
+  NULL
+};
+
+int main(int argc, char **argv) {
+  int result = 0;
+
+  for (int i = 0; tests[i].input; i++) {
+    result |= check_backtranslation(TRANSLATION_TABLE, tests[i].input, NULL, tests[i].normalExpected);
+    result |= check_backtranslation_with_mode(TRANSLATION_TABLE, tests[i].input, NULL, tests[i].partialExpected, partialTrans);
+  }
+
+  lou_free();
+  return result;
+}

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -230,6 +230,10 @@ read_mode (yaml_parser_t *parser) {
       mode |= otherTrans;
     } else if (!strcmp(event.data.scalar.value, "ucBrl")) {
       mode |= ucBrl;
+    } else if (!strcmp(event.data.scalar.value, "noUndefinedDots")) {
+      mode |= noUndefinedDots;
+    } else if (!strcmp(event.data.scalar.value, "partialTrans")) {
+      mode |= partialTrans;
     } else {
       error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
 		    "Mode '%s' not supported\n", event.data.scalar.value);


### PR DESCRIPTION
1. Add a noUndefinedDots mode to disable the output of dot numbers when back-translating undefined patterns.
   
   When backtranslating input from a braille keyboard cell by cell, it is desirable to output characters as soon as they are produced. Similarly, when backtranslating contracted braille, it is desirable to provide a "guess" to the user of the characters they typed. To achieve this, liblouis needs to have the ability to produce no text when indicators (which don't produce a character by themselves) are not followed by another cell. This works already for indicators liblouis knows about such as capital sign, number sign, etc., but it does not work for indicators which are not (and cannot be) specifically defined as indicators. For example, in UEB, dots 4 5 6 alone produces the text "\456/". Setting the noUndefinedDots mode suppresses this dot number output.
   
   Fixes #210.
2. Add a partialTrans mode to specify that back-translation input should be treated as an incomplete word.
   
   If this mode is set, rules that apply only for complete words or at the end of a word will not take effect. This is intended to be used when translating input typed on a braille keyboard to provide a rough idea to the user of the characters they are typing before the word is complete. For example, in UEB g2, if a user types "al", a screen reader would want to speak "a l" as the user is typing, but not "a l s o", since it's possible this is just the beginning of, say, "alive".
