### PR TITLE
tools/brl_checks.c: use correct wide char type.

### DIFF
--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -13,6 +13,7 @@ are permitted in any medium without royalty provided the copyright
 notice and this notice are preserved. This file is offered as-is,
 without any warranty. */
 
+#include <config.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
When built with --enable-ucs4, brl_checks.c was using the 16-bit
wide character functions instead of the 32-bit ones.