### PR TITLE
Fix for partialTrans and noUndefinedDots undeclared identifiers on wi…

### DIFF
--- a/windows/include/liblouis.h
+++ b/windows/include/liblouis.h
@@ -81,7 +81,9 @@ typedef enum {
   pass1Only = 16,
   compbrlLeftCursor = 32,
   otherTrans = 64,
-  ucBrl = 128
+  ucBrl = 128,
+  noUndefinedDots = 256,
+  partialTrans = 512
 } translationModes;
 
 char *EXPORT_CALL lou_version();


### PR DESCRIPTION
…ndows builds

Commits 6b0ab9c5276d9a86eece8a430f9a459e033e2b39 and
56bb7170f14808ac176893274d680839a55fc6c8 added noUndefinedDots and
partialTrans translation modes on liblouis/liblouis.h.in but did not
update windows/include/liblouis.h.
It currently causes the windows build to fail with compile error C2065
(undeclared identifiers for partialTrans and noUndefinedDots). This
commit fixes the issue.