### PR TITLE
Fix for stackoverflow crashes on applications with smaller stack size

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3778,6 +3778,7 @@ compileRule (FileInfo * nested)
   TranslationTableCharacterAttributes after = 0;
   TranslationTableCharacterAttributes before = 0;
 	TranslationTableCharacter *c = NULL;
+  widechar *patterns = NULL;
   int k, i;
 
   noback = nofor = 0;
@@ -3820,11 +3821,15 @@ doOpcode:
 		case CTO_Match:
 		{
 			CharsString ptn_before, ptn_after;
-			widechar patterns[27720];
 			TranslationTableOffset offset;
 			int len, mrk;
 
-				memset(patterns, 0xffff, sizeof(patterns));
+			size_t patternsByteSize = sizeof(*patterns) * 27720;
+			patterns = (widechar*) malloc(patternsByteSize);
+			if(!patterns)
+				outOfMemory();
+			memset(patterns, 0xffff, patternsByteSize);
+
 			noback = 1;
 			getCharacters(nested, &ptn_before);
 			getRuleCharsText(nested, &ruleChars);
@@ -3877,11 +3882,15 @@ doOpcode:
 		case CTO_BackMatch:
 		{
 			CharsString ptn_before, ptn_after, ptn_regex;
-			widechar patterns[27720];
 			TranslationTableOffset offset;
 			int len, mrk;
 
-			memset(patterns, 0xffff, sizeof(patterns));
+			size_t patternsByteSize = sizeof(*patterns) * 27720;
+			patterns = (widechar*) malloc(patternsByteSize);
+			if(!patterns)
+				outOfMemory();
+			memset(patterns, 0xffff, patternsByteSize);
+
 			nofor = 1;
 			getCharacters(nested, &ptn_before);
 			getRuleCharsText(nested, &ruleChars);
@@ -4762,6 +4771,10 @@ doOpcode:
       ok = 0;
       break;
     }
+
+  if (patterns != NULL)
+    free(patterns);
+  
   return ok;
 }
 


### PR DESCRIPTION
This change moves the memory allocation for the patterns variable from the stack to the heap inside the compileRule function. The patterns variable was a widechar array with size 27720 which usually takes 54KB of memory (or 108KB if UCS=4). When there's not available memory on the stack this could lead to stackoverflow crashes or accessing unmapped memory. As this variable is declared in 2 places (with different scopes) inside the function, an executable could require at least 108KB (or 216KB if USC=4) of stack memory per compileRule call.
Similarly to other places, it also adds a check which calls outOfMemory in case of not having sufficient available memory on the heap.
The fix is especially important if we consider that some applications might have smaller stack size limits and requiring large ammounts of stack size (e.g. >100KB) for a single function call can cause such crashes.