### PR TITLE
Tests and small fixes for the Latvian table

### DIFF
--- a/tables/Lv-Lv-g1.utb
+++ b/tables/Lv-Lv-g1.utb
@@ -41,8 +41,8 @@ punctuation ( 2356			left parenthesis						x0028
 punctuation ) 2356			right parenthesis						x0029
 sign * 35-35						asterisk										x002A
 math + 56-235						plus												002B
-punctuation , 6					coma												002C
-punctuation - 36-36			hyphen-minus								002D
+punctuation , 2					coma												002C
+punctuation - 36			hyphen-minus								002D
 punctuation . 256				point												002E
 math / 34								solidus											002F
 
@@ -99,7 +99,7 @@ sign ¤ 45-15			currency sign																	x00A4
 sign ¥ 45-13456		yen	sign																			x00A5
 sign § 346				section sign																	x00A7
 sign © 2356-6-14-2356		copyright																x00A9
-punctuation « 45-2356		left-pointing double angle quotation 		x00AB
+punctuation « 236		left-pointing double angle quotation 		x00AB
 punctuation \x00AD 36 soft hyphen
 sign ° 4-356			degree sign																		x00B0
 sign ² 4-6-126		superscript 2 sign														x00B2
@@ -107,7 +107,7 @@ sign ³ 4-6-146		superscript 3 sign														x00B3
 sign µ 46-134			micro sign																		x00B5
 sign ¶ 4-1234-345 pilcrow sign (paragraph)											x00B6
 sign ¹ 1-27				superscript 1 sign														x00B9
-punctuation » 2356-12		right-pointing double angle quotation		x00BB
+punctuation » 356		right-pointing double angle quotation		x00BB
 math ¼ 6-16-34-1456		vulgar fraction one quarter								x00BC
 math ½ 6-16-34-126		vulgar fraction one half									x00BD
 math ¾ 6-126-34-1456	vulgar fraction 3 quarters								x00BE
@@ -173,7 +173,6 @@ uplow \x0158\x0159 2456					R with caron
 # the letter s	with acute
 uplow \x015A\x015B 246
 
-uplow \x0160\x0161 156						S with caron
 uplow \x0164\x0165 1256						T with caron
 uplow \x016C\x016D 23456						U with breve
 uplow \x016E\x016F 23456					U with ring above
@@ -185,7 +184,6 @@ uplow \x0179\x017A 2346
 # the letter z with dot above
 uplow \x017B\x017C 12346
 
-uplow \x017D\x017E 2346						Z with caron
 
 punctuation	\x2010 36		 # 8208			hyphen
 punctuation	\x2011 36		 # 8209			non-breaking hyphen
@@ -202,7 +200,7 @@ punctuation  \x2026 3-3-3 # 8230		smart ellipsis
 # ------------------------------------------------------
 
 
-capsletter 6				# single capital letter indicator
+capsletter 46				# single capital letter indicator
 begcapsword 6-6			# a block of consecutive capital letters indicator
 
 

--- a/tables/lv.tbl
+++ b/tables/lv.tbl
@@ -1,5 +1,6 @@
 #+locale:lv
 #+type:literary
+#+dots:6
 #+grade:1
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -192,6 +192,7 @@ dist_yaml_TESTS =				\
 	yaml/ko-g2_harness.yaml			\
 	yaml/letterDefTest_harness.yaml		\
 	yaml/lt_harness.yaml			\
+	yaml/lv_harness.yaml			\
 	yaml/mn-MN_harness.yaml			\
 	yaml/multipass-backward.yaml		\
 	yaml/multipass-forward.yaml		\

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -72,6 +72,7 @@ EXTRA_DIST =					\
 	ko-g2_harness.yaml			\
 	letterDefTest_harness.yaml		\
 	lt_harness.yaml				\
+	lv_harness.yaml				\
 	mn-MN_harness.yaml			\
 	multipass-backward.yaml			\
 	multipass-forward.yaml			\

--- a/tests/yaml/lv_harness.yaml
+++ b/tests/yaml/lv_harness.yaml
@@ -6,7 +6,7 @@ tests:
   - - All letters of alphabet, in both lowercase and uppercase
     - aA āĀ bB cC čČ dD eE ēĒ fF gG ģĢ hH iI īĪ jJ kK ķĶ lL ļĻ mM nN ņŅ oO pP rR sS šŠ tT uU ūŪ vV zZ žŽ
     - ⠁⠨⠁ ⠡⠨⠡ ⠃⠨⠃ ⠉⠨⠉ ⠩⠨⠩ ⠙⠨⠙ ⠑⠨⠑ ⠱⠨⠱ ⠋⠨⠋ ⠛⠨⠛ ⠻⠨⠻ ⠓⠨⠓ ⠊⠨⠊ ⠪⠨⠪ ⠚⠨⠚ ⠅⠨⠅ ⠥⠨⠥ ⠇⠨⠇ ⠧⠨⠧ ⠍⠨⠍ ⠝⠨⠝ ⠽⠨⠽ ⠕⠨⠕ ⠏⠨⠏ ⠗⠨⠗ ⠎⠨⠎ ⠮⠨⠮ ⠞⠨⠞ ⠌⠨⠌ ⠬⠨⠬ ⠺⠨⠺ ⠜⠨⠜ ⠼⠨⠼
