### PR TITLE
Documenting logging api deprecation, removing last internal usages

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -165,6 +165,7 @@ Programming with liblouis
 
 * Overview (library)::
 * Data structure of liblouis tables::
+* Deprecation of the logging system::
 * lou_version::
 * lou_translateString::
 * lou_translate::
@@ -2350,6 +2351,7 @@ the doctest directory in the source distribution.
 @menu
 * Overview (library)::
 * Data structure of liblouis tables::
+* Deprecation of the logging system::
 * lou_version::
 * lou_translateString::
 * lou_translate::
@@ -2506,6 +2508,24 @@ Following this is a similar array for back-translation.
 Finally is the @code{ruleArea}, an array of variable size to which
 various structures are mapped and to which almost everything else
 points.
+
+@node Deprecation of the logging system
+@section Deprecation of the logging system
+
+As of version 2.6.0 @code{lou_logFile}, @code{lou_logPrint} and
+@code{lou_logEnd} are deprecated. They are replaced by a more powerful,
+abstract API consisting of @code{lou_registerLogCallback} and
+@code{lou_setLogLevel}. 
+
+Usage of @code{lou_logFile}, @code{lou_logPrint} and @code{lou_logEnd} is
+discouraged as they may not be part of future releases. Applications using
+Liblouis should implement their own logging system.
+
+During the transitional phase, @code{lou_logPrint} is registered as default
+callback in @code{lou_registerLogCallback}. @code{lou_logPrint} is overwritten
+by the first call to @code{lou_registerLogCallback} and reattached when
+@code{NULL} is set as callback. Note that calling @code{lou_logPrint} directly
+will not cause an invokation of the registered callback.
 
 @node lou_version
 @section lou_version
@@ -2889,7 +2909,7 @@ levels. Setting the level to @code{LOG_OFF} disables logging. The
 default level is @code{LOG_INFO}.
 
 @node lou_logFile
-@section lou_logFile
+@section lou_logFile (deprecated)
 @findex lou_logFile
 
 @example
@@ -2902,6 +2922,8 @@ be printed on stderr or to use redirection, as when liblouis is used
 in a GUI application or in liblouisutdml. Any error messages generated
 will be printed to the file given in this call. The entire path name of
 the file must be given.
+
+This function is deprecated. See @ref{Deprecation of the logging system}.
 
 @node lou_logPrint
 @section lou_logPrint (deprecated)
@@ -2918,10 +2940,10 @@ libraries to print messages to the file specified by the call to
 @code{lou_logFile}. In particular, it is used by the companion
 library liblouisutdml.
 
-This function is deprecated as of version 2.6.0.
+This function is deprecated. See @ref{Deprecation of the logging system}.
 
 @node lou_logEnd
-@section lou_logEnd
+@section lou_logEnd (deprecated)
 @findex lou_logEnd
 
 @example
@@ -2930,6 +2952,8 @@ lou_logEnd ();
 
 This function is used at the end of processing a document to close the 
 log file, so that it can be read by the rest of the program.
+
+This function is deprecated. See @ref{Deprecation of the logging system}.
 
 @node lou_setDataPath
 @section lou_setDataPath

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -146,6 +146,9 @@ void EXPORT_CALL lou_logPrint(const char *format, ...);
  * Specify the name of the file to be used by lou_logPrint.
  *
  * If it is not used, this file is stderr
+ *
+ * @deprecated As of 2.6.0, applications using liblouis should
+ * implement their own logging system.
  */
 void EXPORT_CALL lou_logFile(const char *filename);
 
@@ -159,6 +162,9 @@ int EXPORT_CALL lou_readCharFromFile(const char *fileName, int *mode);
 
 /**
  * Close the log file so it can be read by other functions.
+ *
+ * @deprecated As of 2.6.0, applications using liblouis should
+ * implement their own logging system.
  */
 void EXPORT_CALL lou_logEnd();
 

--- a/tests/check_metadata.c
+++ b/tests/check_metadata.c
@@ -21,10 +21,10 @@ log_and_count_errors(logLevels level, const char *message)
     {
     case LOG_ERROR:
       errorCount++;
-      lou_logPrint("\n  ERROR >> %s\n", message);
+      printf("\n  ERROR >> %s\n", message);
       break;
     default:
-      lou_logPrint("%s", message);
+      printf("%s", message);
     }
 }
 

--- a/windows/include/liblouis.h
+++ b/windows/include/liblouis.h
@@ -151,6 +151,9 @@ void EXPORT_CALL lou_logPrint(const char *format, ...);
  * Specify the name of the file to be used by lou_logPrint.
  *
  * If it is not used, this file is stderr
+ *
+ * @deprecated As of 2.6.0, applications using liblouis should
+ * implement their own logging system.
  */
 void EXPORT_CALL lou_logFile(const char *filename);
 
@@ -164,6 +167,9 @@ int EXPORT_CALL lou_readCharFromFile(const char *fileName, int *mode);
 
 /**
  * Close the log file so it can be read by other functions.
+ *
+ * @deprecated As of 2.6.0, applications using liblouis should
+ * implement their own logging system.
  */
 void EXPORT_CALL lou_logEnd();
 


### PR DESCRIPTION
- removes all calls to the deprecated `lou_logPrint` function.
- marks `lou_logFile` and `lou_logEnd` as deprecated, because they only interact with `lou_logPrint`.
- Adds a short section to the docs explaining the api change. I have no idea if this reflects your intentions or the truth at all. There have been a lot of changes over the last years, which made understanding `git blame`s really hard.

Closes issue #233.