### PR TITLE
Updates to SEB British Braille Table

### DIFF
--- a/tables/UEBC-g2.ctb
+++ b/tables/UEBC-g2.ctb
@@ -22,6 +22,9 @@
 
 include UEBC-g1.utb
 
+punctuation ( 12356
+punctuation ) 23456
+
 # the letter a
 largesign a 1
 always about 1-12

--- a/tables/en-GB-g2.ctb
+++ b/tables/en-GB-g2.ctb
@@ -2,7 +2,7 @@
 #
 #  Copyright (C) 2004-2008 ViewPlus Technologies, Inc. www.viewplus.com
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
-#  Copyright (C) 2012,2014  Paul Wood <paulw.torchtrust@gmail.com>
+#  Copyright (C) 2012,2014 Torch Trust, www.torchtrust.org
 #
 #  This file is part of liblouis.
 #
@@ -94,6 +94,7 @@ word bee 12-15-15
 begword bee 12-15-15
 always been 12-15-26
 always beer 12-15-12456
+begword befriend 23-124-1235-24-26-145
 word beg =
 begword begg 12-15-2356
 word begs =
@@ -108,6 +109,7 @@ always bell =
 begword belm = Belmont
 always belt =
 begword belw = belwether
+word bemba =
 always ben 12-26
 begword beni 12-26-24
 begword benif 23-1345-24-124 benificient
@@ -117,6 +119,7 @@ begword benu 23-1345-136 benumbed
 begword ber 12-12456
 begword bera 23-1235-1 berating
 begword bere 23-1235-15 bereft
+word beret 12-12456-15-2345
 begword berea 23-1235-2 bereaved
 begword beri 23-1235-24 beribboned
 always best 12-15-34
@@ -127,6 +130,7 @@ always bets =
 always bett =
 sufword bev = bevies
 begword bever 12-5-15 Beverly beverage
+word bexhill =
 always bio =
 midendword bious 12-24-1256-234 dubious
 joinword by 356
@@ -243,6 +247,8 @@ word donegall =
 
 # the letter e
 midword ea 2
+word leah	=
+word judaean =
 midword eabil = interchangeability
 #always eable 15-1-3456
 #endword eably = noticeably
@@ -266,12 +272,13 @@ always en 26
 always ename 15-5-1345
 sufword enamel 26-1-134-15-123 enameled
 midendword ence 56-15
+endword enced 26-14-1246
 always eneck = bottleneck
 midendword eness 15-56-234 closeness
 endword enesse 15-56-234-15
 #begword enor = enormous
 #begword enou 15-1345-1256
-lowword enough 26
+lowword en 26
 word enough 26-1256-126
 #begword enu 15-1345-136
 always er 12456
@@ -331,7 +338,9 @@ contraction grt
 always had 456-125
 begword hadd 125-1-256 haddock
 sufword hade = hadean 
+sufword hadrian =
 word have 125
+sufword hedge 125-1246-1245-15
 always here 5-125
 always hered 125-12456-1246
 always heren 125-12456-26
@@ -343,6 +352,8 @@ word heretofore 5-125-2345-135-123456-15
 word herself 125-12456-124
 word herf =
 word him 125-134
+always \s-\shis 36-36-125-24-234
+always his\s- 125-24-234-36-36
 word hm 125-3-134
 sufword hmm =
 word himself 125-134-124
@@ -360,6 +371,8 @@ begword immuno = immunofluorescence
 lowword in 35
 word in =
 always in 35
+endword -in 36-35
+begword in- 35-36
 #begword incon 35-14-135-1345 incongruous
 always iness 24-56-234
 endword inesse 24-56-234-15
@@ -386,6 +399,7 @@ always know 5-13
 word knowledge 13
 
 # the letter l
+word latenight 123-1-2345-15-1345-24-126-2345
 midendword less 46-234
 always letter 123-1235
 contraction lr
@@ -457,6 +471,7 @@ always ofold = twofold
 midword ofor 135-123456
 always onesi =
 word anemone =
+word anemonos =
 word hermione 125-12456-134-24-135-1345-15
 midendword oness 135-56-234
 midendword onesse 135-56-234-15 
