### PR TITLE
Python bindings: fix crossbuild.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,7 @@ AC_CONFIG_FILES([
         tests/ueb_test_data/Makefile
         tests/yaml/Makefile
 	python/Makefile
+	python/setup.py
 	python/louis/Makefile
         tools/Makefile
         tools/gnulib/Makefile

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -23,7 +23,6 @@ r"""Python bindings for liblouis
 """
 
 from distutils.core import setup
-import louis
 
 classifiers = [
     'Development Status :: 4 - Beta',
@@ -38,5 +37,5 @@ setup(name="louis",
       download_url = "http://code.google.com/p/liblouis/",
       license="LGPLv2.2",
       classifiers=classifiers,
-      version=louis.version().split(',')[0].split('-',1)[-1],
+      version='@VERSION@',
       packages=["louis"])


### PR DESCRIPTION
setup.py tries to import the louis module at build / install time.
However, this will fail if the package is being cross-built on
a host architecture other than the target architecture.
Instead, setup.py probably should be generated automatically by
autotools.