### PR TITLE
Hot Fix + Pin liblouis-js version

### DIFF
--- a/.travis/after_success/emscripten.sh
+++ b/.travis/after_success/emscripten.sh
@@ -8,12 +8,7 @@ if [ -z "$BUILD_VERSION" ]; then
 	exit 0
 fi
 
-if [ "$IS_OFFICIAL_RELEASE" != true ]; then
-	echo "[liblouis-js] Is not an official release. Not publishing."
-	exit 0
-fi
-
-echo "[liblouis-js] publishing builds..."
+echo "[liblouis-js] publishing builds to development channel..."
 
 git config user.name "Travis CI" &&
 git config user.email "liblouis@users.noreply.github.com" &&
@@ -26,8 +21,9 @@ chmod 600 deploy_key &&
 eval `ssh-agent -s` &&
 ssh-add deploy_key &&
 
-# --- push commit and tag to repository. (This will automatically
-#     publish the package in the bower registry.)
+# --- push commit and tag to repository. (This will also automatically
+#     publish the package in the bower registry as the bower registry
+#     just fetches tags and builds from the dev channel.)
 
 cd ../js-build &&
 git add --all &&
@@ -35,7 +31,9 @@ git add --all &&
 if [ -z `git diff --cached --exit-code` ]; then
 	echo "[liblouis-js] Build is identical to previous build. Omitting commit, only adding tag."
 else
-	git commit -m "Automatic build of version ${BUILD_VERSION}"
+	git commit -m "Automatic build of version ${BUILD_VERSION}" &&
+	git push git@github.com:liblouis/js-build.git master
+
 	if [ $? != 0 ]; then
 		echo "[liblouis-js] Failed to commit. Aborting."
 		exit 1
@@ -43,8 +41,14 @@ else
 fi
 
 git tag -a ${BUILD_VERSION} -m "automatic build for version ${BUILD_VERSION}" &&
-git push git@github.com:liblouis/js-build.git master &&
 git push git@github.com:liblouis/js-build.git $BUILD_VERSION
+
+echo "[liblouis-js] publishing builds to release channel..."
+
+if [ "$IS_OFFICIAL_RELEASE" != true ]; then
+	echo "[liblouis-js] Is not an official release. Not publishing to package managers."
+	exit 0
+fi
 
 # --- push in npm registry
 # TODO

--- a/.travis/before_install/emscripten.sh
+++ b/.travis/before_install/emscripten.sh
@@ -9,7 +9,7 @@ echo $TRAVIS_TAG | grep "^v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$"
 
 if [ $? -eq 1 ]; then
 	echo "[liblouis-js] tag is not valid version string."
-	export BUILD_VERSION="commit-{$COMMIT_SHORT}"
+	export BUILD_VERSION="commit-${COMMIT_SHORT}"
 	export IS_OFFICIAL_RELEASE=false
 else
 	# NOTE: tags cannot be revoked. Only automatically publish as release

--- a/.travis/before_install/emscripten.sh
+++ b/.travis/before_install/emscripten.sh
@@ -21,9 +21,13 @@ fi
 
 echo "[liblouis-js] Assigned this build the version number ${BUILD_VERSION}" &&
 
-# --- obtain the latest version of liblouis-js
-#     contains tests and js snippets appended to builds
-git clone --depth 1 https://github.com/liblouis/liblouis-js.git &&
+# --- obtain liblouis-js. Contains tests and js snippets appended to builds.
+#     liblouis-js version should be incremented by hand, to keep the repositories
+#     in sync.
+git clone https://github.com/liblouis/liblouis-js.git &&
+cd liblouis-js &&
+git checkout 73032f867192de1c4a19b03ef5030926e0ba6d85 &&
+cd .. &&
 # --- obtain the latest version of liblouis/js-build
 #     we publish/deploy to this repository. Contains package
 #     descriptions (package.json and bower.json) and documentation


### PR DESCRIPTION
- Previous merged PR had 2 serious quality issues and should not have made it into the repo. I am sorry.
- Also pins the version of liblouis-js to a specific commit instead of master. Avoids issues we previously had with both repos being out of sync.