### PR TITLE
Define the emphclass bits in liblouis.h in a better way.

### DIFF
--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -48,9 +48,9 @@ char *EXPORT_CALL lou_getProgramPath();
 
 typedef enum {
   plain_text = 0x0000,
-  italic = 0x0001,     // emph_1
-  underline = 0x0002,  // emph_2
-  bold = 0x0004,       // emph_3
+  emph_1 = 0x0001,
+  emph_2 = 0x0002,
+  emph_3 = 0x0004,
   emph_4 = 0x0008,
   emph_5 = 0x0010,
   emph_6 = 0x0020,
@@ -65,9 +65,18 @@ typedef enum {
   // used by syllable  0x4000,
   // used by syllable  0x8000
 } typeforms;
-#define comp_emph_1 italic
-#define comp_emph_2 underline
-#define comp_emph_3 bold
+
+#define italic    emph_1
+#define underline emph_2
+#define bold      emph_3
+
+#define comp_emph_1 emph_1
+#define comp_emph_2 emph_2
+#define comp_emph_3 emph_3
+
+#define EMPH_NAME_BOLD "bold"
+#define EMPH_NAME_ITALIC "italic"
+#define EMPH_NAME_UNDERLINE "underline"
 
 typedef enum {
   noContractions = 1,


### PR DESCRIPTION
The enum contains the official emph_ names.
The original constants (bold, italic, underline) are now #defines so
that code can test for their presence.
The comp_emph_1-3 #defines are based on the corresponding emph_
constants so that they can be independently removed or retained.