### PR TITLE
Add an extended 8-dot computer braille table for U.S. English

### DIFF
--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -95,6 +95,7 @@ table_files = \
 	en-gb-g1.utb \
 	en-GB-g2.ctb \
 	en_GB.tbl \
+	en_US-comp8-ext.tbl \
 	en-in-g1.ctb \
 	en.tbl \
 	en-ueb-chardefs.uti \
@@ -104,6 +105,7 @@ table_files = \
 	en-us-brf.dis \
 	en-us-comp6.ctb \
 	en-us-comp8.ctb \
+	en-us-comp8-ext.utb \
 	en-us-compbrl.ctb \
 	en-us-g1.ctb \
 	en-us-g2.ctb \

--- a/tables/en-us-comp8-ext.utb
+++ b/tables/en-us-comp8-ext.utb
@@ -1,0 +1,570 @@
+#  Copyright (C) 2017 by Davy Kager <mail@davykager.nl>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# --------------------------------------------------------------------------
+#
+#  U.S. English 8-dot computer braille for Windows
+#
+#  Based on:
+#    * BRLTTY
+#      1) en-nabcc.ttb
+#      2) en_US.ttb
+#    * liblouis (en-us-comp8.ctb)
+#    * JAWS (US_Unicode.jtb)
+#    * Window-Eyes (US8.BWE)
+#    * SuperNova (usa.utb)
+#
+#  Goals:
+#    * Complete coverage of the characters in Windows-1252.
+#    * Definitions for other common symbols.
+#    * Unambiguous backtranslation.
+#    * Easy to adopt by users of Windows screen readers.
+#
+#  References:
+#    * North American Braille Computer Code:
+#      <http://brltty.com/doc/Manual-BRLTTY/English/BRLTTY-14.html>
+#    * Computer Braille Code, BANA, 2000:
+#      <http://brailleauthority.org/cbc/cbc2000.pdf>
+
+
+# --------------------------------------------------------------------------
+# Standard includes
+#   * ASCII letters (41-5A, 61-7A)
+#   * ASCII digits (30-39)
+#   * Braille patterns (2800-28FF)
+
+include latinLetterDef8Dots.uti
+include loweredDigits6Dots.uti
+include braille-patterns.cti
+
+# --------------------------------------------------------------------------
+# ASCII symbols (20-7F)
+#   All products have the same definitions.
+#
+# Exceptions:
+#   * LOW LINE, DELETE (5F, 7F)
+#     JAWS, Window-Eyes and SuperNova use dots 4567 for 5F.
+#     BRLTTY and liblouis use dots 456 for 5F.
+#     Literary codes tend to also use dots 456 for 5F.
+#     Use the definitions from BRLTTY and liblouis for this table.
+
+space \x0020 0 SPACE
+punctuation ! 2346 EXCLAMATION MARK
+punctuation " 5 QUOTATION MARK
+sign \x0023 3456 NUMBER SIGN
+sign $ 1246 DOLLAR SIGN
+sign % 146 PERCENT SIGN
+sign & 12346 AMPERSAND
+punctuation ' 3 APOSTROPHE
+punctuation ( 12356 LEFT PARENTHESIS
+punctuation ) 23456 RIGHT PARENTHESIS
+sign * 16 ASTERISK
+sign + 346 PLUS SIGN
+punctuation , 6 COMMA
+sign - 36 HYPHEN-MINUS
+punctuation . 46 FULL STOP
+sign / 34 SOLIDUS
+# ... DIGIT ZERO-NINE (30-39)
+punctuation : 156 COLON
+punctuation ; 56 SEMICOLON
+sign < 126 LESS-THAN SIGN
+sign = 123456 EQUALS SIGN
+sign > 345 GREATER-THAN SIGN
+punctuation ? 1456 QUESTION MARK
+sign @ 47 COMMERCIAL AT
+# ... LATIN CAPITAL LETTER A-Z (41-5A)
+sign [ 2467 LEFT SQUARE BRACKET
+sign \\ 12567 REVERSE SOLIDUS
+sign ] 124567 RIGHT SQUARE BRACKET
+sign ^ 457 CIRCUMFLEX ACCENT
+sign _ 456 LOW LINE
+sign ` 4 GRAVE ACCENT
+# ... LATIN SMALL LETTER A-Z (61-7A)
+sign { 246 LEFT CURLY BRACKET
+sign | 1256 VERTICAL LINE
+sign } 12456 RIGHT CURLY BRACKET
+sign ~ 45 TILDE
+letter \x007F 4567 DELETE
+
+# --------------------------------------------------------------------------
+# ASCII control characters (00-1F)
+#   BRLTTY, JAWS and Window-Eyes use letters and symbols with dots 78.
+#   SuperNova uses abbreviations, e.g. FF is Form Feed.
+#   liblouis does not have all definitions.
+#
+# Use the definitions from BRLTTY, JAWS and Window-Eyes for this table,
+# but not for backtranslation.
+# Exceptions:
+#   * CHARACTER TABULATION, LINE FEED (LF), CARRIAGE RETURN (CR)
+#       (09, 0A, 0D)
+#     BRLTTY, JAWS and Window-Eyes use letters with dots 78.
+#     liblouis uses no dots, dots 78 and no dots, respectively,
+#     which improves readability.
+#     Use the definitions from liblouis for this table.
+
+noback letter \x0000 478 NULL
+noback letter \x0001 178 START OF HEADING
+noback letter \x0002 1278 START OF TEXT
+noback letter \x0003 1478 END OF TEXT
+noback letter \x0004 14578 END OF TRANSMISSION
+noback letter \x0005 1578 ENQUIRY
+noback letter \x0006 12478 ACKNOWLEDGE
+noback letter \x0007 124578 BELL
+noback letter \x0008 12578 BACKSPACE
+noback space \x0009 0 CHARACTER TABULATION
+noback space \x000A 78 LINE FEED (LF)
+noback space \x000B 1378 LINE TABULATION
+noback space \x000C 12378 FORM FEED (FF)
+noback space \x000D 0 CARRIAGE RETURN (CR)
+noback letter \x000E 134578 SHIFT OUT
+noback letter \x000F 13578 SHIFT IN
+noback letter \x0010 123478 DATA LINK ESCAPE
+noback letter \x0011 1234578 DEVICE CONTROL ONE
+noback letter \x0012 123578 DEVICE CONTROL TWO
+noback letter \x0013 23478 DEVICE CONTROL THREE
+noback letter \x0014 234578 DEVICE CONTROL FOUR
+noback letter \x0015 13678 NEGATIVE ACKNOWLEDGE
+noback letter \x0016 123678 SYNCHRONOUS IDLE
+noback letter \x0017 245678 END OF TRANSMISSION BLOCK
+noback letter \x0018 134678 CANCEL
+noback letter \x0019 1345678 END OF MEDIUM
+noback letter \x001A 135678 SUBSTITUTE
+noback letter \x001B 24678 ESCAPE
+noback letter \x001C 125678 INFORMATION SEPARATOR FOUR
+noback letter \x001D 1245678 INFORMATION SEPARATOR THREE
+noback letter \x001E 4578 INFORMATION SEPARATOR TWO
+noback letter \x001F 45678 INFORMATION SEPARATOR ONE
+
+# --------------------------------------------------------------------------
+# Extended control characters (80-9F)
+#   BRLTTY[1] uses letters and symbols with dot 8.
+#   BRLTTY[2] has different definitions.
+#   JAWS does not have all definitions.
+#   liblouis, Window-Eyes and SuperNova do not have any definitions.
+#
+#   JAWS, Window-Eyes and SuperNova use some of the BRLTTY[1] definitions
+#   for accented letters and symbols.
+#
+# Use the definitions from BRLTTY[1] for this table,
+# but not for backtranslation.
+
+noback letter \x0080 48 <control>
+noback letter \x0081 18 <control>
+noback letter \x0082 128 BREAK PERMITTED HERE
+noback letter \x0083 148 NO BREAK HERE
+noback letter \x0084 1458 <control>
+noback letter \x0085 158 NEXT LINE
+noback letter \x0086 1248 START OF SELECTED AREA
+noback letter \x0087 12458 END OF SELECTED AREA
+noback letter \x0088 1258 CHARACTER TABULATION SET
+noback letter \x0089 248 CHARACTER TABULATION WITH JUSTIFICATION
+noback letter \x008A 2458 LINE TABULATION SET
+noback letter \x008B 138 PARTIAL LINE FORWARD
+noback letter \x008C 1238 PARTIAL LINE BACKWARD
+noback letter \x008D 1348 REVERSE LINE FEED
+noback letter \x008E 13458 SINGLE SHIFT TWO
+noback letter \x008F 1358 SINGLE SHIFT THREE
+noback letter \x0090 12348 DEVICE CONTROL STRING
+noback letter \x0091 123458 PRIVATE USE ONE
+noback letter \x0092 12358 PRIVATE USE TWO
+noback letter \x0093 2348 SET TRANSMIT STATE
+noback letter \x0094 23458 CANCEL CHARACTER
+noback letter \x0095 1368 MESSAGE WAITING
+noback letter \x0096 12368 START OF GUARDED AREA
+noback letter \x0097 24568 END OF GUARDED AREA
+noback letter \x0098 13468 START OF STRING
+noback letter \x0099 134568 <control>
+noback letter \x009A 13568 SINGLE CHARACTER INTRODUCER
+noback letter \x009B 2468 CONTROL SEQUENCE INTRODUCER
+noback letter \x009C 12568 STRING TERMINATOR
+noback letter \x009D 124568 OPERATING SYSTEM COMMAND
+noback letter \x009E 458 PRIVACY MESSAGE
+noback letter \x009F 4568 APPLICATION PROGRAM COMMAND
+
+# --------------------------------------------------------------------------
+# Symbols (A0-BF)
+#   JAWS and SuperNova have similar definitions.
+#   BRLTTY[2] has many different definitions.
+#   BRLTTY[1] has different definitions that are well explained.
+#   Window-Eyes (based on descriptions) does not have all definitions.
+#   liblouis does not have any definitions.
+#
+#   JAWS and SuperNova have the same definitions, except for A0, A1.
+#   BRLTTY[2] has the same definitions,
+#   except for A4, A6-A9, AD-AF, B3-B4, B6, B8, B9, BE.
+#
+# A number of conventions can be extracted:
+#   * Inverted punctuation marks use the lowered literary form.
+#   * Currency symbols use dots 46 with combinations of dots 78.
+#   * Symbols resembling letters often use that letter,
+#     either lowered or with dot 8.
+#   * Accents use combinations of dots 456 with dot 8.
+#   * Ordinal indicators use mirrored dots for the letters hj with dot 8.
+#   * Quotation marks use dots for a more or less visual representation.
+#   * Superscript digits use the letters abc with dot 8.
+#   * Fractions use the letters uvx with dot 8.
+#
+# Use the definitions from JAWS and SuperNova for this table.
+# Exceptions:
+#   * NO-BREAK SPACE (A0)
+#     JAWS uses no dots.
+#     SuperNova uses dot 7.
+#     Use the definition from JAWS for this table.
+#   * INVERTED EXCLAMATION MARK (A1)
+#     JAWS uses dots 235, a literary exclamation mark,
+#     which is also used for DIGIT SIX (36).
+#     SuperNova uses dots 367, a lowered literary exclamation mark,
+#     which is in line with INVERTED QUESTION MARK (BF).
+#     Use the definition from SuperNova for this table.
+#   * BROKEN BAR (A6)
+#     JAWS and SuperNova use dots 158.
+#     This is a good definition for EURO SIGN (20AC).
+#     Instead, use dots 1578.
+#   * NOT SIGN (AC)
+#     JAWS and SuperNova use dots 25678.
+#     This is a good definition for LATIN CAPITAL LETTER Y WITH DIAERESIS
+#     (0178).
+#     Instead, use dots 125678, the backslash with dot 8.
+#     This leads to an exception for LATIN CAPITAL LETTER Y WITH DIAERESIS
+#     (0178).
+
+space \x00A0 0 NO-BREAK SPACE
+punctuation \x00A1 367 INVERTED EXCLAMATION MARK
+sign \x00A2 58 CENT SIGN
+sign \x00A3 467 POUND SIGN
+sign \x00A4 4678 CURRENCY SIGN
+sign \x00A5 468 YEN SIGN
+sign \x00A6 1578 BROKEN BAR
+sign \x00A7 357 SECTION SIGN
+sign \x00A8 48 DIAERESIS
+sign \x00A9 123468 COPYRIGHT SIGN
+sign \x00AA 1258 FEMININE ORDINAL INDICATOR
+punctuation \x00AB 1235678 LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+sign \x00AC 125678 NOT SIGN
+sign \x00AD 368 SOFT HYPHEN
+sign \x00AE 12358 REGISTERED SIGN
+sign \x00AF 458 MACRON
+sign \x00B0 4568 DEGREE SIGN
+math \x00B1 23578 PLUS-MINUS SIGN
+digit \x00B2 128 SUPERSCRIPT TWO
+digit \x00B3 148 SUPERSCRIPT THREE
+sign \x00B4 568 ACUTE ACCENT
+sign \x00B5 1348 MICRO SIGN
+sign \x00B6 1458 PILCROW SIGN
+punctuation \x00B7 37 MIDDLE DOT
+sign \x00B8 68 CEDILLA
+digit \x00B9 18 SUPERSCRIPT ONE
+sign \x00BA 2458 MASCULINE ORDINAL INDICATOR
+punctuation \x00BB 2345678 RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+math \x00BC 1368 VULGAR FRACTION ONE QUARTER
+math \x00BD 12368 VULGAR FRACTION ONE HALF
+math \x00BE 13468 VULGAR FRACTION THREE QUARTERS
+punctuation \x00BF 38 INVERTED QUESTION MARK
+
+# --------------------------------------------------------------------------
+# Accented letters and symbols (C0-FF)
+#   BRLTTY[2], JAWS, Window-Eyes and SuperNova have similar definitions.
+#   BRLTTY[1] has different definitions that is well explained.
+#   liblouis does not have any definitions.
+#
+#   JAWS and SuperNova have the same definitions,
+#   except for C1, CD, D3, D8, DA, DD, F2, FD.
+#   Window-Eyes (based on descriptions) has the same definitions
+#   for E0-FF, except for E6, F4, F6,
+#   has no definitions for E3, EC, F0, F5, F8, FC, FD,
+#   and has many missing definitions for C0-DF.
+#   BRLTTY[2] has the same definitions for E0-FF,
+#   except for E3, F0, F2, F5, F8, FD-FF,
+#   and has many different definitions for C0-DF.
+#
+# Two number of conventions can be extracted for small letters:
+#   1) Letters with acute, diaeresis, grave or tilde, and eth and thorn
+#      use dot 8 but not dot 7.
+#      To transform from small to capital, lower the entire cell,
+#      discarding dot 8.
+#   2) Letters with cedilla, circumflex, ring above or stroke, and ae
+#      use dots 78.
+#      To transform from small to capital, remove dot 8.
+#
+# Use the definitions from JAWS, Window-Eyes and SuperNova for this table.
+# If they differ, follow the appropriate convention as described above.
+# Exceptions:
+#   * LATIN CAPITAL LETTER A WITH TILDE, LATIN SMALL LETTER A WITH TILDE
+#       (C3, E3)
+#     JAWS and SuperNova follow convention (2) instead of (1).
+#     This is most likely because using dots 18 (a with dot 8 for tilde)
+#     and lowering the cell yields dot 2, which is DIGIT ONE (31).
+#   * LATIN CAPITAL LETTER Y WITH ACUTE, LATIN SMALL LETTER Y WITH ACUTE
+#       (DD, FD)
+#     JAWS uses dots 1245678 for FD. This does not follow convention (1),
+#     and can thus not be transformed into uppercase.
+#     Following convention (2) also does not work,
+#     because transforming yields RIGHT SQUARE BRACKET (5D).
+#     On the other hand, this definition somewhat resembles the y (13456).
+#     SuperNova uses dots 24568 for FD. This follows convention (1),
+#     and can be transformed into uppercase.
+#     Use the definitions from SuperNova for this table.
+
+uplow \x00C0\x00E0 23678,123568 LATIN LETTER A WITH GRAVE
+uplow \x00C1\x00E1 28,168 LATIN LETTER A WITH ACUTE
+uplow \x00C2\x00E2 167,1678 LATIN LETTER A WITH CIRCUMFLEX
+uplow \x00C3\x00E3 3467,34678 LATIN LETTER A WITH TILDE
+uplow \x00C4\x00E4 567,3458 LATIN LETTER A WITH DIAERESIS
+uplow \x00C5\x00E5 34567,345678 LATIN LETTER A WITH RING ABOVE
+uplow \x00C6\x00E6 3457,34578 LATIN LETTER AE
+uplow \x00C7\x00E7 123467,1234678 LATIN LETTER C WITH CEDILLA
+uplow \x00C8\x00E8 3578,23468 LATIN LETTER E WITH GRAVE
+uplow \x00C9\x00E9 238,1268 LATIN LETTER E WITH ACUTE
+uplow \x00CA\x00EA 1267,12678 LATIN LETTER E WITH CIRCUMFLEX
+uplow \x00CB\x00EB 2358,12468 LATIN LETTER E WITH DIAERESIS
+uplow \x00CC\x00EC 57,348 LATIN LETTER I WITH GRAVE
+uplow \x00CD\x00ED 258,1468 LATIN LETTER I WITH ACUTE
+uplow \x00CE\x00EE 1467,14678 LATIN LETTER I WITH CIRCUMFLEX
+uplow \x00CF\x00EF 23568,124568 LATIN LETTER I WITH DIAERESIS
+uplow \x00D0\x00F0 3567,23458 LATIN LETTER ETH
+uplow \x00D1\x00F1 2567,13458 LATIN LETTER N WITH TILDE
+uplow \x00D2\x00F2 578,3468 LATIN LETTER O WITH GRAVE
+uplow \x00D3\x00F3 2568,14568 LATIN LETTER O WITH ACUTE
+uplow \x00D4\x00F4 14567,145678 LATIN LETTER O WITH CIRCUMFLEX
+uplow \x00D5\x00F5 267,1358 LATIN LETTER O WITH TILDE
+uplow \x00D6\x00F6 358,2468 LATIN LETTER O WITH DIAERESIS
+uplow \x00D8\x00F8 2467,24678 LATIN LETTER O WITH STROKE
+uplow \x00D9\x00F9 35678,234568 LATIN LETTER U WITH GRAVE
+uplow \x00DA\x00FA 268,1568 LATIN LETTER U WITH ACUTE
+uplow \x00DB\x00FB 1567,15678 LATIN LETTER U WITH CIRCUMFLEX
+uplow \x00DC\x00FC 2368,12568 LATIN LETTER U WITH DIAERESIS
+uplow \x00DD\x00FD 3568,24568 LATIN LETTER Y WITH ACUTE
+uplow \x00DE\x00FE 2357,12348 LATIN LETTER THORN
+lowercase \x00DF 34568 LATIN SMALL LETTER SHARP S
+lowercase \x00FF 134568 LATIN SMALL LETTER Y WITH DIAERESIS
+math \x00D7 2348 MULTIPLICATION SIGN
+math \x00F7 3478 DIVISION SIGN
+
+# --------------------------------------------------------------------------
+# Windows-1252 symbols
+#   JAWS and Window-Eyes have similar definitions.
+#   SuperNova has many different definitions.
+#   BRLTTY and liblouis do not have any definitions.
+#
+#   JAWS duplicates definitions from 00-FF,
+#   except for 0152, 0160, 0178, 0192, 2013, 2022.
+#   JAWS and Window-Eyes (based on codepoints) have the same definitions,
+#   except for 0152, 0160, 0161, 0178, 017D, 017E, 0192,
+#   2013, 2014, 2018, 201C, 2022.
+#   SuperNova does not have definitions for 017D, 017E.
+#
+# A number of conventions can be extracted:
+#   * Symbols resembling letters use that letter,
+#     either lowered or with dot 8. SuperNova uses this.
+#   * Quotation marks use dots for a more or less visual representation.
+#     SuperNova uses this.
+#   * Pretty/Smart symbols are flattened to their plain form.
+#     JAWS and Window-Eyes use this.
+#   * Bullets use the notation from UEB. JAWS uses this.
+#
+# The definitions from SuperNova have a number of advantages:
+#   * Left-pointing and right-pointing symbols are easy to identify.
+#   * Symbols resembling letters are intuitive,
+#     because the definitions include the letter.
+#   * The definitions are unambiguous and thus allow backtranslation.
+#
+# Use the definitions from SuperNova for this table.
+# Exceptions:
+#   * LATIN CAPITAL LIGATURE OE, LATIN SMALL LIGATURE OE (0152, 0153)
+#     SuperNova uses dots 13568 for 0153, the z with dot 8,
+#     and uses convention (1) for accented letters to transform to capital.
+#     Instead, use dots 234678 for 0153, the mirrored z with dots 78,
+#     and use convention (2) to transform to capital.
+#   * LATIN CAPITAL LETTER Y WITH DIAERESIS (0178)
+#     SuperNova uses dots 125678.
+#     Instead, use dots 25678, LATIN SMALL LETTER Y WITH DIAERESIS (FF)
+#     transformed to capital using convention (1) for accented letters.
+#     This leads to an exception for NOT SIGN (AC).
+#   * LATIN CAPITAL LETTER Z WITH CARON, LATIN SMALL LETTER Z WITH CARON
+#       (017D, 017E)
+#     SuperNova has no definitions.
+#     Use dots 13568 for 017E, the z with dot 8,
+#     and use convention (1) to transform to capital.
+#   * EURO SIGN (20AC)
+#     JAWS and Window-Eyes use dots 123467.
+#     SuperNova uses dots 158, the e with dot 8.
+#     This leads to an exception for BROKEN BAR (A6).
+
+uplow \x0152\x0153 23467,234678 LATIN LIGATURE OE
+uplow \x0160\x0161 23567,123458 LATIN LETTER S WITH CARON
+uppercase \x0178 25678 LATIN CAPITAL LETTER Y WITH DIAERESIS
+uplow \x017D\x017E 2678,13568 LATIN LETTER Z WITH CARON
+lowercase \x0192 1248 LATIN SMALL LETTER F WITH HOOK
+sign \x02C6 4578 MODIFIER LETTER CIRCUMFLEX ACCENT
+sign \x02DC 478 SMALL TILDE
+punctuation \x2013 3678 EN DASH
+punctuation \x2014 2578 EM DASH
+punctuation \x2018 378 LEFT SINGLE QUOTATION MARK
+punctuation \x2019 678 RIGHT SINGLE QUOTATION MARK
+punctuation \x201A 12467 SINGLE LOW-9 QUOTATION MARK
+punctuation \x201C 2378 LEFT DOUBLE QUOTATION MARK
+punctuation \x201D 5678 RIGHT DOUBLE QUOTATION MARK
+punctuation \x201E 124678 DOUBLE LOW-9 QUOTATION MARK
+sign \x2020 237 DAGGER
+sign \x2021 1238 DOUBLE DAGGER
+sign \x2022 235678 BULLET
+sign \x2026 27 HORIZONTAL ELLIPSIS
+sign \x2030 347 PER MILLE SIGN
+punctuation \x2039 1234567 SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+punctuation \x203A 1234568 SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+sign \x20AC 158 EURO SIGN
+sign \x2122 2367 TRADE MARK SIGN
+
+# --------------------------------------------------------------------------
+# Greek letters
+#   JAWS uses letters and symbols with dot 8.
+#   BRLTTY, liblouis, Window-Eyes and SuperNova have no definitions.
+#
+# Use the definitions from JAWS for this table,
+# but not for backtranslation.
+
+noback uplow \x0391\x03B1 178,18 GREEK LETTER ALPHA
+noback uplow \x0392\x03B2 1278,128 GREEK LETTER BETA
+noback uplow \x0393\x03B3 124578,12458 GREEK LETTER GAMMA
+noback uplow \x0394\x03B4 14578,1458 GREEK LETTER DELTA
+noback uplow \x0395\x03B5 1578,158 GREEK LETTER EPSILON
+noback uplow \x0396\x03B6 135678,13568 GREEK LETTER ZETA
+noback uplow \x0397\x03B7 15678,1568 GREEK LETTER ETA
+noback uplow \x0398\x03B8 145678,14568 GREEK LETTER THETA
+noback uplow \x0399\x03B9 2478,248 GREEK LETTER IOTA
+noback uplow \x039A\x03BA 1378,138 GREEK LETTER KAPPA
+noback uplow \x039B\x03BB 12378,1238 GREEK LETTER LAMDA
+noback uplow \x039C\x03BC 13478,1348 GREEK LETTER MU
+noback uplow \x039D\x03BD 134578,13458 GREEK LETTER NU
+noback uplow \x039E\x03BE 134678,13468 GREEK LETTER XI
+noback uplow \x039F\x03BF 13578,1358 GREEK LETTER OMICRON
+noback uplow \x03A0\x03C0 123478,12348 GREEK LETTER PI
+noback uplow \x03A1\x03C1 123578,12358 GREEK LETTER RHO
+noback lowercase \x03C2 2348 GREEK SMALL LETTER FINAL SIGMA
+noback uplow \x03A3\x03C3 23478,2348 GREEK LETTER SIGMA
+noback uplow \x03A4\x03C4 234578,23458 GREEK LETTER TAU
+noback uplow \x03A5\x03C5 13678,1368 GREEK LETTER UPSILON
+noback uplow \x03A6\x03C6 12478,1248 GREEK LETTER PHI
+noback uplow \x03A7\x03C7 1234678,123468 GREEK LETTER CHI
+noback uplow \x03A8\x03C8 1345678,134568 GREEK LETTER PSI
+noback uplow \x03A9\x03C9 245678,24568 GREEK LETTER OMEGA
+
+# --------------------------------------------------------------------------
+# Whitespace characters
+#   Not based on any definitions from a screen reader.
+
+space \x2000 0 EN QUAD
+space \x2001 0 EM QUAD
+space \x2002 0 EN SPACE
+space \x2003 0 EM SPACE
+space \x2004 0 THREE-PER-EM SPACE
+space \x2005 0 FOUR-PER-EM SPACE
+space \x2006 0 SIX-PER-EM SPACE
+space \x2007 0 FIGURE SPACE
+space \x2008 0 PUNCTUATION SPACE
+space \x2009 0 THIN SPACE
+space \x200A 0 HAIR SPACE
+space \x2028 0 LINE SEPARATOR
+space \x2029 0 PARAGRAPH SEPARATOR
+space \x202F 0 NARROW NO-BREAK SPACE
+space \x205F 0 MEDIUM MATHEMATICAL SPACE
+
+# --------------------------------------------------------------------------
+# Miscellaneous symbols
+#   Not based on any definitions from a screen reader.
+
+noback sign \x2010 36 HYPHEN
+noback sign \x2011 36 NON-BREAKING HYPHEN
+noback sign \x2012 36 FIGURE DASH
+noback sign \x2015 36 HORIZONTAL BAR
+noback math \x2016 1256-1256 DOUBLE VERTICAL LINE
+noback sign \x2027 36 HYPHENATION POINT
+noback punctuation \x203C 2346-2346 DOUBLE EXCLAMATION MARK
+noback math \x2044 34 FRACTION SLASH
+noback punctuation \x2047 1456-1456 DOUBLE QUESTION MARK
+noback punctuation \x2048 1456-2346 QUESTION EXCLAMATION MARK
+noback punctuation \x2049 2346-1456 EXCLAMATION QUESTION MARK
+noback sign \x204E 28 LOW ASTERISK
+noback math \x2212 36 MINUS SIGN
+noback math \x2215 34 DIVISION SLASH
+noback math \x2217 16 ASTERISK OPERATOR
+noback sign \x25CF 16 BLACK CIRCLE
+
+# --------------------------------------------------------------------------
+# Bullets
+#   This provides definitions for the Unicode equivalents
+#   of common bullet shapes from the Symbol and Wingdings fonts.
+#   As such, the definitions do not match the actual symbol descriptions.
+#   Not based on any definitions from a screen reader.
+
+noback sign \x2043 36 HYPHEN BULLET
+noback sign \x21D2 235678 RIGHTWARDS DOUBLE ARROW
+noback sign \x21E8 235678 RIGHTWARDS WHITE ARROW
+noback sign \x25A0 235678 BLACK SQUARE
+noback sign \x25E6 235678 WHITE BULLET
+noback sign \x25FE 235678 BLACK MEDIUM SMALL SQUARE
+noback sign \x2663 235678 BLACK CLUB SUIT
+noback sign \x2666 235678 BLACK DIAMOND SUIT
+noback sign \x2756 235678 BLACK DIAMOND MINUS WHITE X
+noback sign \x2714 235678 HEAVY CHECK MARK
+noback sign \x27A2 235678 THREE-D TOP-LIGHTED RIGHTWARDS ARROWHEAD
+
+# --------------------------------------------------------------------------
+# Ligatures
+#   Not based on any definitions from a screen reader.
+
+noback letter \xFB00 124-124 LATIN SMALL LIGATURE FF
+noback letter \xFB01 124-24 LATIN SMALL LIGATURE FI
+noback letter \xFB02 124-123 LATIN SMALL LIGATURE FL
+noback letter \xFB03 124-124-24 LATIN SMALL LIGATURE FFI
+noback letter \xFB04 124-124-123 LATIN SMALL LIGATURE FFL
+noback letter \xFB06 234-2345 LATIN SMALL LIGATURE ST
+
+# --------------------------------------------------------------------------
+# Formatting characters
+#   Not based on any definitions from a screen reader.
+
+replace \x200B # ZERO WIDTH SPACE
+replace \x200C # ZERO WIDTH NON-JOINER
+replace \x200D # ZERO WIDTH JOINER
+replace \x200E # LEFT-TO-RIGHT MARK
+replace \x200F # RIGHT-TO-LEFT MARK
+replace \x202A # LEFT-TO-RIGHT EMBEDDING
+replace \x202B # RIGHT-TO-LEFT EMBEDDING
+replace \x202C # POP DIRECTIONAL FORMATTING
+replace \x202D # LEFT-TO-RIGHT OVERRIDE
+replace \x202E # RIGHT-TO-LEFT OVERRIDE
+replace \x2060 # WORD JOINER
+replace \x2061 # FUNCTION APPLICATION
+replace \x2062 # INVISIBLE TIMES
+replace \x2063 # INVISIBLE SEPARATOR
+replace \x2064 # INVISIBLE PLUS
+replace \x2066 # LEFT-TO-RIGHT ISOLATE
+replace \x2067 # RIGHT-TO-LEFT ISOLATE
+replace \x2068 # FIRST STRONG ISOLATE
+replace \x2069 # POP DIRECTIONAL ISOLATE
+replace \x206A # INHIBIT SYMMETRIC SWAPPING
+replace \x206B # ACTIVATE SYMMETRIC SWAPPING
+replace \x206C # INHIBIT ARABIC FORM SHAPING
+replace \x206D # ACTIVATE ARABIC FORM SHAPING
+replace \x206E # NATIONAL DIGIT SHAPES
+replace \x206F # NOMINAL DIGIT SHAPES
+replace \xFEFF # ZERO WIDTH NO-BREAK SPACE
+replace \xFFF9 # INTERLINEAR ANNOTATION ANCHOR
+replace \xFFFA # INTERLINEAR ANNOTATION SEPARATOR
+replace \xFFFB # INTERLINEAR ANNOTATION TERMINATOR

--- a/tables/en_US-comp8-ext.tbl
+++ b/tables/en_US-comp8-ext.tbl
@@ -1,0 +1,9 @@
+#+locale:en-US
+#+type:computer
+#+contraction:no
+#+grade:0
+#+dots:8
+#+hyphenation:no
+#+direction:both
+
+include en-us-comp8-ext.utb

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -153,6 +153,8 @@ dist_yaml_TESTS =				\
 	yaml/en-ueb-g2-dictionary_harness.yaml	\
 	yaml/en-ueb-math.yaml			\
 	yaml/en-ueb-symbols_harness.yaml	\
+	yaml/en-us-comp8-ext-back_harness.yaml	\
+	yaml/en-us-comp8-ext-for_harness.yaml	\
 	yaml/en-us-g2-dictionary_harness.yaml	\
 	yaml/en-us-g2-end-emphasis_harness.yaml	\
 	yaml/eo-g1_harness.yaml			\

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -23,6 +23,8 @@ EXTRA_DIST =					\
 	en-ueb-g2-dictionary_harness.yaml	\
 	en-ueb-math.yaml			\
 	en-ueb-symbols_harness.yaml		\
+	en-us-comp8-ext-back_harness.yaml	\
+	en-us-comp8-ext-for_harness.yaml	\
 	en-us-g2-dictionary_harness.yaml	\
 	en-us-g2-end-emphasis_harness.yaml	\
 	eo-g1_harness.yaml			\

--- a/tests/yaml/en-us-comp8-ext-back_harness.yaml
+++ b/tests/yaml/en-us-comp8-ext-back_harness.yaml
@@ -1,0 +1,6 @@
+tables: [tables/unicode.dis, tables/en-us-comp8-ext.utb]
+flags: {testmode: backward}
+tests:
+  - - Ambiguous dot patterns
+    - ⠌ ⠡ ⢎ ⢗ ⢃ ⢑
+    - / * × ® ² €

--- a/tests/yaml/en-us-comp8-ext-for_harness.yaml
+++ b/tests/yaml/en-us-comp8-ext-for_harness.yaml
@@ -1,0 +1,21 @@
+tables: [tables/unicode.dis, tables/en-us-comp8-ext.utb]
+flags: {testmode: forward}
+tests:
+  - - Uppercase and lowercase
+    - Aa Ää
+    - ⡁⠁ ⡰⢜
+  - - Greek
+    - ΑΒΓ αβγ Σσς
+    - ⣁⣃⣛ ⢁⢃⢛ ⣎⢎⢎
+  - - Double punctuation marks
+    - ‼ ⁇ ⁈ ⁉
+    - ⠮⠮ ⠹⠹ ⠹⠮ ⠮⠹
+  - - Bullets
+    - • ■ ◦ ◾
+    - ⣶ ⣶ ⣶ ⣶
+  - - Ligatures
+    - diﬃcult
+    - ⠙⠊⠋⠋⠊⠉⠥⠇⠞
+  - - Formatting characters
+    - ‎left‏right
+    - ⠇⠑⠋⠞⠗⠊⠛⠓⠞


### PR DESCRIPTION
This table solves the problem that the `en-us-comp8` table only covers the ASCII characters. It is based on the most popular screen readers for Windows. While it takes inspiration from these screen readers, the intend is not to copy a single product. Rather, I tried to create a table that is familiar to Windows users.

As mentioned above there isn't really an official standard. The table file documents the design decisions and describes what other tables do. Any and all feedback is much appreciated.

From that table file:
Goals
* Complete coverage of the characters in [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252).
* Definitions for other common symbols.
* Unambiguous backtranslation.
* Easy to adopt by users of Windows screen readers.