### PR TITLE
Cap sign change

### DIFF
--- a/tables/mn-MN.utb
+++ b/tables/mn-MN.utb
@@ -218,7 +218,7 @@ sign \x20AE 4-2345              # mongolian currency symbol
 
 # Braille indicators
 numsign 3456  #number sign, just a dots operand
-capsletter 45
+capsletter 6
 emphclass italic
 begemphphrase italic 456
 

--- a/tests/yaml/mn-MN_harness.yaml
+++ b/tests/yaml/mn-MN_harness.yaml
@@ -1,5 +1,5 @@
 table: [tables/unicode.dis, tables/mn-MN.utb]
 tests:
-  - - Hello world  
+  - # Hello world  
     - Сайн байна уу дэлхий
-    - ⠘⠎⠁⠯⠝ ⠃⠁⠯⠝⠁ ⠥⠥ ⠙⠪⠇⠓⠊⠯
+    - ⠠⠎⠁⠯⠝ ⠃⠁⠯⠝⠁ ⠥⠥ ⠙⠪⠇⠓⠊⠯

--- a/tests/yaml/mn-MN_harness.yaml
+++ b/tests/yaml/mn-MN_harness.yaml
@@ -1,5 +1,5 @@
 table: [tables/unicode.dis, tables/mn-MN.utb]
 tests:
-  - # Hello world
+  - - Hello world  
     - Сайн байна уу дэлхий
     - ⠘⠎⠁⠯⠝ ⠃⠁⠯⠝⠁ ⠥⠥ ⠙⠪⠇⠓⠊⠯


### PR DESCRIPTION
The Mongolian standard capp letter sign was changed to dot 6 following the changes of ueb English. Therefore, I have changed the former cap letter sign which was dots 45, I changed it to dot 6 as same as English UEB braille.