### PR TITLE
en-ueb-g2.ctb: Fix back-translation of "?" to "this".

### DIFF
--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -84,6 +84,7 @@ display " 5
 punctuation " 6-2356
 # The "?" symbol is mostly handled below,
 # but the pattern needs to be defined before prepunc and postpunc can be used.
+display ? 1456
 nofor punctuation ? 236
 nofor punctuation " 356
 nofor prepunc " 236
@@ -132,7 +133,6 @@ math = 5-2356
 display > 345
 punctuation > 4-345
 #   requires grade one indicator when by itself
-display ? 1456
 punctuation ? 56-236
 postpunc ? 236
 display @ 47

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -165,6 +165,7 @@ dist_yaml_TESTS =				\
 	yaml/en-ueb-g1_backward.yaml		\
 	yaml/en-ueb-g1_harness.yaml		\
 	yaml/en-ueb-g2_backward.yaml		\
+	yaml/en-ueb-g2_backward_no_dis.yaml	\
 	yaml/en-ueb-g2-dictionary_harness.yaml	\
 	yaml/en-ueb-math.yaml			\
 	yaml/en-ueb-symbols_harness.yaml	\

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -34,6 +34,7 @@ EXTRA_DIST =					\
 	en-ueb-g1_backward.yaml			\
 	en-ueb-g1_harness.yaml			\
 	en-ueb-g2_backward.yaml			\
+	en-ueb-g2_backward_no_dis.yaml	\
 	en-ueb-g2-dictionary_harness.yaml	\
 	en-ueb-math.yaml			\
 	en-ueb-symbols_harness.yaml		\

--- a/tests/yaml/en-ueb-g2_backward.yaml
+++ b/tests/yaml/en-ueb-g2_backward.yaml
@@ -27,3 +27,5 @@ tests:
   - [⠐⠝, name]
   - [⠰⠃, \\56/b]
   - [⠁⠰⠝, ation]
+  # #309: Ensure correct back-translation to "this".
+  - [⠹, this]

--- a/tests/yaml/en-ueb-g2_backward_no_dis.yaml
+++ b/tests/yaml/en-ueb-g2_backward_no_dis.yaml
@@ -1,0 +1,7 @@
+# Tests for en-ueb-g2.ctb back-translation with no additional display table.
+table: [tables/en-ueb-g2.ctb]
+flags: {testmode: backward}
+tests:
+  # #309: Ensure the display rule is used for "?",
+  # rather than a subsequent rule.
+  - ["?", this]


### PR DESCRIPTION
"?" was incorrectly being back-translated to "his". This occurred because the display opcode for "?" was after the punctuation opcode for "?".
Regression introduced in 5fff9d84 (#211).
Fixes #309.