### PR TITLE
lou_checkyaml.c fixes: (dm)

### DIFF
--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -565,10 +565,14 @@ main(int argc, char *argv[]) {
   int direction = 0;
   int hyphenation = 0;
 
-  file = fopen(argv[1], "rb");
-  assert(file);
-
   file_name = argv[1];
+  file = fopen(file_name, "rb");
+  if (!file)
+    {
+      fprintf(stderr, "%s: file not found: %s\n", program_name, file_name);
+      exit(3);
+    }
+
 
   char *dir_name = strdup(file_name);
   int i = strlen(dir_name);

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <string.h>
 #include "louis.h"
 #include "error.h"


### PR DESCRIPTION
Show an error, rather than crash, if the file can't be opened.
Include <unistd.h> for chdir().