-    - xfail: true
+    - xfail: see https://github.com/liblouis/liblouis/issues/384
   - - Single digits
     - 1 2 3 4 5 6 7 8 9 0
     - ⠼⠁ ⠼⠃ ⠼⠉ ⠼⠙ ⠼⠑ ⠼⠋ ⠼⠛ ⠼⠓ ⠼⠊ ⠼⠚

--- a/tests/yaml/lv_harness.yaml
+++ b/tests/yaml/lv_harness.yaml
@@ -1,0 +1,14 @@
+table: [tables/unicode.dis, tables/lv.tbl]
+tests:
+  - - Pangram
+    - Glāžšķūņa rūķīši dzērumā čiepj Baha koncertflīģeļu vākus.
+    - ⠨⠛⠇⠡⠼⠮⠥⠬⠽⠁ ⠗⠬⠥⠪⠮⠊ ⠙⠜⠱⠗⠌⠍⠡ ⠩⠊⠑⠏⠚ ⠨⠃⠁⠓⠁ ⠅⠕⠝⠉⠑⠗⠞⠋⠇⠪⠻⠑⠧⠌ ⠺⠡⠅⠌⠎⠲
+  - - All letters of alphabet, in both lowercase and uppercase
+    - aA āĀ bB cC čČ dD eE ēĒ fF gG ģĢ hH iI īĪ jJ kK ķĶ lL ļĻ mM nN ņŅ oO pP rR sS šŠ tT uU ūŪ vV zZ žŽ
+    - ⠁⠨⠁ ⠡⠨⠡ ⠃⠨⠃ ⠉⠨⠉ ⠩⠨⠩ ⠙⠨⠙ ⠑⠨⠑ ⠱⠨⠱ ⠋⠨⠋ ⠛⠨⠛ ⠻⠨⠻ ⠓⠨⠓ ⠊⠨⠊ ⠪⠨⠪ ⠚⠨⠚ ⠅⠨⠅ ⠥⠨⠥ ⠇⠨⠇ ⠧⠨⠧ ⠍⠨⠍ ⠝⠨⠝ ⠽⠨⠽ ⠕⠨⠕ ⠏⠨⠏ ⠗⠨⠗ ⠎⠨⠎ ⠮⠨⠮ ⠞⠨⠞ ⠌⠨⠌ ⠬⠨⠬ ⠺⠨⠺ ⠜⠨⠜ ⠼⠨⠼
+  - - Single digits
+    - 1 2 3 4 5 6 7 8 9 0
+    - ⠼⠁ ⠼⠃ ⠼⠉ ⠼⠙ ⠼⠑ ⠼⠋ ⠼⠛ ⠼⠓ ⠼⠊ ⠼⠚
+  - - Punctuation and other symbols
+    - ', . ? ! ; : '' « » ( ) a-b'
+    - ⠂ ⠲ ⠢ ⠖ ⠆ ⠒ ⠄ ⠦ ⠴ ⠶ ⠶ ⠁⠤⠃

--- a/tests/yaml/lv_harness.yaml
+++ b/tests/yaml/lv_harness.yaml
@@ -6,6 +6,7 @@ tests:
   - - All letters of alphabet, in both lowercase and uppercase
     - aA āĀ bB cC čČ dD eE ēĒ fF gG ģĢ hH iI īĪ jJ kK ķĶ lL ļĻ mM nN ņŅ oO pP rR sS šŠ tT uU ūŪ vV zZ žŽ
     - ⠁⠨⠁ ⠡⠨⠡ ⠃⠨⠃ ⠉⠨⠉ ⠩⠨⠩ ⠙⠨⠙ ⠑⠨⠑ ⠱⠨⠱ ⠋⠨⠋ ⠛⠨⠛ ⠻⠨⠻ ⠓⠨⠓ ⠊⠨⠊ ⠪⠨⠪ ⠚⠨⠚ ⠅⠨⠅ ⠥⠨⠥ ⠇⠨⠇ ⠧⠨⠧ ⠍⠨⠍ ⠝⠨⠝ ⠽⠨⠽ ⠕⠨⠕ ⠏⠨⠏ ⠗⠨⠗ ⠎⠨⠎ ⠮⠨⠮ ⠞⠨⠞ ⠌⠨⠌ ⠬⠨⠬ ⠺⠨⠺ ⠜⠨⠜ ⠼⠨⠼
+    - xfail: true
   - - Single digits
     - 1 2 3 4 5 6 7 8 9 0
     - ⠼⠁ ⠼⠃ ⠼⠉ ⠼⠙ ⠼⠑ ⠼⠋ ⠼⠛ ⠼⠓ ⠼⠊ ⠼⠚


### PR DESCRIPTION
As asked for in #384, here's a rather minimalistic testcase file for the Latvian table, and some fixes for what looks like actual bugs in the table.

Note one of the tests is currently failing. I could have marked it as xfail, but there seems to be a huge amount of tests already marked this way, so marking it as failing would most certainly mean it would just get ignored. 

As a sidenote, the table itself is quite a mess, with repeated/conflicting as well as seemingly random definitions pasted from who knows where. Hopefully, someone with better knowledge of Latvian Braille will clean it up one day.