### PR TITLE
Updated tests for #400 and #401

### DIFF
--- a/tests/yaml/issue-400.yaml
+++ b/tests/yaml/issue-400.yaml
@@ -2,7 +2,7 @@ table: |
   display , 6
   display # 3456
   display ; 56
-  include tables/latinLetterDef8Dots.uti
+  include tables/latinLetterDef6Dots.uti
   include tables/digits6Dots.uti
   include tables/litdigits6Dots.uti
   include tables/braille-patterns.cti
@@ -13,40 +13,106 @@ table: |
 
 flags: {testmode: backward}
 tests:
-  # "c" is in numericnocontchars and requires nocontractsign to cancel numeric mode
-  - - "#b;cooler"
-    - "2cooler"
+  # Characters is in numericnocontchars require nocontractsign to cancel numeric mode
+  - - "#abc;abc"
+    - "123abc"
   # "s" is not in numericnocontchars so does not require contractsign to cancel numeric mode
-  - - "#bscooler"
-    - "2scooler"
+  - - "#abckabc"
+    - "123kabc"
     - {xfail: true}
   # whitespace cancels numeric mode
-  - - "#b ,for me"
-    - "2 For me"
+  - - "#abc abc"
+    - "123 abc"
   # capsletter cancels numeric mode
-  - - "#b,scooler"
-    - "2Scooler"
+  - - "#abc,abc"
+    - "123Abc"
     - {xfail: true}
-  - - "#b,cooler"
-    - "2Cooler"
+  - - "#abc,kabc"
+    - "123Kabc"
     - {xfail: true}
 
   # FIXME: the following tests are only relevant if capsletter fails to cancel numeric mode
   # once stuck, numeric mode may not be canceled even by nocontractsign
-  - - "#b,scooler;cooler"
-    - "2Scoolercooler" # FIXME: undefined behavior?
+  - - "#abc,abck;abc"
+    - "123Abckabc" # FIXME: undefined behavior?
     - {xfail: true}
-  - - "#b,scooler#;cooler"
-    - "2Scoolercooler" # FIXME: undefined behavior?
+  - - "#abc,abc#;abc"
+    - "123Abcabc" # FIXME: undefined behavior?
     - {xfail: true}
   # ... but it may be canceled by a numcontractsign if it directly follows a numericnocontchar
-  - - "#b,scooler#a;cooler"
-    - "2Scooler1cooler"
+  - - "#abc,abc#a;abc"
+    - "123Abc1abc"
     - {xfail: true} # capsletter fails, numcontractsign works
-  - - "#b,scoolera;cooler"
-    - "2Scooleracooler" # FIXME: undefined behavior?
+  - - "#abc,abc;abc"
+    - "123Abcabc" # FIXME: undefined behavior?
     - {xfail: true} # capsletter fails, numcontractsign works
   # ... it may also be canceled by whitespace
-  - - "#b,scool ,for me"
-    - "2Scool For me"
+  - - "#abc,abc abc"
+    - "123Abc abc"
     - {xfail: true} # capsletter fails, space works
+
+table: |
+  display , 456
+  display # 3456
+  display ; 56
+  display . 5
+  sign % 123456
+  include tables/latinLetterDef6Dots.uti
+  include tables/digits6Dots.uti
+  include tables/litdigits6Dots.uti
+  include tables/braille-patterns.cti
+  numsign 3456
+  nocontractsign 56
+  numericnocontchars abcdefghij
+  begcapsword 456
+  endcapsword 5
+
+flags: {testmode: backward}
+tests:
+  # endcapsword cancels a word in capitals
+  - - ",abc.abc"
+    - "ABCabc"
+  # Whitespace cancels a word in capitals
+  - - ",abc abc"
+    - "ABC abc"
+  # Non-letter cancels a word in capitals
+  - - ",abc%abc"
+    - "ABC%abc"
+    - {xfail: true}
+  # Number cancels a word in capitals
+  - - ",abc#abc;abc"
+    - "ABC123abc"
+    - {xfail: true}
+
+table: |
+  display , 456
+  display # 3456
+  display ; 56
+  display . 5
+  sign % 123456
+  include tables/latinLetterDef6Dots.uti
+  include tables/digits6Dots.uti
+  include tables/litdigits6Dots.uti
+  include tables/braille-patterns.cti
+  numsign 3456
+  nocontractsign 56
+  numericnocontchars abcdefghij
+  begcaps 456
+  endcaps 5
+
+flags: {testmode: backward}
+tests:
+  # endcaps cancels a block in capitals
+  - - ",abc.abc"
+    - "ABCabc"
+  # Whitespace does not cancel a block in capitals
+  - - ",abc abc"
+    - "ABC ABC"
+  # Non-letter cancels a block in capitals
+  - - ",abc%abc"
+    - "ABC%abc"
+    - {xfail: true} # FIXME: undefined behavior?
+  # Number cancels a block in capitals
+  - - ",abc#abc;abc"
+    - "ABC123abc"
+    - {xfail: true}  # FIXME: undefined behavior?

