### PR TITLE
Fix for number back-translations on fr-fr-g1 and vi-g1 tables

### DIFF
--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -226,6 +226,7 @@ table_files = \
 	latinLetterDef6Dots.uti \
 	latinLetterDef8Dots.uti \
 	litdigits6Dots.uti \
+	litdigits6DotsPlusDot6.uti \
 	loweredDigits6Dots.uti \
 	loweredDigits8Dots.uti \
 	lt.ctb \

--- a/tables/fr-fr-g1.utb
+++ b/tables/fr-fr-g1.utb
@@ -72,6 +72,8 @@ sign # 3456					dièse
 # override zero
 digit 0 3456
 include digits6DotsPlusDot6.uti
+litdigit 0 3456
+include litdigits6DotsPlusDot6.uti
 
 sign \x00A8 46			diaeresis sign
 math \x00F7 6-256		divisé par

--- a/tables/litdigits6DotsPlusDot6.uti
+++ b/tables/litdigits6DotsPlusDot6.uti
@@ -1,0 +1,30 @@
+# liblouis: sub table for literary digits, 6 dots with dot 6 added
+#
+#  Copyright (C) 2017 Victor Montalvao <vsmontalvao@gmail.com>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+litdigit 0 346
+litdigit 1 16
+litdigit 2 126
+litdigit 3 146
+litdigit 4 1456
+litdigit 5 156
+litdigit 6 1246
+litdigit 7 12456
+litdigit 8 1256
+litdigit 9 246

--- a/tables/vi-g1.ctb
+++ b/tables/vi-g1.ctb
@@ -161,6 +161,8 @@ sign # 3456                                     dièse
 # override zero
 digit 0 3456
 include digits6DotsPlusDot6.uti
+litdigit 0 3456
+include litdigits6DotsPlusDot6.uti
 
 sign \x00A8 46                  diaeresis sign
 math \x00F7 6-256               divisé par

--- a/tests/yaml/fr-fr-g1_backward.yaml
+++ b/tests/yaml/fr-fr-g1_backward.yaml
@@ -1,0 +1,21 @@
+tables: [tables/unicode.dis, tables/fr-fr-g1.utb]
+flags: {testmode: backward}
+tests:
+# Backward translations
+  # Digits
+  - [⠼⠼, 0]
+  - [⠼⠡, 1]
+  - [⠼⠣, 2]
+  - [⠼⠩, 3]
+  - [⠼⠹, 4]
+  - [⠼⠱, 5]
+  - [⠼⠫, 6]
+  - [⠼⠻, 7]
+  - [⠼⠳, 8]
+  - [⠼⠪, 9]
+  - [⠼⠡⠼, 10]
+  - [⠼⠡⠡, 11]
+  - [⠼⠡⠣, 12]
+  - [⠼⠪⠪, 99]
+  - [⠼⠡⠼⠼, 100]
+  - [⠼⠡⠼⠼⠼, 1000]

--- a/tests/yaml/fr-fr-g1_harness.yaml
+++ b/tests/yaml/fr-fr-g1_harness.yaml
@@ -1,0 +1,21 @@
+tables: [tables/unicode.dis, tables/fr-fr-g1.utb]
+flags: {testmode: forward}
+tests:
+# Forward translations
+  # Digits
+  - [0, ⠼⠼]
+  - [1, ⠼⠡]
+  - [2, ⠼⠣]
+  - [3, ⠼⠩]
+  - [4, ⠼⠹]
+  - [5, ⠼⠱]
+  - [6, ⠼⠫]
+  - [7, ⠼⠻]
+  - [8, ⠼⠳]
+  - [9, ⠼⠪]
+  - [10, ⠼⠡⠼]
+  - [11, ⠼⠡⠡]
+  - [12, ⠼⠡⠣]
+  - [99, ⠼⠪⠪]
+  - [100, ⠼⠡⠼⠼]
+  - [1000, ⠼⠡⠼⠼⠼]

--- a/tests/yaml/vi-g1_backward.yaml
+++ b/tests/yaml/vi-g1_backward.yaml
@@ -1,0 +1,21 @@
+tables: [tables/unicode.dis, tables/vi-g1.ctb]
+flags: {testmode: backward}
+tests:
+# Backward translations
+  # Digits
+  - [⠼⠼, 0]
+  - [⠼⠡, 1]
+  - [⠼⠣, 2]
+  - [⠼⠩, 3]
+  - [⠼⠹, 4]
+  - [⠼⠱, 5]
+  - [⠼⠫, 6]
+  - [⠼⠻, 7]
+  - [⠼⠳, 8]
+  - [⠼⠪, 9]
+  - [⠼⠡⠼, 10]
+  - [⠼⠡⠡, 11]
+  - [⠼⠡⠣, 12]
+  - [⠼⠪⠪, 99]
+  - [⠼⠡⠼⠼, 100]
+  - [⠼⠡⠼⠼⠼, 1000]

--- a/tests/yaml/vi-g1_harness.yaml
+++ b/tests/yaml/vi-g1_harness.yaml
@@ -1,0 +1,21 @@
+tables: [tables/unicode.dis, tables/vi-g1.ctb]
+flags: {testmode: forward}
+tests:
+# Forward translations
+  # Digits
+  - [0, ⠼⠼]
+  - [1, ⠼⠡]
+  - [2, ⠼⠣]
+  - [3, ⠼⠩]
+  - [4, ⠼⠹]
+  - [5, ⠼⠱]
+  - [6, ⠼⠫]
+  - [7, ⠼⠻]
+  - [8, ⠼⠳]
+  - [9, ⠼⠪]
+  - [10, ⠼⠡⠼]
+  - [11, ⠼⠡⠡]
+  - [12, ⠼⠡⠣]
+  - [99, ⠼⠪⠪]
+  - [100, ⠼⠡⠼⠼]
+  - [1000, ⠼⠡⠼⠼⠼]


### PR DESCRIPTION
This commit adds the litdigit definition for the french and vietnamese
grade 1 tables. These tables only included the digit definition from
digits6DotsPlusDot6.uti, which would provide the correct translations only for computer braille.
Previously, back-translations for a set of cells starting with the number sign
would behave differently from the forward translations, returning
space for 0 (3456-3456) or ignoring the number sign for other digits (e.g. a with
circumflex for 3456-16 instead of 1).