### PR TITLE
Allow to test translations with cursorPos in brl_checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ TAGS
 /tests/capitalized_word
 /tests/checkTable
 /tests/check_metadata
+/tests/compbrlAtCursor
 /tests/emphclass
 /tests/en_gb_g1_italics
 /tests/findTable

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,7 @@ backtranslate_with_letsign_SOURCES = backtranslate_with_letsign.c
 capitalization_SOURCES = capitalization.c
 capitalized_word_SOURCES = default_table.h capitalized_word.c
 checkTable_SOURCES = checkTable.c
+compbrlAtCursor_SOURCES = compbrlAtCursor.c
 emphclass_SOURCES = emphclass.c
 en_gb_g1_italics_SOURCES = en_gb_g1_italics.c
 findTable_SOURCES = findTable.c
@@ -64,6 +65,7 @@ program_TESTS =					\
 	capitalized_word			\
 	checkTable				\
 	check_metadata				\
+	compbrlAtCursor				\
 	emphclass				\
 	en_gb_g1_italics			\
 	findTable				\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -118,7 +118,8 @@ XFAIL_TESTS =					\
 	present_progressive			\
 	lastworditalafter			\
 	en_gb_g1_italics			\
-	squash_space
+	squash_space				\
+	compbrlAtCursor
 
 # en-ueb-symbols_harness.yaml defines the desired behaviour.
 # Apparently the tables aren't quite there yet.

--- a/tests/compbrlAtCursor.c
+++ b/tests/compbrlAtCursor.c
@@ -1,0 +1,38 @@
+/* liblouis Braille Translation and Back-Translation Library
+
+Copyright (C) 2017 Davy Kager
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved. This file is offered as-is,
+without any warranty. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "liblouis.h"
+#include "brl_checks.h"
+
+int
+main(int argc, char **argv)
+{
+  const char *tableList = "tables/unicode.dis,tables/en-us-comp6.ctb";
+  const char *str = "én";
+  const char *expected = "⠄⡳⠭⠴⠴⠑⠔⠄⠝";
+  int mode;
+  int cursorPos;
+  int result = 0;
+
+  mode = 0;
+  cursorPos = 0;
+  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
+  cursorPos = 1;
+  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
+  mode = compbrlAtCursor;
+  cursorPos = 0;
+  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
+  cursorPos = 1;
+  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
+
+  lou_free();
+  return result;
+}

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -192,7 +192,7 @@ int check_full(const char *tableList, const char *str,
          latter has been modified by the translation and contains some
          information about outbuf */
       if (typeform != NULL) print_typeform(typeform, inlen);
-      fprintf(stderr, "Expected: '%s' (length %d)\n", expected, expectedlen);
+      if (cursorPos != NULL) fprintf(stderr, "Cursor:   %d\n", *cursorPos);
       fprintf(stderr, "Received: '");
       print_widechars(outbuf, outlen);
       fprintf(stderr, "' (length %d)\n", outlen);