--- a/tests/yaml/issue-401.yaml
+++ b/tests/yaml/issue-401.yaml
@@ -6,32 +6,32 @@ table: |
   include tables/digits6Dots.uti
   include tables/litdigits6Dots.uti
   include tables/braille-patterns.cti
+  numsign            3456
   begcapsword        456
   # endcapsword before nocontractsign
   endcapsword        56
-  numsign            3456
   nocontractsign     56
   numericnocontchars abcdefghij
 
 flags: {testmode: backward}
 tests:
   # ";" must work as endcapsword
-  - - "|cool;school"
-    - "COOLschool"
+  - - "|ABC;abc"
+    - "ABCabc"
   # ";" must also work as nocontractsign and cancel number mode
-  - - "a#b;cool"
-    - "a2cool"
+  - - "abc#abc;abc"
+    - "abc123abc"
     - {xfail: true} # does not work as nocontractsign
-  - - "#b;cool"
-    - "2cool"
+  - - "#abc;abc"
+    - "123abc"
     - {xfail: true} # does not work as nocontractsign
-  # nocontractsign is not necessary below, as "s" it not in numericmodechars
-  - - "#bscool"
-    - "2scool"
+  # nocontractsign is not necessary below, as "k" it not in numericmodechars
+  - - "#abckabc"
+    - "123kabc"
     - {xfail: true} # character outside numericnocontchars does not cancel numeric mode (issue #400)
   # it shouldn't cause issues though
-  - - "#b;scool"
-    - "2scool"
+  - - "#abc;kabc"
+    - "123kabc"
     - {xfail: true} # character outside numericnocontchars does not cancel numeric mode (issue #400)
 
 table: |
@@ -42,27 +42,27 @@ table: |
   include tables/digits6Dots.uti
   include tables/litdigits6Dots.uti
   include tables/braille-patterns.cti
+  numsign            3456
   begcapsword        456
   # nocontractsign before endcapsword
-  numsign            3456
   nocontractsign     56
-  numericnocontchars abcdefghij
   endcapsword        56
+  numericnocontchars abcdefghij
 
 flags: {testmode: backward}
 tests:
   # ";" must work as endcapsword
-  - - "|cool;school"
-    - "COOLschool"
+  - - "|abc;abc"
+    - "ABCabc"
   # ";" must also work as nocontractsign and cancel number mode
-  - - "a#b;cool"
-    - "a2cool"
-  - - "#b;cool"
-    - "2cool"
-  # nocontractsign is not necessary below, as "s" it not in numericmodechars
-  - - "#bscool"
-    - "2scool"
+  - - "abc#abc;abc"
+    - "abc123abc"
+  - - "#abc;abc"
+    - "123abc"
+  # nocontractsign is not necessary below, as "k" it not in numericmodechars
+  - - "#abckabc"
+    - "123kabc"
     - {xfail: true} # character outside numericnocontchars does not cancel numeric mode (issue #400)
   # it shouldn't cause issues though
-  - - "#b;scool"
-    - "2scool"
+  - - "#abc;kabc"
+    - "123kabc"


### PR DESCRIPTION
This simplifies the strings and cases being tested, and adds a few new testcases for #400, to test cancellation of capitals as well as numbers.