### PR TITLE
Disable tables embeded builds

### DIFF
--- a/.travis/after_success/emscripten.sh
+++ b/.travis/after_success/emscripten.sh
@@ -31,12 +31,5 @@ git tag -a ${BUILD_VERSION} -m "automatic build for version ${BUILD_VERSION}" &&
 git push git@github.com:liblouis/js-build.git master &&
 git push git@github.com:liblouis/js-build.git $BUILD_VERSION
 
-# --- push in npm registry and move the `next` tag pointing
-#     to the latest development version if necessary
-# TODO: get credentials
-# npm publish
-
-# if [ -z $TRAVIS_TAG ]
-# 	npm dist-tag v0.0.0-${BUILD_VERSION} next
-# 	npm dist-tag v0.0.0-${BUILD_VERSION} ${TRAVIS_COMMIT}
-# fi
+# --- push in npm registry
+# TODO

--- a/.travis/script/emscripten-build.sh
+++ b/.travis/script/emscripten-build.sh
@@ -10,7 +10,8 @@ emconfigure ./configure --disable-shared &&
 emmake make &&
 
 buildjs "16" "build-no-tables-utf16.js" &&
-buildjs "16" "build-tables-embeded-root-utf16.js" "--embed-files tables@/" &&
+#buildjs "16" "build-no-tables-wasm-utf16.js" "-s WASM=1" &&
+#buildjs "16" "build-tables-embeded-root-utf16.js" "--embed-files tables@/" &&
 
 echo "[liblouis-js] configuring and making UTF-32 builds..." &&
 emconfigure ./configure --enable-ucs4 --disable-shared &&
@@ -18,6 +19,7 @@ emmake make &&
 
 echo "[liblouis-js] building UTF-32 with no tables..." &&
 buildjs "32" "build-no-tables-utf32.js" &&
-buildjs "32" "build-tables-embeded-root-utf32.js" "--embed-files tables@/" &&
+#buildjs "32" "build-no-tables-wasm-utf32.js" "-s WASM=1" &&
+#buildjs "32" "build-tables-embeded-root-utf32.js" "--embed-files tables@/" &&
 
 echo "[liblouis-js] done building in docker image..."

--- a/.travis/script/emscripten.sh
+++ b/.travis/script/emscripten.sh
@@ -35,8 +35,9 @@ echo "[liblouis-js] testing builds..."
 # and tested instead.
 cd liblouis-js &&
 npm link ../../js-build --production &&
-# NOTE: we only test the build in NodeJS
-node testrunner/main.js &&
+# NOTE: we only test the build in NodeJS as the browser test environment
+# segfaults sometimes for successful builds.
+npm run test-node &&
 cd ..
 
 if [ $? != 0 ]; then


### PR DESCRIPTION
Disables the 2x 25MB builds with all table files embeded. They became virtually useless through changes in the upcoming liblouis-js version.