### PR TITLE
Various back translation fixes.

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -229,7 +229,6 @@ static int itsALetter = 0;
 static int itsCompbrl = 0;
 static int currentCharslen;
 static int currentDotslen;	/*length of current find string */
-static int previousSrc;
 static TranslationTableOpcode currentOpcode;
 static TranslationTableOpcode previousOpcode;
 static const TranslationTableRule *currentRule;	/*pointer to current rule in 

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -98,8 +98,9 @@ doPasses (widechar * outbuf)
 
   while (1)
     {
-      if (currentPass == lastPass)
-        currentOutput = outbuf;
+      currentOutput = (currentPass == lastPass)? outbuf:
+                      (currentInput == passbuf1)? passbuf2:
+		      passbuf1;
 
       switch (currentPass)
         {
@@ -123,7 +124,6 @@ doPasses (widechar * outbuf)
 	return 1;
 
       currentInput = currentOutput;
-      currentOutput = (currentInput == passbuf1)? passbuf2: passbuf1;
       srcmax = dest;
       currentPass -= 1;
     }

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -577,8 +577,6 @@ static int
 findAttribOrSwapRules ()
 {
   TranslationTableOffset ruleOffset;
-  if (src == previousSrc)
-    return 0;
   ruleOffset = table->attribOrSwapRules[currentPass];
   currentCharslen = 0;
   while (ruleOffset)

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -94,7 +94,6 @@ doPasses (widechar * outbuf)
     }
 
   currentPass = firstPass;
-  currentOutput = passbuf2;
 
   while (1)
     {

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -201,7 +201,7 @@ backTranslateWithTracing (const char *tableList, const widechar * inbuf,
       appliedRules = NULL;
       maxAppliedRules = 0;
     }
-  doPasses(outbuf);
+  goodTrans = doPasses(outbuf);
   if (src < *inlen)
     *inlen = srcMapping[src];
   *outlen = dest;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1462,7 +1462,7 @@ back_passDoTest ()
 		 passInstructions[passIC + 4]; k++)
 	      {
 		if (!
-		    (back_findCharOrDots (currentInput[passSrc], 1)->
+		    (back_findCharOrDots (currentInput[passSrc], m)->
 		     attributes & attributes))
 		  {
 		    itsTrue = 0;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1324,8 +1324,8 @@ back_passDoTest ()
 	  break;
 	case pass_lookback:
 	  passSrc -= passInstructions[passIC + 1];
-	  if (passSrc < -1)
-	    passSrc = -1;
+	  if (passSrc < 0)
+	    passSrc = 0;
 	  passIC += 2;
 	  break;
 	case pass_not:

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1464,7 +1464,10 @@ back_passDoTest ()
 		if (!
 		    (back_findCharOrDots (currentInput[passSrc], 1)->
 		     attributes & attributes))
-		  break;
+		  {
+		    itsTrue = 0;
+		    break;
+		  }
 		passSrc++;
 	      }
 	  passIC += 5;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1453,10 +1453,10 @@ back_passDoTest ()
 	case pass_attributes:
 	  attributes = (passInstructions[passIC + 1] << 16) |
 	    passInstructions[passIC + 2];
-	  for (k = 0; k < passInstructions[passIC + 3]; k++)
-	    itsTrue =
-	      (((back_findCharOrDots (currentInput[passSrc++], m)->
-		 attributes & attributes)) ? 1 : 0);
+	  passSrc += passInstructions[passIC + 3] - 1;
+	  itsTrue =
+	    (((back_findCharOrDots (currentInput[passSrc++], m)->
+	       attributes & attributes)) ? 1 : 0);
 	  if (itsTrue)
 	    for (k = passInstructions[passIC + 3]; k <
 		 passInstructions[passIC + 4]; k++)


### PR DESCRIPTION
- Make the pass running code much more manageable.
- _ mustn't be allowed to go below 0.
- An attribute test at the start of a string was being incorrectly resolved.
- The first character of an attribute was being tested inefficiently.
- For all but the first character of an attribute test:
   - corrections were being tested as though they were a multipass test,
   - failure was tested for but not being returned.