### PR TITLE
Unicode braille table for back translating to unicode braille output #214

### DIFF
--- a/tables/unicode-braille.utb
+++ b/tables/unicode-braille.utb
@@ -1,0 +1,291 @@
+#
+#  Copyright (C) 2010, 2011 DocArch <http://www.docarch.be>
+#  Copyright (C) 2016 Babbage B.V. <http://www.babbage.com>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# ----------------------------------------------------------------------------------------------
+#
+# This table is based on braille-patterns.cti, which blocks back translation of unicode braille intentionally
+#
+# It can be used to back translate braille input to unicode braille output
+# ----------------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------------
+# Unicode 2800..28FF  Braille Patterns
+# ----------------------------------------------------------------------------------------------
+
+sign        \x2800  0                    # ⠀                   BRAILLE PATTERN DOTS-0
+sign        \x2801  1                    # ⠁                   BRAILLE PATTERN DOTS-1
+sign        \x2802  2                    # ⠂                   BRAILLE PATTERN DOTS-2
+sign        \x2803  12                   # ⠃                   BRAILLE PATTERN DOTS-12
+sign        \x2804  3                    # ⠄                   BRAILLE PATTERN DOTS-3
+sign        \x2805  13                   # ⠅                   BRAILLE PATTERN DOTS-13
+sign        \x2806  23                   # ⠆                   BRAILLE PATTERN DOTS-23
+sign        \x2807  123                  # ⠇                   BRAILLE PATTERN DOTS-123
+sign        \x2808  4                    # ⠈                   BRAILLE PATTERN DOTS-4
+sign        \x2809  14                   # ⠉                   BRAILLE PATTERN DOTS-14
+sign        \x280A  24                   # ⠊                   BRAILLE PATTERN DOTS-24
+sign        \x280B  124                  # ⠋                   BRAILLE PATTERN DOTS-124
+sign        \x280C  34                   # ⠌                   BRAILLE PATTERN DOTS-34
+sign        \x280D  134                  # ⠍                   BRAILLE PATTERN DOTS-134
+sign        \x280E  234                  # ⠎                   BRAILLE PATTERN DOTS-234
+sign        \x280F  1234                 # ⠏                   BRAILLE PATTERN DOTS-1234
+sign        \x2810  5                    # ⠐                   BRAILLE PATTERN DOTS-5
+sign        \x2811  15                   # ⠑                   BRAILLE PATTERN DOTS-15
+sign        \x2812  25                   # ⠒                   BRAILLE PATTERN DOTS-25
+sign        \x2813  125                  # ⠓                   BRAILLE PATTERN DOTS-125
+sign        \x2814  35                   # ⠔                   BRAILLE PATTERN DOTS-35
+sign        \x2815  135                  # ⠕                   BRAILLE PATTERN DOTS-135
+sign        \x2816  235                  # ⠖                   BRAILLE PATTERN DOTS-235
+sign        \x2817  1235                 # ⠗                   BRAILLE PATTERN DOTS-1235
+sign        \x2818  45                   # ⠘                   BRAILLE PATTERN DOTS-45
+sign        \x2819  145                  # ⠙                   BRAILLE PATTERN DOTS-145
+sign        \x281A  245                  # ⠚                   BRAILLE PATTERN DOTS-245
+sign        \x281B  1245                 # ⠛                   BRAILLE PATTERN DOTS-1245
+sign        \x281C  345                  # ⠜                   BRAILLE PATTERN DOTS-345
+sign        \x281D  1345                 # ⠝                   BRAILLE PATTERN DOTS-1345
+sign        \x281E  2345                 # ⠞                   BRAILLE PATTERN DOTS-2345
+sign        \x281F  12345                # ⠟                   BRAILLE PATTERN DOTS-12345
+sign        \x2820  6                    # ⠠                   BRAILLE PATTERN DOTS-6
+sign        \x2821  16                   # ⠡                   BRAILLE PATTERN DOTS-16
+sign        \x2822  26                   # ⠢                   BRAILLE PATTERN DOTS-26
+sign        \x2823  126                  # ⠣                   BRAILLE PATTERN DOTS-126
+sign        \x2824  36                   # ⠤                   BRAILLE PATTERN DOTS-36
+sign        \x2825  136                  # ⠥                   BRAILLE PATTERN DOTS-136
+sign        \x2826  236                  # ⠦                   BRAILLE PATTERN DOTS-236
+sign        \x2827  1236                 # ⠧                   BRAILLE PATTERN DOTS-1236
+sign        \x2828  46                   # ⠨                   BRAILLE PATTERN DOTS-46
+sign        \x2829  146                  # ⠩                   BRAILLE PATTERN DOTS-146
+sign        \x282A  246                  # ⠪                   BRAILLE PATTERN DOTS-246
+sign        \x282B  1246                 # ⠫                   BRAILLE PATTERN DOTS-1246
+sign        \x282C  346                  # ⠬                   BRAILLE PATTERN DOTS-346
+sign        \x282D  1346                 # ⠭                   BRAILLE PATTERN DOTS-1346
+sign        \x282E  2346                 # ⠮                   BRAILLE PATTERN DOTS-2346
+sign        \x282F  12346                # ⠯                   BRAILLE PATTERN DOTS-12346
+sign        \x2830  56                   # ⠰                   BRAILLE PATTERN DOTS-56
+sign        \x2831  156                  # ⠱                   BRAILLE PATTERN DOTS-156
+sign        \x2832  256                  # ⠲                   BRAILLE PATTERN DOTS-256
+sign        \x2833  1256                 # ⠳                   BRAILLE PATTERN DOTS-1256
+sign        \x2834  356                  # ⠴                   BRAILLE PATTERN DOTS-356
+sign        \x2835  1356                 # ⠵                   BRAILLE PATTERN DOTS-1356
+sign        \x2836  2356                 # ⠶                   BRAILLE PATTERN DOTS-2356
+sign        \x2837  12356                # ⠷                   BRAILLE PATTERN DOTS-12356
+sign        \x2838  456                  # ⠸                   BRAILLE PATTERN DOTS-456
+sign        \x2839  1456                 # ⠹                   BRAILLE PATTERN DOTS-1456
+sign        \x283A  2456                 # ⠺                   BRAILLE PATTERN DOTS-2456
+sign        \x283B  12456                # ⠻                   BRAILLE PATTERN DOTS-12456
+sign        \x283C  3456                 # ⠼                   BRAILLE PATTERN DOTS-3456
+sign        \x283D  13456                # ⠽                   BRAILLE PATTERN DOTS-13456
+sign        \x283E  23456                # ⠾                   BRAILLE PATTERN DOTS-23456
+sign        \x283F  123456               # ⠿                   BRAILLE PATTERN DOTS-123456
+sign        \x2840  7                    # ⡀                   BRAILLE PATTERN DOTS-7
+sign        \x2841  17                   # ⡁                   BRAILLE PATTERN DOTS-17
+sign        \x2842  27                   # ⡂                   BRAILLE PATTERN DOTS-27
+sign        \x2843  127                  # ⡃                   BRAILLE PATTERN DOTS-127
+sign        \x2844  37                   # ⡄                   BRAILLE PATTERN DOTS-37
+sign        \x2845  137                  # ⡅                   BRAILLE PATTERN DOTS-137
+sign        \x2846  237                  # ⡆                   BRAILLE PATTERN DOTS-237
+sign        \x2847  1237                 # ⡇                   BRAILLE PATTERN DOTS-1237
+sign        \x2848  47                   # ⡈                   BRAILLE PATTERN DOTS-47
+sign        \x2849  147                  # ⡉                   BRAILLE PATTERN DOTS-147
+sign        \x284A  247                  # ⡊                   BRAILLE PATTERN DOTS-247
+sign        \x284B  1247                 # ⡋                   BRAILLE PATTERN DOTS-1247
+sign        \x284C  347                  # ⡌                   BRAILLE PATTERN DOTS-347
+sign        \x284D  1347                 # ⡍                   BRAILLE PATTERN DOTS-1347
+sign        \x284E  2347                 # ⡎                   BRAILLE PATTERN DOTS-2347
+sign        \x284F  12347                # ⡏                   BRAILLE PATTERN DOTS-12347
+sign        \x2850  57                   # ⡐                   BRAILLE PATTERN DOTS-57
+sign        \x2851  157                  # ⡑                   BRAILLE PATTERN DOTS-157
+sign        \x2852  257                  # ⡒                   BRAILLE PATTERN DOTS-257
+sign        \x2853  1257                 # ⡓                   BRAILLE PATTERN DOTS-1257
+sign        \x2854  357                  # ⡔                   BRAILLE PATTERN DOTS-357
+sign        \x2855  1357                 # ⡕                   BRAILLE PATTERN DOTS-1357
+sign        \x2856  2357                 # ⡖                   BRAILLE PATTERN DOTS-2357
+sign        \x2857  12357                # ⡗                   BRAILLE PATTERN DOTS-12357
+sign        \x2858  457                  # ⡘                   BRAILLE PATTERN DOTS-457
+sign        \x2859  1457                 # ⡙                   BRAILLE PATTERN DOTS-1457
+sign        \x285A  2457                 # ⡚                   BRAILLE PATTERN DOTS-2457
+sign        \x285B  12457                # ⡛                   BRAILLE PATTERN DOTS-12457
+sign        \x285C  3457                 # ⡜                   BRAILLE PATTERN DOTS-3457
+sign        \x285D  13457                # ⡝                   BRAILLE PATTERN DOTS-13457
+sign        \x285E  23457                # ⡞                   BRAILLE PATTERN DOTS-23457
+sign        \x285F  123457               # ⡟                   BRAILLE PATTERN DOTS-123457
+sign        \x2860  67                   # ⡠                   BRAILLE PATTERN DOTS-67
+sign        \x2861  167                  # ⡡                   BRAILLE PATTERN DOTS-167
+sign        \x2862  267                  # ⡢                   BRAILLE PATTERN DOTS-267
+sign        \x2863  1267                 # ⡣                   BRAILLE PATTERN DOTS-1267
+sign        \x2864  367                  # ⡤                   BRAILLE PATTERN DOTS-367
+sign        \x2865  1367                 # ⡥                   BRAILLE PATTERN DOTS-1367
+sign        \x2866  2367                 # ⡦                   BRAILLE PATTERN DOTS-2367
+sign        \x2867  12367                # ⡧                   BRAILLE PATTERN DOTS-12367
+sign        \x2868  467                  # ⡨                   BRAILLE PATTERN DOTS-467
+sign        \x2869  1467                 # ⡩                   BRAILLE PATTERN DOTS-1467
+sign        \x286A  2467                 # ⡪                   BRAILLE PATTERN DOTS-2467
+sign        \x286B  12467                # ⡫                   BRAILLE PATTERN DOTS-12467
+sign        \x286C  3467                 # ⡬                   BRAILLE PATTERN DOTS-3467
+sign        \x286D  13467                # ⡭                   BRAILLE PATTERN DOTS-13467
+sign        \x286E  23467                # ⡮                   BRAILLE PATTERN DOTS-23467
+sign        \x286F  123467               # ⡯                   BRAILLE PATTERN DOTS-123467
+sign        \x2870  567                  # ⡰                   BRAILLE PATTERN DOTS-567
+sign        \x2871  1567                 # ⡱                   BRAILLE PATTERN DOTS-1567
+sign        \x2872  2567                 # ⡲                   BRAILLE PATTERN DOTS-2567
+sign        \x2873  12567                # ⡳                   BRAILLE PATTERN DOTS-12567
+sign        \x2874  3567                 # ⡴                   BRAILLE PATTERN DOTS-3567
+sign        \x2875  13567                # ⡵                   BRAILLE PATTERN DOTS-13567
+sign        \x2876  23567                # ⡶                   BRAILLE PATTERN DOTS-23567
+sign        \x2877  123567               # ⡷                   BRAILLE PATTERN DOTS-123567
+sign        \x2878  4567                 # ⡸                   BRAILLE PATTERN DOTS-4567
+sign        \x2879  14567                # ⡹                   BRAILLE PATTERN DOTS-14567
+sign        \x287A  24567                # ⡺                   BRAILLE PATTERN DOTS-24567
+sign        \x287B  124567               # ⡻                   BRAILLE PATTERN DOTS-124567
+sign        \x287C  34567                # ⡼                   BRAILLE PATTERN DOTS-34567
+sign        \x287D  134567               # ⡽                   BRAILLE PATTERN DOTS-134567
+sign        \x287E  234567               # ⡾                   BRAILLE PATTERN DOTS-234567
+sign        \x287F  1234567              # ⡿                   BRAILLE PATTERN DOTS-1234567
+sign        \x2880  8                    # ⢀                   BRAILLE PATTERN DOTS-8
+sign        \x2881  18                   # ⢁                   BRAILLE PATTERN DOTS-18
+sign        \x2882  28                   # ⢂                   BRAILLE PATTERN DOTS-28
+sign        \x2883  128                  # ⢃                   BRAILLE PATTERN DOTS-128
+sign        \x2884  38                   # ⢄                   BRAILLE PATTERN DOTS-38
+sign        \x2885  138                  # ⢅                   BRAILLE PATTERN DOTS-138
+sign        \x2886  238                  # ⢆                   BRAILLE PATTERN DOTS-238
+sign        \x2887  1238                 # ⢇                   BRAILLE PATTERN DOTS-1238
+sign        \x2888  48                   # ⢈                   BRAILLE PATTERN DOTS-48
+sign        \x2889  148                  # ⢉                   BRAILLE PATTERN DOTS-148
+sign        \x288A  248                  # ⢊                   BRAILLE PATTERN DOTS-248
+sign        \x288B  1248                 # ⢋                   BRAILLE PATTERN DOTS-1248
+sign        \x288C  348                  # ⢌                   BRAILLE PATTERN DOTS-348
+sign        \x288D  1348                 # ⢍                   BRAILLE PATTERN DOTS-1348
+sign        \x288E  2348                 # ⢎                   BRAILLE PATTERN DOTS-2348
+sign        \x288F  12348                # ⢏                   BRAILLE PATTERN DOTS-12348
+sign        \x2890  58                   # ⢐                   BRAILLE PATTERN DOTS-58
+sign        \x2891  158                  # ⢑                   BRAILLE PATTERN DOTS-158
+sign        \x2892  258                  # ⢒                   BRAILLE PATTERN DOTS-258
+sign        \x2893  1258                 # ⢓                   BRAILLE PATTERN DOTS-1258
+sign        \x2894  358                  # ⢔                   BRAILLE PATTERN DOTS-358
+sign        \x2895  1358                 # ⢕                   BRAILLE PATTERN DOTS-1358
+sign        \x2896  2358                 # ⢖                   BRAILLE PATTERN DOTS-2358
+sign        \x2897  12358                # ⢗                   BRAILLE PATTERN DOTS-12358
+sign        \x2898  458                  # ⢘                   BRAILLE PATTERN DOTS-458
+sign        \x2899  1458                 # ⢙                   BRAILLE PATTERN DOTS-1458
+sign        \x289A  2458                 # ⢚                   BRAILLE PATTERN DOTS-2458
+sign        \x289B  12458                # ⢛                   BRAILLE PATTERN DOTS-12458
+sign        \x289C  3458                 # ⢜                   BRAILLE PATTERN DOTS-3458
+sign        \x289D  13458                # ⢝                   BRAILLE PATTERN DOTS-13458
+sign        \x289E  23458                # ⢞                   BRAILLE PATTERN DOTS-23458
+sign        \x289F  123458               # ⢟                   BRAILLE PATTERN DOTS-123458
+sign        \x28A0  68                   # ⢠                   BRAILLE PATTERN DOTS-68
+sign        \x28A1  168                  # ⢡                   BRAILLE PATTERN DOTS-168
+sign        \x28A2  268                  # ⢢                   BRAILLE PATTERN DOTS-268
+sign        \x28A3  1268                 # ⢣                   BRAILLE PATTERN DOTS-1268
+sign        \x28A4  368                  # ⢤                   BRAILLE PATTERN DOTS-368
+sign        \x28A5  1368                 # ⢥                   BRAILLE PATTERN DOTS-1368
+sign        \x28A6  2368                 # ⢦                   BRAILLE PATTERN DOTS-2368
+sign        \x28A7  12368                # ⢧                   BRAILLE PATTERN DOTS-12368
+sign        \x28A8  468                  # ⢨                   BRAILLE PATTERN DOTS-468
+sign        \x28A9  1468                 # ⢩                   BRAILLE PATTERN DOTS-1468
+sign        \x28AA  2468                 # ⢪                   BRAILLE PATTERN DOTS-2468
+sign        \x28AB  12468                # ⢫                   BRAILLE PATTERN DOTS-12468
+sign        \x28AC  3468                 # ⢬                   BRAILLE PATTERN DOTS-3468
+sign        \x28AD  13468                # ⢭                   BRAILLE PATTERN DOTS-13468
+sign        \x28AE  23468                # ⢮                   BRAILLE PATTERN DOTS-23468
+sign        \x28AF  123468               # ⢯                   BRAILLE PATTERN DOTS-123468
+sign        \x28B0  568                  # ⢰                   BRAILLE PATTERN DOTS-568
+sign        \x28B1  1568                 # ⢱                   BRAILLE PATTERN DOTS-1568
+sign        \x28B2  2568                 # ⢲                   BRAILLE PATTERN DOTS-2568
+sign        \x28B3  12568                # ⢳                   BRAILLE PATTERN DOTS-12568
+sign        \x28B4  3568                 # ⢴                   BRAILLE PATTERN DOTS-3568
+sign        \x28B5  13568                # ⢵                   BRAILLE PATTERN DOTS-13568
+sign        \x28B6  23568                # ⢶                   BRAILLE PATTERN DOTS-23568
+sign        \x28B7  123568               # ⢷                   BRAILLE PATTERN DOTS-123568
+sign        \x28B8  4568                 # ⢸                   BRAILLE PATTERN DOTS-4568
+sign        \x28B9  14568                # ⢹                   BRAILLE PATTERN DOTS-14568
+sign        \x28BA  24568                # ⢺                   BRAILLE PATTERN DOTS-24568
+sign        \x28BB  124568               # ⢻                   BRAILLE PATTERN DOTS-124568
+sign        \x28BC  34568                # ⢼                   BRAILLE PATTERN DOTS-34568
+sign        \x28BD  134568               # ⢽                   BRAILLE PATTERN DOTS-134568
+sign        \x28BE  234568               # ⢾                   BRAILLE PATTERN DOTS-234568
+sign        \x28BF  1234568              # ⢿                   BRAILLE PATTERN DOTS-1234568
+sign        \x28C0  78                   # ⣀                   BRAILLE PATTERN DOTS-78
+sign        \x28C1  178                  # ⣁                   BRAILLE PATTERN DOTS-178
+sign        \x28C2  278                  # ⣂                   BRAILLE PATTERN DOTS-278
+sign        \x28C3  1278                 # ⣃                   BRAILLE PATTERN DOTS-1278
+sign        \x28C4  378                  # ⣄                   BRAILLE PATTERN DOTS-378
+sign        \x28C5  1378                 # ⣅                   BRAILLE PATTERN DOTS-1378
+sign        \x28C6  2378                 # ⣆                   BRAILLE PATTERN DOTS-2378
+sign        \x28C7  12378                # ⣇                   BRAILLE PATTERN DOTS-12378
+sign        \x28C8  478                  # ⣈                   BRAILLE PATTERN DOTS-478
+sign        \x28C9  1478                 # ⣉                   BRAILLE PATTERN DOTS-1478
+sign        \x28CA  2478                 # ⣊                   BRAILLE PATTERN DOTS-2478
+sign        \x28CB  12478                # ⣋                   BRAILLE PATTERN DOTS-12478
+sign        \x28CC  3478                 # ⣌                   BRAILLE PATTERN DOTS-3478
+sign        \x28CD  13478                # ⣍                   BRAILLE PATTERN DOTS-13478
+sign        \x28CE  23478                # ⣎                   BRAILLE PATTERN DOTS-23478
+sign        \x28CF  123478               # ⣏                   BRAILLE PATTERN DOTS-123478
+sign        \x28D0  578                  # ⣐                   BRAILLE PATTERN DOTS-578
+sign        \x28D1  1578                 # ⣑                   BRAILLE PATTERN DOTS-1578
+sign        \x28D2  2578                 # ⣒                   BRAILLE PATTERN DOTS-2578
+sign        \x28D3  12578                # ⣓                   BRAILLE PATTERN DOTS-12578
+sign        \x28D4  3578                 # ⣔                   BRAILLE PATTERN DOTS-3578
+sign        \x28D5  13578                # ⣕                   BRAILLE PATTERN DOTS-13578
+sign        \x28D6  23578                # ⣖                   BRAILLE PATTERN DOTS-23578
+sign        \x28D7  123578               # ⣗                   BRAILLE PATTERN DOTS-123578
+sign        \x28D8  4578                 # ⣘                   BRAILLE PATTERN DOTS-4578
+sign        \x28D9  14578                # ⣙                   BRAILLE PATTERN DOTS-14578
+sign        \x28DA  24578                # ⣚                   BRAILLE PATTERN DOTS-24578
+sign        \x28DB  124578               # ⣛                   BRAILLE PATTERN DOTS-124578
+sign        \x28DC  34578                # ⣜                   BRAILLE PATTERN DOTS-34578
+sign        \x28DD  134578               # ⣝                   BRAILLE PATTERN DOTS-134578
+sign        \x28DE  234578               # ⣞                   BRAILLE PATTERN DOTS-234578
+sign        \x28DF  1234578              # ⣟                   BRAILLE PATTERN DOTS-1234578
+sign        \x28E0  678                  # ⣠                   BRAILLE PATTERN DOTS-678
+sign        \x28E1  1678                 # ⣡                   BRAILLE PATTERN DOTS-1678
+sign        \x28E2  2678                 # ⣢                   BRAILLE PATTERN DOTS-2678
+sign        \x28E3  12678                # ⣣                   BRAILLE PATTERN DOTS-12678
+sign        \x28E4  3678                 # ⣤                   BRAILLE PATTERN DOTS-3678
+sign        \x28E5  13678                # ⣥                   BRAILLE PATTERN DOTS-13678
+sign        \x28E6  23678                # ⣦                   BRAILLE PATTERN DOTS-23678
+sign        \x28E7  123678               # ⣧                   BRAILLE PATTERN DOTS-123678
+sign        \x28E8  4678                 # ⣨                   BRAILLE PATTERN DOTS-4678
+sign        \x28E9  14678                # ⣩                   BRAILLE PATTERN DOTS-14678
+sign        \x28EA  24678                # ⣪                   BRAILLE PATTERN DOTS-24678
+sign        \x28EB  124678               # ⣫                   BRAILLE PATTERN DOTS-124678
+sign        \x28EC  34678                # ⣬                   BRAILLE PATTERN DOTS-34678
+sign        \x28ED  134678               # ⣭                   BRAILLE PATTERN DOTS-134678
+sign        \x28EE  234678               # ⣮                   BRAILLE PATTERN DOTS-234678
+sign        \x28EF  1234678              # ⣯                   BRAILLE PATTERN DOTS-1234678
+sign        \x28F0  5678                 # ⣰                   BRAILLE PATTERN DOTS-5678
+sign        \x28F1  15678                # ⣱                   BRAILLE PATTERN DOTS-15678
+sign        \x28F2  25678                # ⣲                   BRAILLE PATTERN DOTS-25678
+sign        \x28F3  125678               # ⣳                   BRAILLE PATTERN DOTS-125678
+sign        \x28F4  35678                # ⣴                   BRAILLE PATTERN DOTS-35678
+sign        \x28F5  135678               # ⣵                   BRAILLE PATTERN DOTS-135678
+sign        \x28F6  235678               # ⣶                   BRAILLE PATTERN DOTS-235678
+sign        \x28F7  1235678              # ⣷                   BRAILLE PATTERN DOTS-1235678
+sign        \x28F8  45678                # ⣸                   BRAILLE PATTERN DOTS-45678
+sign        \x28F9  145678               # ⣹                   BRAILLE PATTERN DOTS-145678
+sign        \x28FA  245678               # ⣺                   BRAILLE PATTERN DOTS-245678
+sign        \x28FB  1245678              # ⣻                   BRAILLE PATTERN DOTS-1245678
+sign        \x28FC  345678               # ⣼                   BRAILLE PATTERN DOTS-345678
+sign        \x28FD  1345678              # ⣽                   BRAILLE PATTERN DOTS-1345678
+sign        \x28FE  2345678              # ⣾                   BRAILLE PATTERN DOTS-2345678
+sign        \x28FF  12345678             # ⣿                   BRAILLE PATTERN DOTS-12345678
+
+
+# ----------------------------------------------------------------------------------------------
+


### PR DESCRIPTION
As proposed in #214, added a new unicode braille table based on braille-patterns.cti. This adds the possibility to back translate braille input to unicode braille output. Implements #214
