### PR TITLE
Revert "Fix back-translation for contractions followed by punctuation"

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -647,7 +647,7 @@ back_selectRule ()
 			break;
 		    case CTO_Contraction:
 		      if ((beforeAttributes & (CTC_Space | CTC_Punctuation))
-			  && ((afterAttributes & (CTC_Space | CTC_Punctuation)) || isEndWord ()))
+			  && ((afterAttributes & CTC_Space) || isEndWord ()))
 			return;
 		      break;
 		    case CTO_LowWord:

--- a/tests/yaml/en-ueb-g1_backward.yaml
+++ b/tests/yaml/en-ueb-g1_backward.yaml
@@ -16,9 +16,3 @@ tests:
   - [⠠⠁, A]
   - [⠠⠠, ""]
   - [⠠⠠⠁⠁, AA]
-  # Backtranslations followed by punctuation
-  - [⠁⠂, "a,"]
-  - [⠃⠂, "b,"]
-  - [⠉⠂, "c,"]
-  - [⠙⠂, "d,"]
-

--- a/tests/yaml/en-ueb-g2_backward.yaml
+++ b/tests/yaml/en-ueb-g2_backward.yaml
@@ -35,13 +35,3 @@ tests:
   - [⠼⠁⠰⠠⠁, 1A]
   # #309: Ensure correct back-translation to "this".
   - [⠹, this]
-
-  # Contractions followed by punctuation
-  # 1-letter contractions
-  - [⠃⠂, "but,"]
-  - [⠉⠂, "can,"]
-  - [⠙⠂, "do,"]
-  # multi-letter contractions
-  - [⠁⠃⠂, "about,"]
-  - [⠁⠃⠧⠂, "above,"]
-


### PR DESCRIPTION
Reverts liblouis/liblouis#347

I just noticed an unexpected interaction in relation to this merge. It affects particularly back-translations for ueb grade-2 words with "ea" after letters that have contractions associated, such as words like meat(134-2-2345), head(125-2-145) and others.
With this, back-translating meat would detect that 'm' is a CTO_Contraction and then consider that the dot-2 right after is a CTC_Punctuation and CTC_Sign (',') and then return right there with a contraction for 'm' (more) before checking that the following letter can also be back-translated to letters instead of punctuation. The end result for both of these cases would be "moreeat" and "haveead" instead of "meat" and "head".
I checked that adding sufword opcode for these words would fix the issue (e.g. sufword meat 134-2-2345) but I'm afraid the problem might be much more general that adding particular cases like that would not be enough.
We might consider reverting this merge for now until we find a more general solution.

Thanks,
Victor
