### PR TITLE
UEB grade 2: Fix back-translation of whole word contractions followed by other contractions.

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3406,8 +3406,6 @@ compileUplow (FileInfo * nested,
       {
 	attr = CTC_Letter | CTC_UpperCase;
 	upperCell = addCharOrDots (nested, upperDots.chars[k], 1);
-	if (upperDots.length != 1)
-	  attr = CTC_Space;
 	upperCell->attributes |= attr;
 	upperCell->uppercase = upperCell->realchar;
       }

--- a/tests/yaml/en-ueb-g2_backward.yaml
+++ b/tests/yaml/en-ueb-g2_backward.yaml
@@ -51,3 +51,20 @@ tests:
   # See https://github.com/liblouis/liblouis/pull/350
   - [⠍⠂⠞, "meat"]
   - [⠓⠂⠙, "head"]
+
+  # #364: Whole word contractions followed by other contractions.
+  # In this case, the whole word contraction should not apply.
+  - [⠁⠇⠐⠕, alone]
+  - [⠃⠜, bar]
+  - [⠃⠢, ben]
+  - [⠠⠃⠢, Ben]
+  - [⠙⠨⠑, dance]
+  - [⠋⠰⠑, fence]
+  - [⠓⠻, her]
+  - [⠎⠯, sand]
+  - [⠎⠔, sin]
+  - [⠎⠬, sing]
+  - [⠠⠎⠬, Sing]
+  - [⠎⠷, sof]
+  - [⠎⠰⠛, song]
+  - [⠹⠬, thing]


### PR DESCRIPTION
For example, the dot pattern for "thing" (⠹⠬) was previously being back-translated as "thising".
This occurred because certain uplow opcodes included cells such as ⠬ in a multi-cell pattern and the table compiler was setting a space attribute for any cells in a multi-cell uplow opcode. I don't know why (and the code pre-dates version control), but I can't think of a good reason and removing this doesn't break any tests.