### PR TITLE
Fix back-translation for contractions followed by punctuation

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -647,7 +647,7 @@ back_selectRule ()
 			break;
 		    case CTO_Contraction:
 		      if ((beforeAttributes & (CTC_Space | CTC_Punctuation))
-			  && ((afterAttributes & CTC_Space) || isEndWord ()))
+			  && ((afterAttributes & (CTC_Space | CTC_Punctuation)) || isEndWord ()))
 			return;
 		      break;
 		    case CTO_LowWord:

--- a/tests/yaml/en-ueb-g1_backward.yaml
+++ b/tests/yaml/en-ueb-g1_backward.yaml
@@ -16,3 +16,9 @@ tests:
   - [⠠⠁, A]
   - [⠠⠠, ""]
   - [⠠⠠⠁⠁, AA]
+  # Backtranslations followed by punctuation
+  - [⠁⠂, "a,"]
+  - [⠃⠂, "b,"]
+  - [⠉⠂, "c,"]
+  - [⠙⠂, "d,"]
+

--- a/tests/yaml/en-ueb-g2_backward.yaml
+++ b/tests/yaml/en-ueb-g2_backward.yaml
@@ -35,3 +35,13 @@ tests:
   - [⠼⠁⠰⠠⠁, 1A]
   # #309: Ensure correct back-translation to "this".
   - [⠹, this]
+
+  # Contractions followed by punctuation
+  # 1-letter contractions
+  - [⠃⠂, "but,"]
+  - [⠉⠂, "can,"]
+  - [⠙⠂, "do,"]
+  # multi-letter contractions
+  - [⠁⠃⠂, "about,"]
+  - [⠁⠃⠧⠂, "above,"]
+


### PR DESCRIPTION
Back-translations were not detecting word contractions when followed by punctuation. Forward translations were already producing the expected result.

This commit adds a check for `CTC_Punctuation` together with `CTC_Space` when detecting contractions in `lou_backTranslateString.c`. Similar checks were already being done in other places such as in: [master/liblouis/lou_translateString.c#L2225](https://github.com/liblouis/liblouis/blob/master/liblouis/lou_translateString.c#L2225) (for forward translations).

Example: When using "en-ueb-g2.ctb", "12-2" would back-translate to "b," instead of "but,".
The issue is particularly important for the usage of other conjunctions such as "although".

Tests which verify the back-translation behavior with and without contractions are also included.