### PR TITLE
Silence the infiniteTranslationLoop build warning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ TAGS
 /tests/hyphenate_alderen
 /tests/hyphenate_straightforward
 /tests/hyphenate_xxx
+/tests/infiniteTranslationLoop
 /tests/inpos
 /tests/inpos_compbrl
 /tests/inpos_match_replace

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -52,6 +52,7 @@ check_metadata_SOURCES = check_metadata.c
 # Note that this is not currently included in check_programs below
 # otherwise make check would never complete.
 infiniteTranslationLoop_SOURCES = infiniteTranslationLoop.c
+noinst_PROGRAMS = infiniteTranslationLoop
 
 program_TESTS =					\
 	backtranslate				\


### PR DESCRIPTION
Added infiniteTranslationLoop to noinst_PROGRAMS in tests/Makefile.am