### PR TITLE
Fix NMakefile for findTable rename and wrappers removal

### DIFF
--- a/windows/Makefile.nmake
+++ b/windows/Makefile.nmake
@@ -25,11 +25,11 @@ WIDECHAR_TYPE = unsigned int
 DLLFLAGS = /dll /nologo
 LIBFLAGS = /nologo
 
-HEADERS = $(SRCDIR)\internal.h $(SRCDIR)\liblouis.h $(SRCDIR)\findTable.h \
+HEADERS = $(SRCDIR)\internal.h $(SRCDIR)\liblouis.h \
     include\config.h
-OBJ = commonTranslationFunctions.obj compileTranslationTable.obj findTable.obj \
+OBJ = commonTranslationFunctions.obj compileTranslationTable.obj \
     logging.obj lou_backTranslateString.obj lou_translateString.obj \
-    pattern.obj utils.obj wrappers.obj
+    metadata.obj pattern.obj utils.obj
 
 all: liblouis.lib
     link $(DLLFLAGS) /OUT:liblouis.dll $(OBJ)  
@@ -54,9 +54,6 @@ compileTranslationTable.obj: $(SRCDIR)\compileTranslationTable.c \
     $(HEADERS)
     $(CC) $(CFLAGS) $(SRCDIR)\compileTranslationTable.c
 
-findTable.obj: $(SRCDIR)\findTable.c $(HEADERS)
-    $(CC) $(CFLAGS) $(SRCDIR)\findTable.c
-
 logging.obj: $(SRCDIR)\logging.c $(HEADERS)
     $(CC) $(CFLAGS) $(SRCDIR)\logging.c
 
@@ -67,11 +64,11 @@ lou_backTranslateString.obj: $(SRCDIR)\lou_backTranslateString.c \
 lou_translateString.obj: $(SRCDIR)\lou_translateString.c $(HEADERS)
     $(CC) $(CFLAGS) $(SRCDIR)\lou_translateString.c
 
+metadata.obj: $(SRCDIR)\metadata.c $(HEADERS)
+    $(CC) $(CFLAGS) $(SRCDIR)\metadata.c
+
 pattern.obj: $(SRCDIR)\pattern.c $(HEADERS)
     $(CC) $(CFLAGS) $(SRCDIR)\pattern.c
 
 utils.obj: $(SRCDIR)\utils.c $(HEADERS)
     $(CC) $(CFLAGS) $(SRCDIR)\utils.c
-
-wrappers.obj: $(SRCDIR)\wrappers.c $(HEADERS)
-    $(CC) $(CFLAGS) $(SRCDIR)\wrappers.c


### PR DESCRIPTION
Broken by 0350ec0005cb51d06383198739ece70c9c2f8e7c and c9e7460757fc6b388a1eb8baf357fbe085e82a11.