### PR TITLE
Add the windows/utils directory to the tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,6 +298,10 @@ output.txt
 /windows/include/Makefile
 /windows/include/Makefile.in
 
+# /windows/utils
+/windows/utils/Makefile
+/windows/utils/Makefile.in
+
 # stuff for local development
 local/
 local

--- a/configure.ac
+++ b/configure.ac
@@ -158,31 +158,31 @@ esac
 
 AC_CONFIG_FILES([
 	Makefile
-        doc/Makefile
-        man/Makefile
-        liblouis/Makefile
-        liblouis/liblouis.h
+	doc/Makefile
+	man/Makefile
+	liblouis/Makefile
+	liblouis/liblouis.h
 	windows/Makefile
 	windows/include/Makefile
-        tables/Makefile
+	windows/utils/Makefile
+	tables/Makefile
 	liblouis.pc
-        tests/Makefile
-        tests/resolve_table.h
-        tests/tables/Makefile
-        tests/tables/emphclass/Makefile
-        tests/tables/moreTables/Makefile
-        tests/tables/resolve_table/Makefile
-        tests/tables/resolve_table/dir_1/Makefile
-        tests/tables/resolve_table/dir_1/dir_1.1/Makefile
-        tests/tables/resolve_table/dir_2/Makefile
+	tests/Makefile
+	tests/resolve_table.h
+	tests/tables/Makefile
+	tests/tables/emphclass/Makefile
+	tests/tables/moreTables/Makefile
+	tests/tables/resolve_table/Makefile
+	tests/tables/resolve_table/dir_1/Makefile
+	tests/tables/resolve_table/dir_1/dir_1.1/Makefile
+	tests/tables/resolve_table/dir_2/Makefile
 	tests/tablesWithMetadata/Makefile
-        tests/ueb_test_data/Makefile
-        tests/yaml/Makefile
+	tests/ueb_test_data/Makefile
+	tests/yaml/Makefile
 	python/Makefile
 	python/setup.py
 	python/louis/Makefile
-        tools/Makefile
-        tools/gnulib/Makefile
+	tools/Makefile
+	tools/gnulib/Makefile
 	gnulib/Makefile])
 AC_OUTPUT
-

--- a/windows/Makefile.am
+++ b/windows/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = include
+SUBDIRS = include utils
 
 EXTRA_DIST = \
 	configure.mk \

--- a/windows/utils/Makefile.am
+++ b/windows/utils/Makefile.am
@@ -1,0 +1,2 @@
+EXTRA_DIST = \
+	find-replace.ps1


### PR DESCRIPTION
This is required to build with MSVC but was missing from `make dist`.