### PR TITLE
Update emscripten build release handling

### DIFF
--- a/.travis/after_success/emscripten.sh
+++ b/.travis/after_success/emscripten.sh
@@ -8,6 +8,11 @@ if [ -z "$BUILD_VERSION" ]; then
 	exit 0
 fi
 
+if [ "$IS_OFFICIAL_RELEASE" != true ]; then
+	echo "[liblouis-js] Is not an official release. Not publishing."
+	exit 0
+fi
+
 echo "[liblouis-js] publishing builds..."
 
 git config user.name "Travis CI" &&

--- a/.travis/after_success/emscripten.sh
+++ b/.travis/after_success/emscripten.sh
@@ -31,7 +31,17 @@ ssh-add deploy_key &&
 
 cd ../js-build &&
 git add --all &&
-git commit -m "Automatic build of version ${BUILD_VERSION}" &&
+
+if [ -z `git diff --cached --exit-code` ]; then
+	echo "[liblouis-js] Build is identical to previous build. Omitting commit, only adding tag."
+else
+	git commit -m "Automatic build of version ${BUILD_VERSION}"
+	if [ $? != 0 ]; then
+		echo "[liblouis-js] Failed to commit. Aborting."
+		exit 1
+	fi
+fi
+
 git tag -a ${BUILD_VERSION} -m "automatic build for version ${BUILD_VERSION}" &&
 git push git@github.com:liblouis/js-build.git master &&
 git push git@github.com:liblouis/js-build.git $BUILD_VERSION

--- a/.travis/before_install/emscripten.sh
+++ b/.travis/before_install/emscripten.sh
@@ -9,9 +9,14 @@ echo $TRAVIS_TAG | grep "^v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$"
 
 if [ $? -eq 1 ]; then
 	echo "[liblouis-js] tag is not valid version string."
-        export BUILD_VERSION="v0.0.0-${COMMIT_SHORT}"
+        export BUILD_VERSION="commit-{$COMMIT_SHORT}"
+	export IS_OFFICIAL_RELEASE=false
 else
-	export BUILD_VERSION=$TRAVIS_TAG
+	# NOTE: tags cannot be revoked. Only automatically publish as release
+	# candidate. A contributer should confirm the correctness of the build
+	# and rerelease unaltered binaries without the -rc suffix.
+	export BUILD_VERSION="${TRAVIS_TAG}-rc.1"
+	export IS_OFFICIAL_RELEASE=true
 fi
 
 echo "[liblouis-js] Assigned this build the version number ${BUILD_VERSION}" &&

--- a/.travis/script/emscripten-build.sh
+++ b/.travis/script/emscripten-build.sh
@@ -8,10 +8,12 @@ echo "[liblouis-js] starting build process in docker image..." &&
 echo "[liblouis-js] configuring and making UTF-16 builds..." &&
 emconfigure ./configure --disable-shared &&
 emmake make &&
+# install to obtain a table folder which does not contain build scripts
+emmake make install prefix="$(pwd)/out-emscripten-install"
 
 buildjs "16" "build-no-tables-utf16.js" &&
 #buildjs "16" "build-no-tables-wasm-utf16.js" "-s WASM=1" &&
-#buildjs "16" "build-tables-embeded-root-utf16.js" "--embed-files tables@/" &&
+#buildjs "16" "build-tables-embeded-root-utf16.js" "--embed-files ./out-emscripten-install/share/liblouis/tables@/" &&
 
 echo "[liblouis-js] configuring and making UTF-32 builds..." &&
 emconfigure ./configure --enable-ucs4 --disable-shared &&
@@ -20,6 +22,6 @@ emmake make &&
 echo "[liblouis-js] building UTF-32 with no tables..." &&
 buildjs "32" "build-no-tables-utf32.js" &&
 #buildjs "32" "build-no-tables-wasm-utf32.js" "-s WASM=1" &&
-#buildjs "32" "build-tables-embeded-root-utf32.js" "--embed-files tables@/" &&
+#buildjs "32" "build-tables-embeded-root-utf32.js" "--embed-files ./out-emscripten-install/share/liblouis/tables@/" &&
 
 echo "[liblouis-js] done building in docker image..."

--- a/.travis/script/emscripten.sh
+++ b/.travis/script/emscripten.sh
@@ -18,9 +18,15 @@ rm -rf ../js-build/tables/ &&
 cp -R ./tables/ ../js-build/tables/ &&
 cp -Rf ./out/* ../js-build/
 
-if [ -n "$BUILD_VERSION" ]; then
+if [ "$IS_OFFICIAL_RELEASE" = true ]; then
 	cd ../js-build
 	npm version --no-git-tag-version $BUILD_VERSION
+
+	if [ $? != 0 ]; then
+		echo "[liblouis-js] Failed to update npm version tag. Aborting."
+		exit 1
+	fi
+
 	cd -
 fi
 

--- a/.travis/script/emscripten.sh
+++ b/.travis/script/emscripten.sh
@@ -15,7 +15,7 @@ fi
 #     managers.
 echo "[liblouis-js] bundling files to package for publish..." &&
 rm -rf ../js-build/tables/ &&
-cp -R ./tables/ ../js-build/tables/ &&
+cp -R ./out-emscripten-install/share/liblouis/tables/ ../js-build/tables/ &&
 cp -Rf ./out/* ../js-build/
 
 if [ "$IS_OFFICIAL_RELEASE" = true ]; then


### PR DESCRIPTION
- only push to package managers if the build is an official release
- only publish automatic builds as release candidates. Devs should confirm the build and update the version tag.
- change the prefix of development versions to "commit-" instead of "v0.0.0-". (This is possible as we no longer publish development versions to package managers.)