@@ -488,6 +503,7 @@ word out 1256
 always ought 5-1256
 always ow 246
 word o'clock 135-3-14
+word o’clock 135-3-14
 
 # the letter p
 always paid 1234-145
@@ -506,6 +522,7 @@ word percvg =
 always perhaps 1234-12456-125
 word perh =
 always pher 1234-125-12456 cyphered
+word porthole =
 begword potho = pothole pothook
 begword pred 1234-1235-1246
 begword pre =
@@ -580,10 +597,11 @@ sufword renegade 1235-26-15-1245-1-145-15
 #begword renu = renunciation
 sufword reread 1235-15-1235-2-145
 sufword rerun = reruns
-#always rever 1235-15-1236-12456
+always rever 1235-15-1236-12456
 always reveren 1235-5-15-26 irreverent
 always reverence 1235-5-15-56-15 irreverence
 sufword reverie 1235-5-15-24-15
+word revers 1235-5-15-234
 always right 5-1235
 
 # the letter s
@@ -614,6 +632,7 @@ always some 5-234
 midendword somed 234-135-134-1246 ransomed
 always somer 234-135-134-12456 somersault 
 always spirit 456-234
+always sphere 234-1234-5-125
 midendword ssword 234-234-45-2456 crossword 
 endnum st 34
 word st =
@@ -634,7 +653,6 @@ always ssh =
 always shood =
 word such 234-16
 word sch =
-always sword =
 
 # the letter t
 endnum th 1456
@@ -651,6 +669,7 @@ joinword to 235
 word today 2345-145
 contraction td
 word tomorrow 2345-134
+word tomorrows 2345-134-234
 contraction tm
 word tonight 2345-1345
 contraction tn
@@ -702,6 +721,8 @@ begword vice = viceroy
 
 # the letter w
 lowword was 356
+always \s-\swas 36-36-2456-1-234
+always was\s-\s 2456-1-234-36-36
 word wh =
 always wh 156
 midendword whart 2456-125-345-2345 Newhart
@@ -709,6 +730,8 @@ word which 156
 midendword whouse 2456-125-1256-234-15 Newhouse
 word will 2456
 lowword were 2356
+always \s-\swere 36-36-2456-12456-15
+always were\s-\s 2456-12456-15-36-36
 always where 5-156
 word whereupon 5-156-45-136
 word wherever 156-12456-5-15
@@ -792,3 +815,13 @@ begword ultra =
 begword electro =
 begword neuro =
 begword psycho 1234-234-13456-16-135
+
+
+# Apostrophes
+
+word 'ear 3-15-345
+word ’ear 3-15-345
+midendword e'er 15-3-12456
+midendword e’er 15-3-12456
+word goin' 1245-135-35-3
+word goin’ 1245-135-35-3

--- a/tables/en-gb-g1.utb
+++ b/tables/en-gb-g1.utb
@@ -28,182 +28,6 @@ include text_nabcc.dis All display opcodes
 include ukchardefs.cti All character definition opcodes
 
 
