### PR TITLE
UEB g2: Fix back-translation for contractions followed by punctuation.

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -357,7 +357,13 @@ isEndWord (void)
 	{
 	  testRule =
 	    (TranslationTableRule *) & table->ruleArea[testRuleOffset];
-	  if (testRule->charslen > 1)
+	  /* #360: Don't treat begword/midword as definite translations here
+	   * because we don't know whether they apply yet. Subsequent
+	   * input will allow us to determine whether the word continues.
+	   */
+	  if (testRule->charslen > 1
+	      && testRule->opcode != CTO_BegWord
+	      && testRule->opcode != CTO_MidWord)
 	    TranslationFound = 1;
 	  if (testRule->opcode == CTO_PostPunc)
 	    postpuncFound = 1;

--- a/tests/yaml/en-ueb-g2_backward.yaml
+++ b/tests/yaml/en-ueb-g2_backward.yaml
@@ -36,14 +36,16 @@ tests:
   # #309: Ensure correct back-translation to "this".
   - [⠹, this]
 
-  # Contractions followed by punctuation
+  # #360: Contractions followed by punctuation
   # 1-letter contractions
-  - [⠃⠂, "but,", {xfail: true}]
-  - [⠉⠂, "can,", {xfail: true}]
-  - [⠙⠂, "do,", {xfail: true}]
+  - [⠃⠂, "but,"]
+  - [⠃⠲, "but."]
+  - [⠉⠂, "can,"]
+  - [⠙⠂, "do,"]
   # multi-letter contractions
-  - [⠁⠃⠂, "about,", {xfail: true}]
-  - [⠁⠃⠧⠂, "above,", {xfail: true}]
+  - [⠁⠃⠂, "about,"]
+  - [⠁⠃⠲, "about."]
+  - [⠁⠃⠧⠂, "above,"]
 
   # Make sure back-translation for words with "ea" after letters that
   # have contractions associated, such as words like meat, head and


### PR DESCRIPTION
When checking for the end of a word, exclude begword and midword rules from rules which are immediately treated as meaning this is not the end of a word, as we don't know whether they apply yet. Subsequent input will allow us to determine whether the word continues.
Fixes #360.