### PR TITLE
Add EXPORT_CALL to lou_getEmphClasses

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5479,7 +5479,7 @@ getLastTableList ()
 }
 
 /* Return the emphasis classes declared in tableList. */
-char const**
+char const **EXPORT_CALL
 lou_getEmphClasses(const char* tableList)
 {
   const char *names[MAX_EMPH_CLASSES + 1];

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -215,7 +215,7 @@ formtype EXPORT_CALL lou_getTypeformForEmphClass(const char *tableList, const ch
  * and should be released with free(). The strings must not be released,
  * and are no longer valid after lou_free() has been called.
  */
-char const**EXPORT_CALL lou_getEmphClasses(const char *tableList);
+char const **EXPORT_CALL lou_getEmphClasses(const char *tableList);
 
 /**
  * Set the path used for searching for tables and liblouisutdml files.


### PR DESCRIPTION
When cross-compiling 3.1.0 I get the following error:

```
-*- mode: compilation; default-directory: "~/src/liblouis-mingw/" -*-
Compilation started at Mon Mar  6 16:22:22

make LDFLAGS='-avoid-version -Xcompiler -static-libgcc'
Making all in gnulib
make[1]: Entering directory '/home/eglic/src/liblouis-mingw/gnulib'
make  all-recursive
make[2]: Entering directory '/home/eglic/src/liblouis-mingw/gnulib'
make[3]: Entering directory '/home/eglic/src/liblouis-mingw/gnulib'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/home/eglic/src/liblouis-mingw/gnulib'
make[2]: Leaving directory '/home/eglic/src/liblouis-mingw/gnulib'
make[1]: Leaving directory '/home/eglic/src/liblouis-mingw/gnulib'
Making all in liblouis
make[1]: Entering directory '/home/eglic/src/liblouis-mingw/liblouis'
make  all-am
make[2]: Entering directory '/home/eglic/src/liblouis-mingw/liblouis'
/bin/bash ../libtool  --tag=CC   --mode=compile i686-w64-mingw32-gcc -DHAVE_CONFIG_H -I.  -DTABLESDIR=\""/tmp/liblouis-mingw32/share"/liblouis/tables\" -I../gnulib -I../gnulib   -g -O2 -Wl,--add-stdcall-alias -MT compileTranslationTable.lo -MD -MP -MF .deps/compileTranslationTable.Tpo -c -o compileTranslationTable.lo compileTranslationTable.c
libtool: compile:  i686-w64-mingw32-gcc -DHAVE_CONFIG_H -I. -DTABLESDIR=\"/tmp/liblouis-mingw32/share/liblouis/tables\" -I../gnulib -I../gnulib -g -O2 -Wl,--add-stdcall-alias -MT compileTranslationTable.lo -MD -MP -MF .deps/compileTranslationTable.Tpo -c compileTranslationTable.c  -DDLL_EXPORT -DPIC -o .libs/compileTranslationTable.o
compileTranslationTable.c:5483:1: error: conflicting types for ‘lou_getEmphClasses’
 lou_getEmphClasses(const char* tableList)
 ^
In file included from louis.h:40:0,
                 from compileTranslationTable.c:42:
liblouis.h:218:26: note: previous declaration of ‘lou_getEmphClasses’ was here
 char const **EXPORT_CALL lou_getEmphClasses(const char *tableList);
                          ^
Makefile:1039: recipe for target 'compileTranslationTable.lo' failed
make[2]: *** [compileTranslationTable.lo] Error 1
make[2]: Leaving directory '/home/eglic/src/liblouis-mingw/liblouis'
Makefile:920: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/eglic/src/liblouis-mingw/liblouis'
Makefile:986: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1

Compilation exited abnormally with code 2 at Mon Mar  6 16:22:23
```

This patch should fix this 