-# Braille indicators
-numsign 3456  number sign, just a dots operand
-multind 56-6 letsign capsletter
-letsign 56
-capsletter 6
-begcapsword 6-6
-endcapsword 6-3
-emphclass italic
-emphclass underline
-emphclass bold
-begemph italic 46
-endemph italic 46-3
-begemph bold 46-46
-endemph bold 46-3
-begcomp 6-346
-endcomp 6-346
-
-# the decimal digits
-include litdigits6Dots.uti
-
-# Letters are defined in en-chardefs
-
-#single letter words
-largesign a 1
-largesign A 1
-word I 24
-word O 135
-word o 135
-
-# abbreviations
-contraction ie
-word i.e. 24-256-15-256
-contraction ok
-word o.k. 135-256-13-256
-
-# Roman Numerals
-contraction ii
-contraction iii
-contraction iv
-contraction vi
-contraction vii
-contraction viii
-contraction ix
-contraction xi
-contraction xii
-contraction xiii
-
-
-# punctuation
-prepunc " 236
-postpunc " 356
-always " 5
-prepunc ' 6-236
-postpunc ' 356-3
-postpunc '' 356
-postpunc ''' 356-3-356
-
-always ' 3
-word 'ave 3-1-1236-15
-word ’ave 3-1-1236-15
-midendword 'an 3-1-1345
-midendword ’an 3-1-1345
-endword 'ah 3-1-125
-endword ’ah 3-1-125
-midendword 'am 3-1-134
-midendword ’am 3-1-134
-endword 'd 3-145
-endword ’d 3-145
-word 'em 3-15-134
-word ’em 3-15-134
-word 'ear 3-15-1-1235
-word ’ear 3-15-1-1235
-word goin' 1245-135-24-1345-3
-word goin’ 1245-135-24-1345-3
-begword ha'p 125-1-3-1234
-begword ha’p 125-1-3-1234
-endword 'll 3-123-123
-endword ’ll 3-123-123
-endword 'm 3-134
-endword ’m 3-134
-endword 'n 3-1345
-endword ’n 3-1345
-begword o'd 135-3-145
-begword o’d 135-3-145
-begword o'l 135-3-123
-begword o’l 135-3-123
-word 'ome 3-135-134-15
-word ’ome 3-135-134-15
-endword 're 3-1235-15
-endword ’re 3-1235-15
-endword 'ry 3-1235-13456
-endword ’ry 3-1235-13456
-endword 'r 3-1235
-endword ’r 3-1235
-endword 's 3-234
-endword ’s 3-234
-endword 't 3-2345
-endword ’t 3-2345
-word 'tis =
-word 'twas =
-word 'uns 3-136-1345-234
-word ’uns 3-136-1345-234
-endword 've 3-1236-15
-endword ’ve 3-1236-15
-midnum , 3
-always , 2
-midnum . 2
-#decpoint . 2 # removed to sort out translations such as p.11
-always . 256
-always ; 23
-midnum : 3456
-always : 25
-#endnum ! 6-235
-always ! 235
-always # 4-3456
-midnum / 456-34-3456
-always / 456-34
-always ? 236
-endnum % 0-25-1234
-always % 25-1234
-midnum ^ 346-3456
-always ^ 456-126
-always ~ 4-156
-always & 4-12346
-midnum * 0-56-236-3456
-always * 35-35
-repeated *** 35-35-0-35-35-0-35-35
-always ( 2356
-prepunc ( 2356
-postpunc ) 2356
-begword ( 2356
-endword ) 2356
-always [ 6-2356
-always ] 2356-3
-always { 46-2356
-always } 46-2356
-always -com 36-14-135-134
-endword -to 36-2345-135 pointed-to resource
-endword -by 36-12-13456 used-by
-# always _ 78
-prepunc `` 236
-postpunc ` 6-236
-prepunc ` 6-236
-postpunc ’ 356-3 end single curly quote
-prepunc ’ 356-3
-always ‘ 6-236 start single curly quote
-always ` 4
-always @ 2346
-always \\ 5-16
-always | 5-123
-repeated \x00a0 0 no break space
-repeated --- 36-36-36
-
-# repeated ___ 78-78-78
-repeated ___ 46-46-46
-
-repeated ::: 25-25-25
-
-repeated === 56-2356-56-2356-56-2356
-repeated ~~~ 4-156-4-156-4-156
-always \s-\s 36-36
-always \s-\scom 36-36-14-135-134
-always ... 3-3-3
-always .\s.\s. 3-3-3 . . .
-# always  \x2026 3-3-3 # 8230			MS Word smart ellipsis
-
-# the hyphen
-always \s–\s 36-36
-#always - 36
-repeated ­­­ 36-36-36
-always \s­\s 36-36
-midword - 36
-joinword - 36
-begword - 36
-hyphen - 36
-
 # accented letters
 
 uplow \x00C0\x00E0 1				# a with grave
@@ -355,7 +179,10 @@ hyphen 	\x2010 36		 # 8208			hyphen
 # punctuation \x2011 36		 # 8209			non-breaking hyphen
 punctuation \x2011 23478	# 8209  non-breaking hyphen
 
-
+punctuation \x2212 36
+always \x2212 36
+always \s\x2212\s 36-36
+midnum \x2013 36-3456
 always	\x2013 56-36		 # 8211		smart minus sign
 
 
@@ -363,6 +190,202 @@ always	\x201C 236	 # 8220			smart opening double quote
 always	\x201D 356	 # 8221			smart closing double quote
 always	\x201E 236	 # 8222			smart double low quotation mark
 always	\x201F 356	 # 8223			smart double high reverse quotation mark
+
+
+# Braille indicators
+numsign 3456  number sign, just a dots operand
+multind 56-6 letsign capsletter
+letsign 56
+capsletter 6
+begcapsword 6-6
+endcapsword 6-3
+emphclass italic
+emphclass underline
+emphclass bold
+begemph italic 46
+endemph italic 46-3
+begemph bold 46-46
+endemph bold 46-3
+begcomp 6-346
+endcomp 6-346
+
+# the decimal digits
+include litdigits6Dots.uti
+
+# Letters are defined in en-chardefs
+
+#single letter words
+largesign a 1
+largesign A 1
+word I 24
+word O 135
+word o 135
+
+# abbreviations
+contraction ie
+word i.e. 24-256-15-256
+contraction ok
+word o.k. 135-256-13-256
+contraction eg
+
+# Roman Numerals
+contraction ii
+contraction iii
+contraction iv
+contraction vi
+contraction vii
+contraction viii
+contraction ix
+contraction xi
+contraction xii
+contraction xiii
+
+
+# punctuation
+prepunc " 236
+postpunc " 356
+always \s-" 36-36-356
+always \s-” 36-36-356
+always ..." 3-3-3-356
+always …" 3-3-3-356
+always ...” 3-3-3-356
+always …” 3-3-3-356
+always ?" 236-356
+word " 236
+begnum ' 3
+prepunc ' 6-236
+postpunc ' 356-3
+postpunc '' 356
+postpunc ''' 356-3-356
+
+always ' 3
+word 'ave 3-1-1236-15
+word ’ave 3-1-1236-15
+midendword 'an 3-1-1345
+midendword ’an 3-1-1345
+endword 'ah 3-1-125
+endword ’ah 3-1-125
+midendword 'am 3-1-134
+midendword ’am 3-1-134
+word c'mon 14-3-134-135-1345
+word c’mon 14-3-134-135-1345
+endword 'd 3-145
+endword ’d 3-145
+begword d' 145-3
+begword d’ 145-3
+word 'em 3-15-134
+word ’em 3-15-134
+word 'ear 3-15-1-1235
+word ’ear 3-15-1-1235
+midendword e'e 15-3-15
+midendword e’e 15-3-15
+word goin' 1245-135-24-1345-3
+word goin’ 1245-135-24-1345-3
+begword ha'p 125-1-3-1234
+begword ha’p 125-1-3-1234
+endword 'll 3-123-123
+endword ’ll 3-123-123
+endword 'm 3-134
+endword ’m 3-134
+endword 'n 3-1345
+endword ’n 3-1345
+begword o'd 135-3-145
+begword o’d 135-3-145
+begword o'l 135-3-123
+begword o’l 135-3-123
+word 'ome 3-135-134-15
+word ’ome 3-135-134-15
+endword 're 3-1235-15
+endword ’re 3-1235-15
+endword 'ry 3-1235-13456
+endword ’ry 3-1235-13456
+endword 'r 3-1235
+endword ’r 3-1235
+endword 's 3-234
+endword ’s 3-234
+endword 't 3-2345
+endword ’t 3-2345
+word 'tis =
+word 'twas =
+word 'uns 3-136-1345-234
+word ’uns 3-136-1345-234
+endword 've 3-1236-15
+endword ’ve 3-1236-15
+midnum , 3
+always , 2
+midnum . 2
+#decpoint . 2 # removed to sort out translations such as p.11
+always . 256
+always ; 23
+midnum : 3456
+always : 25
+#endnum ! 6-235
+always ! 235
+begnum # 4
+always # 4-3456
+midnum / 456-34-3456
+always / 456-34
+always // 345
+always ? 236
+endnum % 0-25-1234
+always % 25-1234
+midnum ^ 346-3456
+always ^ 456-126
+always ~ 4-156
+always & 4-12346
+midnum * 0-56-236-3456
+always * 35-35
+repeated *** 35-35-0-35-35-0-35-35
+always ( 2356
+prepunc ( 2356
+postpunc ) 2356
+begword ( 2356
+endword ) 2356
+always [ 6-2356
+always ] 2356-3
+always { 46-2356
+always } 46-2356
+always -com 36-14-135-134
+endword -to 36-2345-135 pointed-to resource
+endword -by 36-12-13456 used-by
+# always _ 78
+prepunc `` 236
+postpunc ` 6-236
+prepunc ` 6-236
+postpunc ’ 356-3 end single curly quote
+prepunc ’ 356-3
+always ‘ 6-236 start single curly quote
+always ` 4
+begword @ 4-2346
+always @ 2346
+always \\ 5-16
+always | 5-123
+repeated \x00a0 0 no break space
+repeated --- 36-36-36
+
+# repeated ___ 78-78-78
+repeated ___ 46-46-46
+
+repeated ::: 25-25-25
+
+repeated === 56-2356-56-2356-56-2356
+repeated ~~~ 4-156-4-156-4-156
+always \s-\s 36-36
+always \s-\scom 36-36-14-135-134
+always ... 3-3-3
+always .\s.\s. 3-3-3 . . .
+# always  \x2026 3-3-3 # 8230			MS Word smart ellipsis
+
+# the hyphen
+always \s–\s 36-36
+#always - 36
+repeated ­­­ 36-36-36
+always \s­\s 36-36
+midword - 36
+joinword - 36
+begword - 36
+hyphen - 36
+
 
 
 # mathematical symbols
@@ -375,7 +398,8 @@ midnum + 0-56-235-3456
 begnum + 56-235
 joinnum + 56-235
 joinword + 56-235
-midnum - 36-3456
+midnum - 36-3456 removed for verse references
+midnum \x2013 36
 #always - 36
 joinnum × 56-236
 joinword × 56-236
@@ -401,31 +425,31 @@ always ¥ 4-13456 yen
 always µ 2-134 mu
 
 # special character sequences
-compbrl :// URLs
-compbrl www.
+literal :// URLs
+literal www.
 
-compbrl .com
-compbrl .edu
-compbrl .gov
-compbrl .mil
-compbrl .net
-compbrl .org
-compbrl .co.uk
-# include countries.cti
-
-compbrl .doc
+literal .com
+literal .edu
+literal .gov
+literal .mil
+literal .net
+literal .org
+literal .doc
 compbrl .xml
 compbrl .xsl
-compbrl .htm
-compbrl .html
-compbrl .tex
-compbrl .txt
-compbrl .gif
-compbrl .jpg
-compbrl .png
-compbrl .wav
-compbrl .tar
-compbrl .zi
+literal .htm
+literal .html
+literal .tex
+literal .txt
+literal .gif
+literal .jpg
+literal .png
+literal .wav
+literal .tar
+literal .zip
+literal .uk
+
+# include countries.cti
 
 # Problems handled with context
 #context _$l["."]$l @256 U.S.

--- a/tables/ukchardefs.cti
+++ b/tables/ukchardefs.cti
@@ -19,9 +19,22 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 
+# Attributes and dot patterns for the printable ASCII characters
+
 space \t 0 tab            #  9
 space \x000A 0
 space \x000D 0
+space \x2002 0		EN SPACE
+space \x2003 0		EM SPACE
+space \x2004 0		THREE-PER-EM SPACE
+space \x2005 0		FOUR-PER-EM SPACE
+space \x2006 0		SIX-PER-EM SPACE
+space \x2007 0		FIGURE SPACE
+space \x2008 0		PUNCTUATION SPACE
+space \x2009 0		THIN SPACE
+space \x200a 0		HAIR SPACE
+space \x202f 0		NARROW NO-BREAK SPACE
+space \x205f 0		MEDIUM MATHEMATICAL SPACE
 space \s 0 blank					# 32
 punctuation ! 2346				# 33
 punctuation " 5						# 34
@@ -30,14 +43,15 @@ sign $ 1246								# 36
 sign % 146								# 37
 sign & 12346							# 38
 punctuation ' 3						# 39 apostrophe
-punctuation ( 12356				# 40
-punctuation ) 23456				# 41
+punctuation ( 2356				# 40
+punctuation ) 2356				# 41
+
 sign * 16									# 42
 math + 346								# 43
 punctuation , 6						# 44
 punctuation - 36					# 45
-punctuation . 46					# 46
-math / 34									# 47
+punctuation . 256					# 256
+punctuation / 34									# 47
 include loweredDigits6Dots.uti
 punctuation : 156					# 58
 punctuation ; 56					# 59
@@ -71,23 +85,28 @@ sign § 4-234-3						# 167 section sign \x00A7
 
 sign \x00A9 2356-6-14-2356 # 169	© copyright sign
 
-punctuation \x00Ad 36			# 173	  soft hyphen
+punctuation \x00Ad 36-36			# 173	  soft hyphen
 
 sign \x00B0 356						# 176	  ° degrees sign
-
+sign \x00B4 3 						# 180 ´ accute accent !!!! used for apostrophe override
 sign \x00B5 46-134				# 181		µ micro sign
 sign \x00B6 4-1234-345		#	182	  ¶ pilcrow sign
+
+sign \x00BC 3456-1-256 #Quarter
+sign \x00BD 3456-1-23 #Half
 
 math \x00D7 56-236				# 215		× multiplication sign
 
 math \x00F7 56-256				# 247		÷ division sign
 
-punctuation \x2010 36			# 8208  hyphen
-punctuation \x2013 6-36		# 8211	en dash
+punctuation \x2010 36-36			# 8208  hyphen
+punctuation \x2013 36-36		# 8211	en dash
+punctuation \x2014 36-36		# 8212	em dash
+punctuation – 36-36		# 150	En dash
 
 
-punctuation	\x2018 3			# 8216	smart single left quotation mark
-punctuation	\x2019 3			# 8217	smart single right quotation mark
+punctuation	\x2018 6-236			# 8216	smart single left quotation mark
+punctuation	\x2019 356-3			# 8217	smart single right quotation mark
 
 punctuation	\x201C 236		# 8220	smart opening double quote
 punctuation	\x201D 356		# 8221	smart closing double quote
@@ -98,4 +117,3 @@ punctuation \x2026 3-3-3	# 8230 smart ellipsis
 
 sign \x20AC 4-15					# 8364 Euro sign
 
-noback sign \X25CF 16		# 9679 black circle


### PR DESCRIPTION
This is an attempt to salvage the updates from #29. I ported the tables to the new syntax used since version 3.0 of liblouis.

The test still fail because `ukchardefs.cti` now defines `punctuation ( 2356` as opposed to `punctuation ( 12356` as it was previously. That is not  a problem in itself. The problem is that `UEBC-g2.ctb` still uses the dot pattern `12356` in several places:
```
tables/UEBC-g2.ctb:289: error: Dot pattern \12356/ is not defined.
tables/UEBC-g2.ctb:430: error: Dot pattern \12356/ is not defined.
tables/UEBC-g2.ctb:490: error: Dot pattern \12356/ is not defined.
tables/UEBC-g2.ctb:491: error: Dot pattern \12356/ is not defined.
tables/UEBC-g2.ctb:492: error: Dot pattern \12356/ is not defined.
tables/UEBC-g2.ctb:493: error: Dot pattern \12356/ is not defined.
tables/UEBC-g2.ctb:688: error: Dot pattern \23456/ is not defined.
```

An example of this is the following:
```
sufword geoff 1245-15-12356-124 Geoffrey
```
@torchtrust can you fix these problems in `UEBC-g2.ctb` and send me a new version of the file? Please use the version of `UEBC-g2.ctb` that is attached to this pull request, not an old version that you might have lying around.

Thanks