### PR TITLE
Add support for ueb shape symbols with grade 1 indicator

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -628,8 +628,8 @@ back_selectRule (void)
 		      return;
 		    case CTO_LetterRule:
 		    case CTO_NoContractRule:
-		      if (!(beforeAttributes &
-			    CTC_Letter) && (afterAttributes & CTC_Letter))
+		      if (!(beforeAttributes & (CTC_Letter | CTC_Sign))
+			    && (afterAttributes & (CTC_Letter | CTC_Sign)))
 			return;
 		      break;
 		    case CTO_MultInd:

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -3738,3 +3738,13 @@ match %[_~^]%<* unsaid ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-234-145
 
 word rared 1235-1-1235-1246
 word firedrill 124-24-1235-15-145-1235-24-123-123
+
+# Shape symbols require a grade 1 indicator (Section 3.22.1)
+contraction \x25a0 ■ filled (solid) square
+contraction \x25a1 □ square
+contraction \x25a7 ▧ shaded square (upper left to lower right)
+contraction \x25b2 ▲ filled (solid) (equilateral) triangle
+contraction \x25b3 △ regular (equilateral) triangle
+contraction \x25cb ○ circle
+contraction \x25cd ◍ shaded circle
+

--- a/tests/yaml/en-ueb-03-symbols.yaml
+++ b/tests/yaml/en-ueb-03-symbols.yaml
@@ -206,3 +206,18 @@ tests:
   - ',anne ,- village girl'
 - - Joan – 〃 〃
   - ',joan ,- "1 "1'
+
+
+# 3.22.1 page 34
+
+- - '• Vice-President Client Services'
+  - _4 ,vice-,presid5t ,cli5t ,s}vices
+- - '□ Director Library Services'
+  - ;$#d ,director ,libr>y ,s}vices
+- - '○ Manager Braille Production'
+  - ;$= ,manag} ,brl ,produc;n
+- - '○ Manager Audio Production'
+  - ;$= ,manag} ,audio ,produc;n
+- - '□ Director Rehabilitation Services'
+  - ;$#d ,director ,rehabilita;n ,s}vices
+


### PR DESCRIPTION
Based on the Section 3.22 (Shapes page 34) from [http://www.iceb.org/Rules%20of%20Unified%20English%20Braille%202013.pdf](http://www.iceb.org/Rules%20of%20Unified%20English%20Braille%202013.pdf), shape symbols when represented on ueb-g2 should require a grade 1 indicator before the symbol. This is also shown in the Examples section just below.

My goal here is to make signs also be available to take a grade 1 indicator in some way.
One alternative (in the code below) is to use a contraction opcode for forward translations and add CTC_Sign to be considered when checking a CTO_NoContractRule for back-translations.

That said, I do understand that semantically I just want to indicate that it should have a grade-1 sign and not that it is a contraction when using a grade-2 table.
I'd like to get some feedback on if that's acceptable or if we could find a more elegant approach based on what we have currently.