### PR TITLE
Eliminate MSVC warning about different const qualifiers in compileTranslationTable.c

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5498,7 +5498,9 @@ lou_getEmphClasses(const char* tableList)
     unsigned int size = count * sizeof(names[0]);
     char const* * result = malloc(size);
     if (!result) return NULL;
-    memcpy(result, names, size);
+    /* The void* cast is necessary to stop MSVC from warning about
+     * different 'const' qualifiers (C4090). */
+    memcpy((void*)result, names, size);
     return result;
   }
 }


### PR DESCRIPTION
In lou_getEmphClasses, the destination pointer past to memcpy is a const char**, meaning that the strings are constant but the array itself isn't. However, memcpy takes a void* and MSVC doesn't seem to consider the multiple levels of pointers in this case.
To get around this, just explicitly cast to a void* when passing the destination to memcpy.
This warning is currently breaking building liblouis for NVDA, since we treat all level 1 warnings as errors.