### PR TITLE
Hungarian grade tables: adapt new 2017 grade standard changes

### DIFF
--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -35,15 +35,12 @@ begcapsword 46-46
 emphclass italic
 emphclass underline
 emphclass bold
-begemphphrase italic 46-46
-endemphphrase italic before 46
-lenemphphrase italic 4
-begemphword italic 46-3
-endemphword italic 46-36
-emphletter italic 46-25
-begemphphrase bold 456-456
-endemphphrase bold before 456
-lenemphphrase bold 4
+begemph italic 356
+endemph italic  236
+begemph bold 356
+endemph bold 236
+begemph underline 356
+endemph underline 236
 begcomp 456-346
 endcomp 456-156
 midnum : 3
@@ -52,8 +49,15 @@ hyphen - 36
 decpoint , 2
 midnum . 3-3456
 endnum . 3
-
+endnum – 36-36
 #Following part implementing the new braille standard changes
+#When some punctuation character have after end of numbers, need add a dot6 prefix before the punctuation character dots
+endnum : 6-25
+endnum ? 6-26
+endnum ; 6-23
+endnum ! 6-235
+endnum " 6-236
+
 always . 3
 always ' 6-3
 postpunc . 256
@@ -122,10 +126,10 @@ always < 5-13
 always > 46-2
 always / 5-2
 always | 45
-always { 12345
-always } 12456
-always [ 12356
-always ] 23456
+always { 5-2346
+always } 5-1356
+always [ 46-2346
+always ] 46-1356
 always \\ 16
 always ^ 2346
 always ` 4
@@ -136,4 +140,8 @@ space \x000c 0
 space \x001b 1b
 space \e 1b
 space \f 0
+always ä 5-1
+noback context $l$p["–"] @36-36
+noback context $l["–"] @36-36
+noback always \\_ 6 letter sign before Roman page numbers
 undefined 26

--- a/tables/hu-hu-g2.ctb
+++ b/tables/hu-hu-g2.ctb
@@ -28,22 +28,18 @@ include hu-chardefs.cti
 include hu-exceptionwords.cti
 include hu-hu-g2_exceptions.cti
 include braille-patterns.cti
-
 #Braille indicators
 numsign 3456
 begcapsword 46
 emphclass italic
 emphclass underline
 emphclass bold
-begemphphrase italic 46-46
-endemphphrase italic before 46
-lenemphphrase italic 4
-begemphword italic 46-3
-endemphword italic 46-36
-emphletter italic 46-25
-begemphphrase bold 456-456
-endemphphrase bold before 456
-lenemphphrase bold 4
+begemph italic 356
+endemph italic  236
+begemph bold 356
+endemph bold 236
+begemph underline 356
+endemph underline 236
 begcomp 456-346
 endcomp 456-156
 midnum : 3
@@ -52,8 +48,15 @@ hyphen - 36
 decpoint , 2
 midnum . 3-3456
 endnum . 3
-
+endnum – 36-36
 #Following part implementing the new braille standard changes
+#When some punctuation character have after end of numbers, need add a dot6 prefix before the punctuation character dots
+endnum : 6-25
+endnum ? 6-26
+endnum ; 6-23
+endnum ! 6-235
+endnum " 6-236
+
 always . 3
 always ' 6-3
 postpunc . 256
@@ -122,10 +125,10 @@ always < 5-13
 always > 46-2
 always / 5-2
 always | 45
-always { 12345
-always } 12456
-always [ 12356
-always ] 23456
+always { 5-2346
+always } 5-1356
+always [ 46-2346
+always ] 46-1356
 always \\ 16
 always ^ 2346
 always ` 4
@@ -237,7 +240,9 @@ noback context $U["oldog"]$s$U$a @135-123-145-135-1245	For example Boldog Gizell
 noback context $U["oldog"]$l1-30$s$U$a @135-123-145-135-1245	For example Boldogfalvi Tamás name not need abbreviate the boldog word part with 12-1245 dots
 noback context $U$l1-30$s["de"]$s$U$a @145-15	General, need abbrewiate the de word with 1545 dots, but hungarian literary texts some spanish or portuguese names need replacing the abbreviated de word with normal 145-15 dots. For example: Rio de Janeiro, 
 noback context $U["ond"]$l1-30$s$U$a @135-1345-145	General need abbreviate the gond word part with 1245-145 dots, but in names, this is not need. For example: Gonda János, Gondos Réka.
+noback context [%nagysz"zabad"]$s$U$a @156-1-12-1-145
 noback context [%nagysz"zabad"]$l1-30$s$U$a @156-1-12-1-145
+always ponta-kormá 1234-135-1345-2345-1-36-13-135-1235-134-4
 
 noback context [", "] @2
 noback context $U["emmel"]$s$U$a @15-134-134-15-123	For example Temmel Anikó, Temmel Márta names not need apply the suffix abbreviation
@@ -253,4 +258,8 @@ noback pass2 @124-135-1235-1235-4-234 @1235-1235-4-234
 noback pass2 @145-16-123-136-2345-4-1345 @145-16-123-136
 noback pass2 @1236-24-123-4-1245 @1236-1245
 noback pass2 @1236-1-13-135-13-0-1236-24-123-4-1245 @1236-1-13-135-13-0-1236-24-123-4-1245
+always ä 5-1
+noback context $l$p["–"] @36-36
+noback context $l["–"] @36-36
+noback always \\_ 6 letter sign before Roman page numbers
 undefined 26

--- a/tables/hu-hu-g2_exceptions.cti
+++ b/tables/hu-hu-g2_exceptions.cti
@@ -160,7 +160,7 @@ always ezóta 15-126-246
 always mióta 134-24-246
 always régóta 1235-16-1245-246
 always azután 1-126-136
-always ezután 1-126-136
+always ezután 15-126-136
 always miután 134-24-136
 always délután 145-16-123-136
 always délutánnal 145-16-123-136-1236
@@ -216,6 +216,7 @@ always olvas 135-234
 always össze 12345-15
 always összekap 12345-15-13-1-1234
 always pont 1234-2345
+always ponttal 1234-2345-1236
 always ponty 1234-135-1345-1256
 always ponttyal 1234-135-1345-1256-1236
 always pontty 1234-135-1345-1256-1256


### PR DESCRIPTION
Since jul of 2017, some dot combinations changed in hungarian grade1 and grade2 standard. This fix adapt these changes.
Before the 3.3 release publication please merge this change into Liblouis repository master branch.