@@ -210,16 +210,16 @@ int check_full(const char *tableList, const char *str,
 #endif
 
       if (i < outlen && i < expectedlen) {
-	fprintf(stderr, "Diff: Expected '%.*s' but received '%.*s' in index %d\n",
-	        (int)expected_utf8_len, expected_utf8, (int)out_utf8_len, out_utf8, i);
+        fprintf(stderr, "Diff:     Expected '%.*s' but received '%.*s' in index %d\n",
+          (int)expected_utf8_len, expected_utf8, (int)out_utf8_len, out_utf8, i);
       } else if (i < expectedlen) {
-	fprintf(stderr,
-	        "Diff: Expected '%.*s' but received nothing in index %d\n",
-	        (int)expected_utf8_len, expected_utf8, i);
+        fprintf(stderr,
+          "Diff:     Expected '%.*s' but received nothing in index %d\n",
+          (int)expected_utf8_len, expected_utf8, i);
       } else {
-	fprintf(stderr,
-	        "Diff: Expected nothing but received '%.*s' in index %d\n",
-	        (int)out_utf8_len, out_utf8, i);
+        fprintf(stderr,
+          "Diff:     Expected nothing but received '%.*s' in index %d\n",
+          (int)out_utf8_len, out_utf8, i);
       }
       free(expected_utf8);
       free(out_utf8);

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -193,6 +193,7 @@ int check_full(const char *tableList, const char *str,
          information about outbuf */
       if (typeform != NULL) print_typeform(typeform, inlen);
       if (cursorPos != NULL) fprintf(stderr, "Cursor:   %d\n", *cursorPos);
+      fprintf(stderr, "Expected: '%s' (length %d)\n", expected, expectedlen);
       fprintf(stderr, "Received: '");
       print_widechars(outbuf, outlen);
       fprintf(stderr, "' (length %d)\n", outlen);

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -4,6 +4,7 @@ Copyright (C) 2012 James Teh <jamie@nvaccess.org>
 Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
 Copyright (C) 2015 Mike Gray <mgray@aph.org>
 Copyright (C) 2010-2016 Swiss Library for the Blind, Visually Impaired and Print Disabled
+Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
 Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright
@@ -28,29 +29,58 @@ int check_cursor_pos(const char *tableList, const char *str, const int *expected
 /* Check if a string is translated as expected. Return 0 if the
    translation is as expected and 1 otherwise. */
 int check_translation(const char *tableList, const char *str,
-		      const formtype *typeform, const char *expected);
+                      const formtype *typeform, const char *expected);
 
 /* Check if a string is translated as expected. Return 0 if the
    translation is as expected and 1 otherwise. */
 int check_translation_with_mode(const char *tableList, const char *str,
-				const formtype *typeform, const char *expected, int mode);
+                                const formtype *typeform, const char *expected,
+                                int mode);
+
+/* Check if a string is translated as expected. Return 0 if the
+   translation is as expected and 1 otherwise. */
+int check_translation_with_cursorpos(const char *tableList, const char *str,
+                                     const formtype *typeform,
+                                     const char *expected,
+                                     const int *cursorPos);
+
+/* Check if a string is translated as expected. Return 0 if the
+   translation is as expected and 1 otherwise. */
+int check_translation_full(const char *tableList, const char *str,
+                           const formtype *typeform, const char *expected,
+                           int mode, const int *cursorPos);
 
 /* Check if a string is backtranslated as expected. Return 0 if the
    backtranslation is as expected and 1 otherwise. */
 int check_backtranslation(const char *tableList, const char *str,
-		      const formtype *typeform, const char *expected);
+                          const formtype *typeform, const char *expected);
 
 /* Check if a string is backtranslated as expected. Return 0 if the
    backtranslation is as expected and 1 otherwise. */
 int check_backtranslation_with_mode(const char *tableList, const char *str,
-				const formtype *typeform, const char *expected, int mode);
+                                    const formtype *typeform,
+                                    const char *expected, int mode);
+
+/* Check if a string is backtranslated as expected. Return 0 if the
+   backtranslation is as expected and 1 otherwise. */
+int check_backtranslation_with_cursorpos(const char *tableList, const char *str,
+                                         const formtype *typeform,
+                                         const char *expected,
+                                         const int *cursorPos);
+
+/* Check if a string is backtranslated as expected. Return 0 if the
+   backtranslation is as expected and 1 otherwise. */
+int check_backtranslation_full(const char *tableList, const char *str,
+                               const formtype *typeform, const char *expected,
+                               int mode, const int *cursorPos);
 
 /* Check if a string is translated as expected for the given direction
    (0 = forward, backward otherwise). Return 0 if the translation is
    as expected and 1 otherwise. Print diagnostic output on failure if
    diagnostics is not 0. */
-int check_with_mode(const char *tableList, const char *str, const formtype *typeform,
-		    const char *expected, int mode, int direction, int diagnostics);
+int check_full(const char *tableList, const char *str,
+               const formtype *typeform, const char *expected,
+               int mode, const int *cursorPos, int direction, int diagnostics);
 
 /* Check if a string is hyphenated as expected. Return 0 if the
    hyphenation is as expected and 1 otherwise. */

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -514,8 +514,8 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
       // means that if we are testing multiple tables at the same time
       // they must have the same mapping (i.e. the emphasis classes
       // must be defined in the same order).
-      if (xfail != check_with_mode(*table, word, typeform,
-				   translation, translation_mode, direction, !xfail)) {
+      if (xfail != check_full(*table, word, typeform,
+				   translation, translation_mode, NULL, direction, !xfail)) {
 	if (description)
 	  fprintf(stderr, "%s\n", description);
 	error_at_line(0, 0, file_name, event.start_mark.line + 1,


### PR DESCRIPTION
Needs some more work, but I'm putting it up here to illustrate what I meant to do in #271.