### PR TITLE
Fix the \v escape character

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1459,7 +1459,7 @@ parseChars (FileInfo * nested, CharsString * result, CharsString * token)
 		  ch = 9;
 		  break;
 		case 'v':
-		  ch = 22;
+		  ch = 11;
 		  break;
 		case 'w':
 		  ch = ENDSEGMENT;


### PR DESCRIPTION
It points to [U+0016](http://www.fileformat.info/info/unicode/char/0016/index.htm) but the manual suggests it should be [U+000B](http://www.fileformat.info/info/unicode/char/000b/index.htm).