### PR TITLE
Move getEmphClasses() to liblouis.h (from louis.h).

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5334,7 +5334,7 @@ getLastTableList ()
 
 /* Return the emphasis classes declared in tableList. */
 char const**
-getEmphClasses(const char* tableList)
+lou_getEmphClasses(const char* tableList)
 {
   const char *names[MAX_EMPH_CLASSES + 1];
   unsigned int count = 0;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5333,16 +5333,28 @@ getLastTableList ()
 }
 
 /* Return the emphasis classes declared in tableList. */
-char **
+char const**
 getEmphClasses(const char* tableList)
 {
-  char **emphClasses = malloc(sizeof(char*) * (MAX_EMPH_CLASSES + 1));
-  int i = 0;
-  if (getTable(tableList))
-    for (; table->emphClasses[i]; i++)
-      emphClasses[i] = strdup(table->emphClasses[i]);
-  emphClasses[i] = NULL;
-  return emphClasses;
+  const char *names[MAX_EMPH_CLASSES + 1];
+  unsigned int count = 0;
+  if (!getTable(tableList)) return NULL;
+
+  while (count < MAX_EMPH_CLASSES)
+    {
+      char const* name = table->emphClasses[count];
+      if (!name) break;
+      names[count++] = name;
+    }
+  names[count++] = NULL;
+
+  {
+    unsigned int size = count * sizeof(names[0]);
+    char const* * result = malloc(size);
+    if (!result) return NULL;
+    memcpy(result, names, size);
+    return result;
+  }
 }
 
 void *EXPORT_CALL

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -202,10 +202,11 @@ formtype EXPORT_CALL lou_getTypeformForEmphClass(const char *tableList, const ch
 
 /**
  * Return the emphasis class names declared in tableList as a
- * NULL-terminated array of strings. The array is created with malloc()
- * and should be released with free(). The strings must not be released.
+ * NULL-terminated array of strings. The array is acquired with malloc()
+ * and should be released with free(). The strings must not be released,
+ * and are no longer valid after lou_free() has been called.
  */
-char const** lou_getEmphClasses(const char *tableList);
+char const**EXPORT_CALL lou_getEmphClasses(const char *tableList);
 
 /**
  * Set the path used for searching for tables and liblouisutdml files.

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -201,6 +201,13 @@ int EXPORT_CALL lou_compileString(const char *tableList, const char *inString);
 formtype EXPORT_CALL lou_getTypeformForEmphClass(const char *tableList, const char *emphClass);
 
 /**
+ * Return the emphasis class names declared in tableList as a
+ * NULL-terminated array of strings. The array is created with malloc()
+ * and should be released with free(). The strings must not be released.
+ */
+char const** getEmphClasses(const char *tableList);
+
+/**
  * Set the path used for searching for tables and liblouisutdml files.
  *
  * Overrides the installation path. */

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -205,7 +205,7 @@ formtype EXPORT_CALL lou_getTypeformForEmphClass(const char *tableList, const ch
  * NULL-terminated array of strings. The array is created with malloc()
  * and should be released with free(). The strings must not be released.
  */
-char const** getEmphClasses(const char *tableList);
+char const** lou_getEmphClasses(const char *tableList);
 
 /**
  * Set the path used for searching for tables and liblouisutdml files.

--- a/liblouis/louis.h
+++ b/liblouis/louis.h
@@ -601,11 +601,6 @@ widechar getCharFromDots(widechar d);
 void *liblouis_allocMem(AllocBuf buffer, int srcmax, int destmax);
 
 /**
- * Return the emphasis classes declared in tableList.
- */
-char **getEmphClasses(const char *tableList);
-
-/**
  * Hash function for character strings
  */
 int stringHash(const widechar *c);

--- a/tests/emphclass.c
+++ b/tests/emphclass.c
@@ -15,7 +15,7 @@ without any warranty. */
 #include "louis.h"
 #include "brl_checks.h"
 
-static char** emph_classes = NULL;
+static const char** emph_classes = NULL;
 
 static formtype *
 typeform(const char* class, const char* fromString)
@@ -69,11 +69,12 @@ main (int argc, char **argv)
 		fprintf(stderr, "%s should be valid\n", table);
 		return 1;
 	}
-	emph_classes = getEmphClasses(table);
+	emph_classes = lou_getEmphClasses(table);
 	result |= check_translation(table,
 	                            "foobar",
 	                            typeform("foo", "+++++"),
 	                            "~,foobar");
+        if (emph_classes) free(emph_classes);
 	lou_free();
 	return result;
 }

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -90,7 +90,7 @@ int translation_mode = 0;
 int errors = 0;
 int count = 0;
 
-static char** emph_classes = NULL;
+static char const** emph_classes = NULL;
 
 void
 simple_error (const char *msg, yaml_parser_t *parser, yaml_event_t *event) {
@@ -669,8 +669,6 @@ main(int argc, char *argv[]) {
 
   yaml_parser_delete(&parser);
 
-  for (int i = 0; emph_classes[i]; i++)
-    free(emph_classes[i]);
   free(emph_classes);
   lou_free();
 

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -141,7 +141,7 @@ read_tables (yaml_parser_t *parser, char *tables_list) {
     }
     yaml_event_delete(&event);
   }
-  emph_classes = getEmphClasses(tables_list); // get declared emphasis classes
+  emph_classes = lou_getEmphClasses(tables_list); // get declared emphasis classes
 }
 
 void


### PR DESCRIPTION
This allows it to be called by user applications.
It now points directly to the class names because const has been added
to protect them.