### PR TITLE
Enhance test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@
 sudo: required
 dist: trusty
 
+# the check-format test seems to fail with clang-format 5.0, so for
+# now stay with the older version of clang and hence the whole trusty
+# image
+group: deprecated-2017Q4
+
 language: c
 
 services:

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.8.11
+# Doxyfile 1.8.13
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -118,7 +118,17 @@ REPEAT_BRIEF           = YES
 # the entity):The $name class, The $name widget, The $name file, is, provides,
 # specifies, contains, represents, a, an and the.
 
-ABBREVIATE_BRIEF       =
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
 
 # If the ALWAYS_DETAILED_SEC and REPEAT_BRIEF tags are both set to YES then
 # doxygen will generate a detailed section even if there is only a brief
@@ -242,7 +252,7 @@ TCL_SUBST              =
 # members will be omitted, etc.
 # The default value is: NO.
 
-OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_FOR_C  = YES
 
 # Set the OPTIMIZE_OUTPUT_JAVA tag to YES if your project consists of Java or
 # Python sources only. Doxygen will then generate output that is more tailored
@@ -292,6 +302,15 @@ EXTENSION_MAPPING      =
 # The default value is: YES.
 
 MARKDOWN_SUPPORT       = YES
+
+# When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
+# to that level are automatically included in the table of contents, even if
+# they do not have an id attribute.
+# Note: This feature currently applies only to Markdown headings.
+# Minimum value: 0, maximum value: 99, default value: 0.
+# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
+
+TOC_INCLUDE_HEADINGS   = 0
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can
@@ -771,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = liblouis
+INPUT                  = liblouis tools tests python
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -793,10 +812,12 @@ INPUT_ENCODING         = UTF-8
 # If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
 # *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
 # *.hh, *.hxx, *.hpp, *.h++, *.cs, *.d, *.php, *.php4, *.php5, *.phtml, *.inc,
-# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f, *.for, *.tcl,
-# *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
+# *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
+# *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          =
+FILE_PATTERNS          = *.c \
+                         *.h \
+                         *.py
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -851,7 +872,7 @@ EXAMPLE_PATH           =
 # *.h) to filter out the source-files in the directories. If left blank all
 # files are included.
 
-EXAMPLE_PATTERNS       =
+EXAMPLE_PATTERNS       = *
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands
@@ -2360,6 +2381,11 @@ DIAFILE_DIRS           =
 # will not generate output for the diagram.
 
 PLANTUML_JAR_PATH      =
+
+# When using plantuml, the PLANTUML_CFG_FILE tag can be used to specify a
+# configuration file for plantuml.
+
+PLANTUML_CFG_FILE      =
 
 # When using plantuml, the specified paths are searched for files specified by
 # the !include statement in a plantuml block.

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2573,12 +2573,12 @@ for emphasis are @samp{italic}, @samp{underline}, @samp{bold},
 @end example
 
 @item inputPos
-A list of 0-based input positions, one for each output position. Useful when
-simulating screen reader interaction, to debug contraction and cursor
-behavior as in the following example.
-Note that all positions in this and the following examples start at 0.
-Also note that in these examples the additional options are not
-passed using the ``flow style'' notation.
+A list of 0-based input positions, one for each output position.
+Useful when simulating screen reader interaction, to debug contraction
+and cursor behavior as in the following example. Note that all
+positions in this and the following examples start at 0. Also note
+that in these examples the additional options are not passed using the
+``flow style'' notation.
 
 @example
   -
@@ -2600,21 +2600,41 @@ behavior as in the following example.
 @end example
 
 @item cursorPos
-A list of cursor positions, one for each input position. Useful when
-simulating screen reader interaction, to debug contraction and cursor
-behavior as in the following example:
+The cursor position for the given translation and optionally an
+expected cursor position where the cursor is supposed to be after the
+translation. Useful when simulating screen reader interaction, to
+debug contraction and cursor behavior:
 
-Note that compbrlAtCursor is implicitly specified for all cursor
-positions. This makes this test suitable only for testing a single
-word, since the translation would otherwise vary according to the
-cursor position.
+The cursor position can take two forms: You can either specify a
+single number or alternatively you can give a tuple of two numbers.
+
+@table @asis
+
+@item single number (e.g. @samp{4})
+When you simply want to specify the cursor position for the given
+translation you pass a number as in the following example:
 
 @example
   -
-    - went
-    - ⠺⠑⠝⠞
-    - cursorPos: [0,1,2,3]
+    - you went to
+    - ⠽ ⠺⠑⠝⠞ ⠞⠕
+    - mode: [compbrlAtCursor]
+      cursorPos: 4
 @end example
+
+@item a tuple (e.g. @samp{[4,2]})
+When you expect the cursor to be in a particular position after the
+translation and you want to check this then pass a tuple of cursor
+positions as in the following example:
+
+@example
+  -
+    - you went to
+    - ⠽ ⠺⠑⠝⠞ ⠞⠕
+    - mode: [compbrlAtCursor]
+      cursorPos: [4,2]
+@end example
+@end table
 
 @item mode
 A list of translation modes that should be used for this test. If not

--- a/tests/backtranslate.c
+++ b/tests/backtranslate.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
   int result = 0;
 
   for (int i = 0; tests[i].input; i++)
-    result |= check_backtranslation(TRANSLATION_TABLE, tests[i].input, NULL, tests[i].expected);
+    result |= check(TRANSLATION_TABLE, tests[i].input, tests[i].expected, .direction=1);
 
   lou_free();
   return result;

--- a/tests/backtranslate_noUndefinedDots.c
+++ b/tests/backtranslate_noUndefinedDots.c
@@ -19,8 +19,8 @@ without any warranty. */
 int main(int argc, char **argv) {
   int result = 0;
 
-  result |= check_backtranslation(TRANSLATION_TABLE, UNDEFINED_DOTS, NULL, "\\\\456/");
-  result |= check_backtranslation_with_mode(TRANSLATION_TABLE, UNDEFINED_DOTS, NULL, "", noUndefinedDots);
+	result |= check(TRANSLATION_TABLE, UNDEFINED_DOTS, "\\\\456/", .direction=1);
+	result |= check(TRANSLATION_TABLE, UNDEFINED_DOTS, "", .direction=1, .mode=noUndefinedDots);
 
   lou_free();
   return result;

--- a/tests/backtranslate_partialTrans.c
+++ b/tests/backtranslate_partialTrans.c
@@ -34,8 +34,8 @@ int main(int argc, char **argv) {
   int result = 0;
 
   for (int i = 0; tests[i].input; i++) {
-    result |= check_backtranslation(TRANSLATION_TABLE, tests[i].input, NULL, tests[i].normalExpected);
-    result |= check_backtranslation_with_mode(TRANSLATION_TABLE, tests[i].input, NULL, tests[i].partialExpected, partialTrans);
+		result |= check(TRANSLATION_TABLE, tests[i].input, tests[i].normalExpected, .direction=1);
+		result |= check(TRANSLATION_TABLE, tests[i].input, tests[i].partialExpected, .direction=1, .mode=partialTrans);
   }
 
   lou_free();

--- a/tests/backtranslate_with_letsign.c
+++ b/tests/backtranslate_with_letsign.c
@@ -19,8 +19,8 @@ int main(int argc, char **argv) {
   const char *input = "but b can ";
   const char *expected = "b ;b c ";
 
-  result |= check_translation(TRANSLATION_TABLE, input, NULL, expected);
-  result |= check_backtranslation(TRANSLATION_TABLE, expected, NULL, input);
+  result |= check(TRANSLATION_TABLE, input, expected);
+  result |= check(TRANSLATION_TABLE, expected, input, .direction=1);
 
   lou_free();
   return result;

--- a/tests/capitalization.c
+++ b/tests/capitalization.c
@@ -20,23 +20,23 @@ main (int argc, char **argv)
 {
 	int rst = 0;
 	
-	rst |= check_translation(table, "Abc", NULL, "+abc");
-	rst |= check_translation(table, "ABC", NULL, "[abc");
-	rst |= check_translation(table, "AbcXyz", NULL, "+abc+xyz");
-	rst |= check_translation(table, "ABcXYz", NULL, "[ab]c[xy]z");
-	rst |= check_translation(table, "ABC-XYZ", NULL, "[abc-[xyz");
-	rst |= check_translation(table, "ABC XYZ ABC", NULL, "<abc xyz abc>");
-	rst |= check_translation(table, "ABC-XYZ-ABC", NULL, "[abc-[xyz-[abc");
-	rst |= check_translation(table, "ABC XYZ-ABC", NULL, "[abc [xyz-[abc");
-	rst |= check_translation(table, "ABC XYZ ABC   ", NULL, "<abc xyz abc>   ");
-	rst |= check_translation(table, "ABC XYZ ABC XYZ", NULL, "<abc xyz abc xyz>");
-	rst |= check_translation(table, "ABC-XYZ-ABC-XYZ", NULL, "[abc-[xyz-[abc-[xyz");
-	rst |= check_translation(table, "ABC XYZ-ABC-XYZ", NULL, "[abc [xyz-[abc-[xyz");
-	rst |= check_translation(table, "ABC XYZ ABC-XYZ", NULL, "<abc xyz abc-xyz>");
-	rst |= check_translation(table, "A B C", NULL, "<a b c>");
-	rst |= check_translation(table, "A B C ", NULL, "<a b c> ");
-	rst |= check_translation(table, "A-B-C", NULL, "+a-+b-+c");
-	rst |= check_translation(table, "AB-X-BC", NULL, "[ab-+x-[bc");
+	rst |= check(table, "Abc", "+abc");
+	rst |= check(table, "ABC", "[abc");
+	rst |= check(table, "AbcXyz", "+abc+xyz");
+	rst |= check(table, "ABcXYz", "[ab]c[xy]z");
+	rst |= check(table, "ABC-XYZ", "[abc-[xyz");
+	rst |= check(table, "ABC XYZ ABC", "<abc xyz abc>");
+	rst |= check(table, "ABC-XYZ-ABC", "[abc-[xyz-[abc");
+	rst |= check(table, "ABC XYZ-ABC", "[abc [xyz-[abc");
+	rst |= check(table, "ABC XYZ ABC   ", "<abc xyz abc>   ");
+	rst |= check(table, "ABC XYZ ABC XYZ", "<abc xyz abc xyz>");
+	rst |= check(table, "ABC-XYZ-ABC-XYZ", "[abc-[xyz-[abc-[xyz");
+	rst |= check(table, "ABC XYZ-ABC-XYZ", "[abc [xyz-[abc-[xyz");
+	rst |= check(table, "ABC XYZ ABC-XYZ", "<abc xyz abc-xyz>");
+	rst |= check(table, "A B C", "<a b c>");
+	rst |= check(table, "A B C ", "<a b c> ");
+	rst |= check(table, "A-B-C", "+a-+b-+c");
+	rst |= check(table, "AB-X-BC", "[ab-+x-[bc");
 	
 	return rst;      
 }

--- a/tests/compbrlAtCursor.c
+++ b/tests/compbrlAtCursor.c
@@ -18,20 +18,12 @@ main(int argc, char **argv)
   const char *tableList = "tables/unicode.dis,tables/en-us-comp6.ctb";
   const char *str = "én";
   const char *expected = "⠄⡳⠭⠴⠴⠑⠔⠄⠝";
-  int mode;
-  int cursorPos;
   int result = 0;
 
-  mode = 0;
-  cursorPos = 0;
-  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
-  cursorPos = 1;
-  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
-  mode = compbrlAtCursor;
-  cursorPos = 0;
-  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
-  cursorPos = 1;
-  result |= check_translation_full(tableList, str, NULL, expected, mode, &cursorPos);
+  result |= check(tableList, str, expected, .cursorPos=0);
+  result |= check(tableList, str, expected, .cursorPos=1);
+  result |= check(tableList, str, expected, .mode=compbrlAtCursor, .cursorPos=0);
+  result |= check(tableList, str, expected, .mode=compbrlAtCursor, .cursorPos=1);
 
   lou_free();
   return result;

--- a/tests/emphclass.c
+++ b/tests/emphclass.c
@@ -70,11 +70,8 @@ main (int argc, char **argv)
 		return 1;
 	}
 	emph_classes = lou_getEmphClasses(table);
-	result |= check_translation(table,
-	                            "foobar",
-	                            typeform("foo", "+++++"),
-	                            "~,foobar");
-        if (emph_classes) free(emph_classes);
+	result |= check(table, "foobar", "~,foobar", .typeform=typeform("foo", "+++++"));
+	if (emph_classes) free(emph_classes);
 	lou_free();
 	return result;
 }

--- a/tests/en_gb_g1_italics.c
+++ b/tests/en_gb_g1_italics.c
@@ -27,19 +27,19 @@ main(int argc, char **argv)
   const char *typeform = "00000000000000";
   const char *expected = ",this is a ,test";
 
-  result |= check_translation(TRANSLATION_TABLE, str, convert_typeform(typeform), expected);
+  result |= check(TRANSLATION_TABLE, str, expected, .typeform=convert_typeform(typeform));
 
   str      = "This is a Test in Italic.";
   typeform = "1111111111111111111111111";
   expected = "..,this is a ,test in ,italic4.'";
 
-  result |= check_translation(TRANSLATION_TABLE, str, convert_typeform(typeform), expected);
+  result |= check(TRANSLATION_TABLE, str, expected, .typeform=convert_typeform(typeform));
 
   str      = "This is a Test";
   typeform = "00000111100000";
   expected = ",this .is .a ,test";
 
-  result |= check_translation(TRANSLATION_TABLE, str, convert_typeform(typeform), expected);
+  result |= check(TRANSLATION_TABLE, str, expected, .typeform=convert_typeform(typeform));
 
   /* Test case requested here:
    * http://www.freelists.org/post/liblouis-liblouisxml/Mesar-here-are-some-test-possibilities */
@@ -48,7 +48,7 @@ main(int argc, char **argv)
   typeform = "111111111111111";
   expected = ".\"t .& ._s";
 
-  result |= check_translation(TRANSLATION_TABLE, str, convert_typeform(typeform), expected);
+  result |= check(TRANSLATION_TABLE, str, expected, .typeform=convert_typeform(typeform));
 
   lou_free();
   return result;

--- a/tests/hash_collision.c
+++ b/tests/hash_collision.c
@@ -29,9 +29,9 @@ main (int argc, char **argv)
     }
   }
 
-  result |= check_translation(table, "aaaaa", NULL, "a");
-  result |= check_translation(table, "aaaaa", NULL, "a");
-  result |= check_translation(table, "aazzz", NULL, "a");
+  result |= check(table, "aaaaa", "a");
+  result |= check(table, "aaaaa", "a");
+  result |= check(table, "aazzz", "a");
 
   lou_free();
   return result;

--- a/tests/infiniteTranslationLoop.c
+++ b/tests/infiniteTranslationLoop.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
   const char *text = "---.com";
   const char *expected = "";
 
-  result |= check_translation("tables/UEBC-g2.ctb", text, NULL, expected);
+  result |= check("tables/UEBC-g2.ctb", text, expected);
 
   lou_free();
 

--- a/tests/inpos.c
+++ b/tests/inpos.c
@@ -48,15 +48,10 @@ main(int argc, char **argv)
   const int inpos3[] = {0,0,5,6,8};
   const int inpos4[] = {0,0,5,6,6,6,8};
 
-  result |= check_inpos(table1, txt, inpos1);
-  result |= check_inpos(table2, txt, inpos2);
-  result |= check_inpos(table3, txt, inpos3);
-  result |= check_inpos(table4, txt, inpos4);
-
-  result |= check(table1, txt, brl1);
-  result |= check(table2, txt, brl2);
-  result |= check(table3, txt, brl3);
-  result |= check(table4, txt, brl4);
+  result |= check(table1, txt, brl1, .expected_inputPos=inpos1);
+  result |= check(table2, txt, brl2, .expected_inputPos=inpos2);
+  result |= check(table3, txt, brl3, .expected_inputPos=inpos3);
+  result |= check(table4, txt, brl4, .expected_inputPos=inpos4);
 
   lou_free();
 

--- a/tests/inpos.c
+++ b/tests/inpos.c
@@ -53,10 +53,10 @@ main(int argc, char **argv)
   result |= check_inpos(table3, txt, inpos3);
   result |= check_inpos(table4, txt, inpos4);
 
-  result |= check_translation(table1, txt, NULL, brl1);
-  result |= check_translation(table2, txt, NULL, brl2);
-  result |= check_translation(table3, txt, NULL, brl3);
-  result |= check_translation(table4, txt, NULL, brl4);
+  result |= check(table1, txt, brl1);
+  result |= check(table2, txt, brl2);
+  result |= check(table3, txt, brl3);
+  result |= check(table4, txt, brl4);
 
   lou_free();
 

--- a/tests/inpos_compbrl.c
+++ b/tests/inpos_compbrl.c
@@ -20,10 +20,11 @@ int
 main (int argc, char **argv)
 {
   const char *str1 = "user@example.com";
+  const char *expected = "_+user@example.com_:";
   const int expected_inpos[] = 
     {0,0,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,15,15};
 
-  int result = check_inpos(TRANSLATION_TABLE, str1, expected_inpos);
+  int result = check(TRANSLATION_TABLE, str1, expected, .expected_inputPos=expected_inpos);
 
   lou_free();
 

--- a/tests/inpos_match_replace.c
+++ b/tests/inpos_match_replace.c
@@ -27,8 +27,7 @@ main(int argc, char **argv)
 
   const int inpos[] = {0,1,2,3,4,5,6,7,8,9,9,12,13,14,15,16,17,18,19};
 
-  result |= check(table, txt, brl);
-  result |= check_inpos(table, txt, inpos);
+  result |= check(table, txt, brl, .expected_inputPos=inpos);
 
   lou_free();
 

--- a/tests/inpos_match_replace.c
+++ b/tests/inpos_match_replace.c
@@ -27,7 +27,7 @@ main(int argc, char **argv)
 
   const int inpos[] = {0,1,2,3,4,5,6,7,8,9,9,12,13,14,15,16,17,18,19};
 
-  result |= check_translation(table, txt, NULL, brl);
+  result |= check(table, txt, brl);
   result |= check_inpos(table, txt, inpos);
 
   lou_free();

--- a/tests/lastworditalafter.c
+++ b/tests/lastworditalafter.c
@@ -25,14 +25,14 @@ main(int argc, char **argv)
   const formtype typeform[] = {1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0};
   const char *expected = ".,he sd x wasn't .alw .\"w+ z expect$4";
 
-  result |= check_translation(TRANSLATION_TABLE, str, typeform, expected);
+  result |= check(TRANSLATION_TABLE, str, expected, .typeform=typeform);
 
   /* Then check a test table that defines lastworditalafter */
   str      = "Er sagte es funktioniere nicht immer wie erwartet.";
   const formtype typeform2[] = {1,1,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
   expected = "_ER SAGTE ES __FUNKTION0RE NI4T', IMMER W0 ERWARTET.";
 
-  result |= check_translation("tables/de-ch-g1.ctb", str, typeform2, expected);
+  result |= check("tables/de-ch-g1.ctb", str, expected, .typeform=typeform2);
 
   lou_free();
 

--- a/tests/letterDefTest.c
+++ b/tests/letterDefTest.c
@@ -22,10 +22,10 @@ int main(int argc, char **argv)
   const char *text = "\\x280d\\x280e";  // "⠍⠎"
   const char *expected = "sm";  // "⠎⠍"
 
-  result |= check_translation("tests/tables/letterDefTest_letter.ctb", text, NULL, expected);
-  result |= check_translation("tests/tables/letterDefTest_lowercase.ctb", text, NULL, expected);
-  //result |= check_translation("tests/tables/letterDefTest_uplow.ctb", text, NULL, expected);
-  result |= check_translation("tests/tables/letterDefTest_uppercase.ctb", text, NULL, expected);
+  result |= check("tests/tables/letterDefTest_letter.ctb", text, expected);
+  result |= check("tests/tables/letterDefTest_lowercase.ctb", text, expected);
+  //result |= check("tests/tables/letterDefTest_uplow.ctb", text, expected);
+  result |= check("tests/tables/letterDefTest_uppercase.ctb", text, expected);
 
   lou_free();
 

--- a/tests/pass0_typebuf.c
+++ b/tests/pass0_typebuf.c
@@ -28,7 +28,7 @@ main(int argc, char **argv)
     for (i = 4; i < 7; i++)
       typeform[i] = 1;
 
-    result = check_translation(table, text, typeform, expected);
+    result = check(table, text, expected, .typeform=typeform);
 
     lou_free();
 

--- a/tests/pass2.c
+++ b/tests/pass2.c
@@ -21,10 +21,10 @@ main(int argc, char **argv)
   int result = 0;
 
   /* First check a plain word to see if the table works */
-  result = check_translation(table, "Rene", NULL, "rene");
+  result = check(table, "Rene", "rene");
 
   /* then try a word which uses pass2 */
-  result |= check_translation(table, "Reno", NULL, "ren'o");
+  result |= check(table, "Reno", "ren'o");
 
   lou_free();
 

--- a/tests/pass2_inpos.c
+++ b/tests/pass2_inpos.c
@@ -26,20 +26,20 @@ main(int argc, char **argv)
   const char* str1 = "Rene";
   const int expected_inpos1[] = {0,1,2,3,3};
 
-  result |= check_inpos(table, str1, expected_inpos1);
+  result |= check(table, str1, "rene", .expected_inputPos=expected_inpos1);
 
   /* then try a word which uses pass2 and makes the output longer */
   const char* str2 = "Reno";
   const int expected_inpos2[] = {0,1,2,3,3};
 
-  result |= check_inpos(table, str2, expected_inpos2);
+  result |= check(table, str2, "ren'o", .expected_inputPos=expected_inpos2);
 
   /* finally try a word also uses pass2, deletes a char from the
      output and essentially shortens the output */
   const char* str3 = "xRen";
   const int expected_inpos3[] = {1,2,3};
 
-  result |= check_inpos(table, str3, expected_inpos3);
+  result |= check(table, str3, "ren", .expected_inputPos=expected_inpos3);
 
   lou_free();
 

--- a/tests/squash_space.c
+++ b/tests/squash_space.c
@@ -105,18 +105,18 @@ int main(int argc, char **argv)
   int tests_len = sizeof(tests)/sizeof(char*);
 
   for (i = 0; i < tests_len; i += 2)
-    result |= check_translation("tests/tables/squash_space_with_repeated.utb", tests[i], NULL, tests[i+1]);
+    result |= check("tests/tables/squash_space_with_repeated.utb", tests[i], tests[i+1]);
 
   tests_len = sizeof(strings)/sizeof(char*);
 
   for (i = 0; i < tests_len; i++)
-    result |= check_translation("tests/tables/squash_space_with_correct.utb", strings[i], NULL, expected);
+    result |= check("tests/tables/squash_space_with_correct.utb", strings[i], expected);
 
   for (i = 0; i < tests_len; i++)
-    result |= check_translation("tests/tables/squash_space_with_context_1.utb", strings[i], NULL, expected);
+    result |= check("tests/tables/squash_space_with_context_1.utb", strings[i], expected);
 
   for (i = 0; i < tests_len; i++)
-    result |= check_translation("tests/tables/squash_space_with_context_2.utb", strings[i], NULL, expected);
+    result |= check("tests/tables/squash_space_with_context_2.utb", strings[i], expected);
 
   lou_free();
 

--- a/tests/uplow_with_unicode.c
+++ b/tests/uplow_with_unicode.c
@@ -24,11 +24,11 @@ main(int argc, char **argv)
 
   const char *expected = "g^";
 
-  result |= check_translation("tests/tables/uplow_with_unicode.ctb", str1, NULL, expected);
-  result |= check_translation("tests/tables/uplow_with_unicode.ctb", str2, NULL, expected);
+  result |= check("tests/tables/uplow_with_unicode.ctb", str1, expected);
+  result |= check("tests/tables/uplow_with_unicode.ctb", str2, expected);
 
-  result |= check_translation("tests/tables/lowercase_with_unicode.ctb", str1, NULL, expected);
-  result |= check_translation("tests/tables/lowercase_with_unicode.ctb", str2, NULL, expected);
+  result |= check("tests/tables/lowercase_with_unicode.ctb", str1, expected);
+  result |= check("tests/tables/lowercase_with_unicode.ctb", str2, expected);
 
   lou_free();
 

--- a/tests/yaml/en-GB-g2_backward.yaml
+++ b/tests/yaml/en-GB-g2_backward.yaml
@@ -10,4 +10,5 @@ tests:
   - # an example where the text to be backtranslated is grade 2, but the word at the cursor is grade 1.
     - ⠽ ⠺⠑⠝⠞ ⠞⠕
     - you went to
-    - {mode: [compbrlAtCursor], cursorPos: [0,1,2,3,4,5,6,7,8]}
+    - mode: [compbrlAtCursor]
+      cursorPos: [2,4]

--- a/tests/yaml/en-GB-g2_harness.yaml
+++ b/tests/yaml/en-GB-g2_harness.yaml
@@ -221,11 +221,7 @@ tests:
     - you went to
     - ⠽ ⠺⠑⠝⠞ ⠞⠕
     - mode: [compbrlAtCursor]
-      cursorPos: [0,1,2,3,4,5,6,7,8,9,10]
-      # FIXME: the original json based test only specified one cursor
-      # position to be tested. Since I don't know the expected result
-      # I'm setting this test to xfail
-      xfail: Test incomplete
+      cursorPos: [4,2]
   - # An example to reproduce:
     # https://bugzilla.gnome.org/show_bug.cgi?id=651217 note that the
     # braille cursor is very squeued. computer cursor is at pos 13,
@@ -233,21 +229,14 @@ tests:
     - Pappa Pappa help me.
     - ⠠⠏⠁⠏⠏⠁ ⠠⠏⠁⠏⠏⠁ ⠓⠑⠇⠏ ⠍⠑⠲
     - mode: [compbrlAtCursor]
-      cursorPos: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
-      # FIXME: the original json based test only specified one cursor
-      # position to be tested. Since I don't know the expected result
-      # I'm setting this test to xfail
-      xfail: Test incomplete
+      cursorPos: [13,15]
+      xfail: Braille cursor is very squeued
   - # this testcase tests cursor position when mode is 0. The word
     # about is contracted to ab. The user presses cursor routing 1 on
     # their display, which should land on letter b, but instead it
     # lands on letter a (index 0).
     - about
     - ⠁⠃
-    - cursorPos: [0,1,2,3,4]
-      # FIXME: for some reason this test passes and fails when run in
-      # the Python based harness tests. At the moment we do not know
-      # why it passes in the yaml tests. Is this a problem in the
-      # Python bindings, a problem in the way tests are run in
-      # brl_checks.c or in check_yaml.c?
-      xfail: off
+    - mode: [compbrlAtCursor]
+      cursorPos: [1,1]
+      xfail: true

--- a/tests/yaml/en-GB-g2_harness.yaml
+++ b/tests/yaml/en-GB-g2_harness.yaml
@@ -215,7 +215,7 @@ tests:
   - # same as above example.
     - to the moon
     - ⠖⠮ ⠍⠕⠕⠝
-  - # an example of where text should generally be contracted, accept
+  - # an example of where text should generally be contracted, except
     # at the point of the cursor. also specify where the computer
     # cursor is at, and where we expect the braille cursor to be.
     - you went to
@@ -232,9 +232,9 @@ tests:
       cursorPos: [13,15]
       xfail: Braille cursor is very squeued
   - # this testcase tests cursor position when mode is 0. The word
-    # about is contracted to ab. The user presses cursor routing 1 on
-    # their display, which should land on letter b, but instead it
-    # lands on letter a (index 0).
+    # 'about' is contracted to 'ab'. The user presses cursor routing 1
+    # on their display, which should land on letter 'b', but instead
+    # it lands on letter 'a' (index 0).
     - about
     - ⠁⠃
     - mode: [compbrlAtCursor]

--- a/tests/yaml/fr-bfu-g2_harness.yaml
+++ b/tests/yaml/fr-bfu-g2_harness.yaml
@@ -3,9 +3,8 @@ tests:
   - - foo 14035
     - ⠋⠕⠕ ⠠⠡⠹⠼⠩⠱
     - mode: [compbrlAtCursor]
-      cursorPos: [0,1,2,3,4,5,6,7,8]
+      cursorPos: [0,0]
   - - foo 14035
     - ⠋⠕⠕ ⠡⠹⠼⠩⠱
-    - xfail: true
-      mode: [compbrlAtCursor]
-      cursorPos: [0,1,2,3,4,5,6,7,8]
+    - mode: [compbrlAtCursor]
+      cursorPos: [5,5]

--- a/tests/yaml/hu-hu-g1_harness.yaml
+++ b/tests/yaml/hu-hu-g1_harness.yaml
@@ -1185,10 +1185,6 @@ tests:
   - ['Az e-mail címem: akarmi@akarmi.hu.', ⠨⠁⠣ ⠑⠤⠍⠁⠊⠇ ⠉⠌⠍⠑⠍⠒ ⠁⠅⠁⠗⠍⠊⠘⠁⠅⠁⠗⠍⠊⠄⠓⠥⠄]
   - - bombázásszimulátor
     - ⠃⠕⠍⠃⠈⠣⠈⠎⠱⠊⠍⠥⠇⠈⠞⠕⠗
-    - cursorPos: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]
-      # FIXME: for some reason this test passes and fails when run in
-      # the Python based harness tests. At the moment we do not know
-      # why it passes in the yaml tests. Is this a problem in the
-      # Python bindings, a problem in the way tests are run in
-      # brl_checks.c or in check_yaml.c?
-      xfail: off
+    - mode: [compbrlAtCursor]
+      cursorPos: [2,2]
+      xfail: true

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = gnulib lou_maketable.d
 
 AM_CPPFLAGS =					\
-	-Wall -Wextra				\
+	-Wall -Wextra -Wno-override-init	\
 	-I$(top_srcdir)/liblouis		\
 	-I$(top_srcdir)/tools/gnulib		\
 	-I$(top_builddir)/tools/gnulib

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -14,6 +14,11 @@
  without any warranty.
 */
 
+/**
+ * @file
+ * @brief Test helper functions
+ */
+
 #include <config.h>
 #include <assert.h>
 #include <stdio.h>

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -67,6 +67,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 	int i, retval = 0;
 	int funcStatus = 0;
 	formtype *typeformbuf = NULL;
+	int *inputPos = NULL;
 	int cursorPosbuf = 0;
 
 	inbuf = malloc(sizeof(widechar) * inlen);
@@ -85,12 +86,15 @@ check_base(const char *tableList, const char *input, const char *expected,
 		retval = 1;
 		goto fail;
 	}
+	if (in.expected_inputPos) {
+		inputPos = malloc(sizeof(int) * inlen);
+	}
 	if (in.direction == 0) {
 		funcStatus = lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, typeformbuf,
-				NULL, NULL, NULL, &cursorPosbuf, in.mode);
+				NULL, NULL, inputPos, &cursorPosbuf, in.mode);
 	} else {
 		funcStatus = lou_backTranslate(tableList, inbuf, &inlen, outbuf, &outlen,
-				typeformbuf, NULL, NULL, NULL, &cursorPosbuf, in.mode);
+				typeformbuf, NULL, NULL, inputPos, &cursorPosbuf, in.mode);
 	}
 	if (!funcStatus) {
 		fprintf(stderr, "Translation failed.\n");
@@ -145,6 +149,26 @@ check_base(const char *tableList, const char *input, const char *expected,
 			free(expected_utf8);
 			free(out_utf8);
 		}
+	}
+	if (in.expected_inputPos) {
+		for (i = 0; i < outlen; i++) {
+			int error_printed = 0;
+			if (in.expected_inputPos[i] != inputPos[i]) {
+				if (!error_printed) {  // Print only once
+					fprintf(stderr, "Inpos failure:\n");
+					error_printed = 1;
+				}
+				fprintf(stderr, "Expected %d, received %d in index %d\n",
+						in.expected_inputPos[i], inputPos[i], i);
+				retval = 1;
+			}
+		}
+	}
+	if ((in.cursorPos >= 0) && (cursorPosbuf != in.expected_cursorPos)) {
+		fprintf(stderr, "Cursor position failure:\n");
+		fprintf(stderr, "Initial:%d Expected:%d Actual:%d \n", in.cursorPos,
+				in.expected_cursorPos, cursorPosbuf);
+		retval = 1;
 	}
 
 fail:

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -68,6 +68,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 	int funcStatus = 0;
 	formtype *typeformbuf = NULL;
 	int *inputPos = NULL;
+	int *outputPos = NULL;
 	int cursorPos = 0;
 
 	inbuf = malloc(sizeof(widechar) * inlen);
@@ -87,14 +88,17 @@ check_base(const char *tableList, const char *input, const char *expected,
 		goto fail;
 	}
 	if (in.expected_inputPos) {
-		inputPos = malloc(sizeof(int) * inlen);
+		inputPos = malloc(sizeof(int) * outlen);
+	}
+	if (in.expected_outputPos) {
+		outputPos = malloc(sizeof(int) * inlen);
 	}
 	if (in.direction == 0) {
 		funcStatus = lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, typeformbuf,
-				NULL, NULL, inputPos, &cursorPos, in.mode);
+				NULL, outputPos, inputPos, &cursorPos, in.mode);
 	} else {
 		funcStatus = lou_backTranslate(tableList, inbuf, &inlen, outbuf, &outlen,
-				typeformbuf, NULL, NULL, inputPos, &cursorPos, in.mode);
+				typeformbuf, NULL, outputPos, inputPos, &cursorPos, in.mode);
 	}
 	if (!funcStatus) {
 		fprintf(stderr, "Translation failed.\n");
@@ -150,12 +154,13 @@ check_base(const char *tableList, const char *input, const char *expected,
 			free(out_utf8);
 		}
 	}
+
 	if (in.expected_inputPos) {
+		int error_printed = 0;
 		for (i = 0; i < outlen; i++) {
-			int error_printed = 0;
 			if (in.expected_inputPos[i] != inputPos[i]) {
 				if (!error_printed) {  // Print only once
-					fprintf(stderr, "Inpos failure:\n");
+					fprintf(stderr, "Input position failure:\n");
 					error_printed = 1;
 				}
 				fprintf(stderr, "Expected %d, received %d in index %d\n",
@@ -164,6 +169,22 @@ check_base(const char *tableList, const char *input, const char *expected,
 			}
 		}
 	}
+
+	if (in.expected_outputPos) {
+		int error_printed = 0;
+		for (i = 0; i < inlen; i++) {
+			if (in.expected_outputPos[i] != outputPos[i]) {
+				if (!error_printed) {  // Print only once
+					fprintf(stderr, "Output position failure:\n");
+					error_printed = 1;
+				}
+				fprintf(stderr, "Expected %d, received %d in index %d\n",
+						in.expected_outputPos[i], outputPos[i], i);
+				retval = 1;
+			}
+		}
+	}
+
 	if ((in.cursorPos >= 0) && (cursorPos != in.expected_cursorPos)) {
 		fprintf(stderr, "Cursor position failure:\n");
 		fprintf(stderr, "Initial:%d Expected:%d Actual:%d \n", in.cursorPos,
@@ -176,6 +197,9 @@ fail:
 	free(outbuf);
 	free(expectedbuf);
 	free(typeformbuf);
+	free(inputPos);
+	free(outputPos);
+
 	return retval;
 }
 
@@ -198,94 +222,6 @@ update_typeform(const char *typeform_string, formtype *typeform, const typeforms
 	int i;
 	for (i = 0; i < len; i++)
 		if (typeform_string[i] != ' ') typeform[i] |= kind;
-}
-
-int
-check_inpos(const char *tableList, const char *str, const int *expected_poslist) {
-	widechar *inbuf;
-	widechar *outbuf;
-	int *inpos;
-	int inlen;
-	int outlen;
-	int i, retval = 0;
-
-	inlen = strlen(str) * 2;
-	outlen = inlen;
-	inbuf = malloc(sizeof(widechar) * inlen);
-	outbuf = malloc(sizeof(widechar) * outlen);
-	inpos = malloc(sizeof(int) * inlen);
-	for (i = 0; i < inlen; i++) {
-		inbuf[i] = str[i];
-	}
-	if (!lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, NULL, NULL, NULL, inpos,
-				NULL, 0)) {
-		fprintf(stderr, "Translation failed.\n");
-		retval = 1;
-		goto fail;
-	}
-	for (i = 0; i < outlen; i++) {
-		if (expected_poslist[i] != inpos[i]) {
-			if (!retval)  // Print only once
-				fprintf(stderr, "Inpos failure:\n");
-			fprintf(stderr, "Expected %d, received %d in index %d\n", expected_poslist[i],
-					inpos[i], i);
-			retval = 1;
-		}
-	}
-
-fail:
-	free(inbuf);
-	free(outbuf);
-	free(inpos);
-	return retval;
-}
-
-int
-check_outpos(const char *tableList, const char *str, const int *expected_poslist) {
-	widechar *inbuf;
-	widechar *outbuf;
-	int *inpos, *outpos;
-	int origInlen, inlen;
-	int outlen;
-	int i, retval = 0;
-
-	origInlen = inlen = strlen(str);
-	outlen = inlen * 2;
-	inbuf = malloc(sizeof(widechar) * inlen);
-	outbuf = malloc(sizeof(widechar) * outlen);
-	/* outputPos can be affected by inputPos, so pass inputPos as well. */
-	inpos = malloc(sizeof(int) * outlen);
-	outpos = malloc(sizeof(int) * inlen);
-	for (i = 0; i < inlen; i++) {
-		inbuf[i] = str[i];
-	}
-	if (!lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, NULL, NULL, outpos,
-				inpos, NULL, 0)) {
-		fprintf(stderr, "Translation failed.\n");
-		retval = 1;
-		goto fail;
-	}
-	if (inlen != origInlen) {
-		fprintf(stderr, "original inlen %d and returned inlen %d differ\n", origInlen,
-				inlen);
-	}
-
-	for (i = 0; i < inlen; i++) {
-		if (expected_poslist[i] != outpos[i]) {
-			if (!retval)  // Print only once
-				fprintf(stderr, "Outpos failure:\n");
-			fprintf(stderr, "Expected %d, received %d in index %d\n", expected_poslist[i],
-					outpos[i], i);
-			retval = 1;
-		}
-	}
-
-fail:
-	free(inbuf);
-	free(outbuf);
-	free(inpos);
-	free(outpos);
-	return retval;
 }
 
 int

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -67,7 +67,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 	int i, retval = 0;
 	int funcStatus = 0;
 	formtype *typeformbuf = NULL;
-	int cursorPosbuf;
+	int *cursorPosbuf = NULL;
 
 	inbuf = malloc(sizeof(widechar) * inlen);
 	outbuf = malloc(sizeof(widechar) * outlen);
@@ -77,7 +77,9 @@ check_base(const char *tableList, const char *input, const char *expected,
 		memcpy(typeformbuf, in.typeform, outlen * sizeof(formtype));
 	}
 	if (in.cursorPos >= 0) {
-		cursorPosbuf = in.cursorPos;
+		cursorPosbuf = malloc(sizeof(int));
+		*cursorPosbuf = in.cursorPos;
+		//		memcpy(cursorPosbuf, in.cursorPos, sizeof(int));
 	}
 	inlen = _lou_extParseChars(input, inbuf);
 	if (!inlen) {
@@ -87,10 +89,10 @@ check_base(const char *tableList, const char *input, const char *expected,
 	}
 	if (in.direction == 0) {
 		funcStatus = lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, typeformbuf,
-				NULL, NULL, NULL, &cursorPosbuf, in.mode);
+				NULL, NULL, NULL, cursorPosbuf, in.mode);
 	} else {
 		funcStatus = lou_backTranslate(tableList, inbuf, &inlen, outbuf, &outlen,
-				typeformbuf, NULL, NULL, NULL, &cursorPosbuf, in.mode);
+				typeformbuf, NULL, NULL, NULL, cursorPosbuf, in.mode);
 	}
 	if (!funcStatus) {
 		fprintf(stderr, "Translation failed.\n");
@@ -152,6 +154,7 @@ fail:
 	free(outbuf);
 	free(expectedbuf);
 	free(typeformbuf);
+	free(cursorPosbuf);
 	return retval;
 }
 

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -185,7 +185,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 		}
 	}
 
-	if ((in.cursorPos >= 0) && (cursorPos != in.expected_cursorPos)) {
+	if ((in.expected_cursorPos >= 0) && (cursorPos != in.expected_cursorPos)) {
 		fprintf(stderr, "Cursor position failure:\n");
 		fprintf(stderr, "Initial:%d Expected:%d Actual:%d \n", in.cursorPos,
 				in.expected_cursorPos, cursorPos);

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -5,7 +5,8 @@
    Copyright (C) 2012 Bert Frees <bertfrees@gmail.com>
    Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
    Copyright (C) 2015 Mike Gray <mgray@aph.org>
-   Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
+   Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print
+   Disabled
    Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
    Copying and distribution of this file, with or without modification,

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -67,7 +67,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 	int i, retval = 0;
 	int funcStatus = 0;
 	formtype *typeformbuf = NULL;
-	int *cursorPosbuf = NULL;
+	int cursorPosbuf = 0;
 
 	inbuf = malloc(sizeof(widechar) * inlen);
 	outbuf = malloc(sizeof(widechar) * outlen);
@@ -77,9 +77,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 		memcpy(typeformbuf, in.typeform, outlen * sizeof(formtype));
 	}
 	if (in.cursorPos >= 0) {
-		cursorPosbuf = malloc(sizeof(int));
-		*cursorPosbuf = in.cursorPos;
-		//		memcpy(cursorPosbuf, in.cursorPos, sizeof(int));
+		cursorPosbuf = in.cursorPos;
 	}
 	inlen = _lou_extParseChars(input, inbuf);
 	if (!inlen) {
@@ -89,10 +87,10 @@ check_base(const char *tableList, const char *input, const char *expected,
 	}
 	if (in.direction == 0) {
 		funcStatus = lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, typeformbuf,
-				NULL, NULL, NULL, cursorPosbuf, in.mode);
+				NULL, NULL, NULL, &cursorPosbuf, in.mode);
 	} else {
 		funcStatus = lou_backTranslate(tableList, inbuf, &inlen, outbuf, &outlen,
-				typeformbuf, NULL, NULL, NULL, cursorPosbuf, in.mode);
+				typeformbuf, NULL, NULL, NULL, &cursorPosbuf, in.mode);
 	}
 	if (!funcStatus) {
 		fprintf(stderr, "Translation failed.\n");
@@ -154,7 +152,6 @@ fail:
 	free(outbuf);
 	free(expectedbuf);
 	free(typeformbuf);
-	free(cursorPosbuf);
 	return retval;
 }
 

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -1,17 +1,17 @@
 /* liblouis Braille Translation and Back-Translation Library
 
- Copyright (C) 2008 Eitan Isaacson <eitan@ascender.com>
- Copyright (C) 2012 James Teh <jamie@nvaccess.org>
- Copyright (C) 2012 Bert Frees <bertfrees@gmail.com>
- Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
- Copyright (C) 2015 Mike Gray <mgray@aph.org>
- Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
- Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
+   Copyright (C) 2008 Eitan Isaacson <eitan@ascender.com>
+   Copyright (C) 2012 James Teh <jamie@nvaccess.org>
+   Copyright (C) 2012 Bert Frees <bertfrees@gmail.com>
+   Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
+   Copyright (C) 2015 Mike Gray <mgray@aph.org>
+   Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
+   Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
- Copying and distribution of this file, with or without modification,
- are permitted in any medium without royalty provided the copyright
- notice and this notice are preserved. This file is offered as-is,
- without any warranty.
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved. This file is offered as-is,
+   without any warranty.
 */
 
 /**

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -68,7 +68,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 	int funcStatus = 0;
 	formtype *typeformbuf = NULL;
 	int *inputPos = NULL;
-	int cursorPosbuf = 0;
+	int cursorPos = 0;
 
 	inbuf = malloc(sizeof(widechar) * inlen);
 	outbuf = malloc(sizeof(widechar) * outlen);
@@ -78,7 +78,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 		memcpy(typeformbuf, in.typeform, outlen * sizeof(formtype));
 	}
 	if (in.cursorPos >= 0) {
-		cursorPosbuf = in.cursorPos;
+		cursorPos = in.cursorPos;
 	}
 	inlen = _lou_extParseChars(input, inbuf);
 	if (!inlen) {
@@ -91,10 +91,10 @@ check_base(const char *tableList, const char *input, const char *expected,
 	}
 	if (in.direction == 0) {
 		funcStatus = lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, typeformbuf,
-				NULL, NULL, inputPos, &cursorPosbuf, in.mode);
+				NULL, NULL, inputPos, &cursorPos, in.mode);
 	} else {
 		funcStatus = lou_backTranslate(tableList, inbuf, &inlen, outbuf, &outlen,
-				typeformbuf, NULL, NULL, inputPos, &cursorPosbuf, in.mode);
+				typeformbuf, NULL, NULL, inputPos, &cursorPos, in.mode);
 	}
 	if (!funcStatus) {
 		fprintf(stderr, "Translation failed.\n");
@@ -164,10 +164,10 @@ check_base(const char *tableList, const char *input, const char *expected,
 			}
 		}
 	}
-	if ((in.cursorPos >= 0) && (cursorPosbuf != in.expected_cursorPos)) {
+	if ((in.cursorPos >= 0) && (cursorPos != in.expected_cursorPos)) {
 		fprintf(stderr, "Cursor position failure:\n");
 		fprintf(stderr, "Initial:%d Expected:%d Actual:%d \n", in.cursorPos,
-				in.expected_cursorPos, cursorPosbuf);
+				in.expected_cursorPos, cursorPos);
 		retval = 1;
 	}
 

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -1,18 +1,17 @@
 /* liblouis Braille Translation and Back-Translation Library
 
-   Copyright (C) 2008 Eitan Isaacson <eitan@ascender.com>
-   Copyright (C) 2012 James Teh <jamie@nvaccess.org>
-   Copyright (C) 2012 Bert Frees <bertfrees@gmail.com>
-   Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
-   Copyright (C) 2015 Mike Gray <mgray@aph.org>
-   Copyright (C) 2010-2016 Swiss Library for the Blind, Visually Impaired and Print
-   Disabled
-   Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
+ Copyright (C) 2008 Eitan Isaacson <eitan@ascender.com>
+ Copyright (C) 2012 James Teh <jamie@nvaccess.org>
+ Copyright (C) 2012 Bert Frees <bertfrees@gmail.com>
+ Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
+ Copyright (C) 2015 Mike Gray <mgray@aph.org>
+ Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
+ Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright
-   notice and this notice are preserved. This file is offered as-is,
-   without any warranty.
+ Copying and distribution of this file, with or without modification,
+ are permitted in any medium without royalty provided the copyright
+ notice and this notice are preserved. This file is offered as-is,
+ without any warranty.
 */
 
 #include <config.h>
@@ -24,11 +23,6 @@
 #include "internal.h"
 #include "brl_checks.h"
 #include "unistr.h"
-
-int
-check_full(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected, int mode, const int *cursorPos, int direction,
-		int diagnostics);
 
 void
 print_int_array(const char *prefix, int *pos_list, int len) {
@@ -60,130 +54,43 @@ print_widechars(widechar *buffer, int length) {
 	free(result_buf);
 }
 
-/* Helper function to convert a typeform string of '0's, '1's, '2's etc.
- * to the required format, which is an array of 0s, 1s, 2s, etc.
- * For example, "0000011111000" is converted to {0,0,0,0,0,1,1,1,1,1,0,0,0}
- * The caller is responsible for freeing the returned array. */
-formtype *
-convert_typeform(const char *typeform_string) {
-	int len = strlen(typeform_string);
-	formtype *typeform = malloc(len * sizeof(formtype));
-	int i;
-	for (i = 0; i < len; i++) typeform[i] = typeform_string[i] - '0';
-	return typeform;
-}
-
-void
-update_typeform(const char *typeform_string, formtype *typeform, const typeforms kind) {
-	int len = strlen(typeform_string);
-	int i;
-	for (i = 0; i < len; i++)
-		if (typeform_string[i] != ' ') typeform[i] |= kind;
-}
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected) {
-	return check_translation_full(tableList, str, typeform, expected, 0, 0);
-}
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation_with_mode(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, int mode) {
-	return check_translation_full(tableList, str, typeform, expected, mode, 0);
-}
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation_with_cursorpos(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, const int *cursorPos) {
-	return check_translation_full(tableList, str, typeform, expected, 0, cursorPos);
-}
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation_full(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected, int mode, const int *cursorPos) {
-	return check_full(tableList, str, typeform, expected, mode, cursorPos, 0, 1);
-}
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected) {
-	return check_backtranslation_full(tableList, str, typeform, expected, 0, 0);
-}
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation_with_mode(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, int mode) {
-	return check_backtranslation_full(tableList, str, typeform, expected, mode, 0);
-}
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation_with_cursorpos(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, const int *cursorPos) {
-	return check_backtranslation_full(tableList, str, typeform, expected, 0, cursorPos);
-}
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation_full(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, int mode, const int *cursorPos) {
-	return check_full(tableList, str, typeform, expected, mode, cursorPos, 1, 1);
-}
-
 /* direction, 0=forward, otherwise backwards. If diagnostics is 1 then
  * print diagnostics in case where the translation is not as
  * expected */
 int
-check_full(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected, int mode, const int *cursorPos, int direction,
-		int diagnostics) {
+check_base(const char *tableList, const char *input, const char *expected,
+		optional_test_params in) {
 	widechar *inbuf, *outbuf, *expectedbuf;
-	int inlen = strlen(str);
+	int inlen = strlen(input);
 	int outlen = inlen * 10;
 	int expectedlen = strlen(expected);
 	int i, retval = 0;
 	int funcStatus = 0;
 	formtype *typeformbuf = NULL;
-	int *cursorPosbuf = NULL;
+	int cursorPosbuf;
 
 	inbuf = malloc(sizeof(widechar) * inlen);
 	outbuf = malloc(sizeof(widechar) * outlen);
 	expectedbuf = malloc(sizeof(widechar) * expectedlen);
-	if (typeform != NULL) {
+	if (in.typeform != NULL) {
 		typeformbuf = malloc(outlen * sizeof(formtype));
-		memcpy(typeformbuf, typeform, outlen * sizeof(formtype));
+		memcpy(typeformbuf, in.typeform, outlen * sizeof(formtype));
 	}
-	if (cursorPos != NULL) {
-		cursorPosbuf = malloc(sizeof(int));
-		memcpy(cursorPosbuf, cursorPos, sizeof(int));
+	if (in.cursorPos >= 0) {
+		cursorPosbuf = in.cursorPos;
 	}
-	inlen = _lou_extParseChars(str, inbuf);
+	inlen = _lou_extParseChars(input, inbuf);
 	if (!inlen) {
 		fprintf(stderr, "Cannot parse input string.\n");
 		retval = 1;
 		goto fail;
 	}
-	if (direction == 0) {
+	if (in.direction == 0) {
 		funcStatus = lou_translate(tableList, inbuf, &inlen, outbuf, &outlen, typeformbuf,
-				NULL, NULL, NULL, cursorPosbuf, mode);
+				NULL, NULL, NULL, &cursorPosbuf, in.mode);
 	} else {
 		funcStatus = lou_backTranslate(tableList, inbuf, &inlen, outbuf, &outlen,
-				typeformbuf, NULL, NULL, NULL, cursorPosbuf, mode);
+				typeformbuf, NULL, NULL, NULL, &cursorPosbuf, in.mode);
 	}
 	if (!funcStatus) {
 		fprintf(stderr, "Translation failed.\n");
@@ -196,14 +103,14 @@ check_full(const char *tableList, const char *str, const formtype *typeform,
 		;
 	if (i < outlen || i < expectedlen) {
 		retval = 1;
-		if (diagnostics) {
+		if (in.diagnostics) {
 			outbuf[outlen] = 0;
-			fprintf(stderr, "Input:    '%s'\n", str);
+			fprintf(stderr, "Input:    '%s'\n", input);
 			/* Print the original typeform not the typeformbuf, as the
 			 * latter has been modified by the translation and contains some
 			 * information about outbuf */
-			if (typeform != NULL) print_typeform(typeform, inlen);
-			if (cursorPos != NULL) fprintf(stderr, "Cursor:   %d\n", *cursorPos);
+			if (in.typeform != NULL) print_typeform(in.typeform, inlen);
+			if (in.cursorPos >= 0) fprintf(stderr, "Cursor:   %d\n", in.cursorPos);
 			fprintf(stderr, "Expected: '%s' (length %d)\n", expected, expectedlen);
 			fprintf(stderr, "Received: '");
 			print_widechars(outbuf, outlen);
@@ -245,8 +152,28 @@ fail:
 	free(outbuf);
 	free(expectedbuf);
 	free(typeformbuf);
-	free(cursorPosbuf);
 	return retval;
+}
+
+/* Helper function to convert a typeform string of '0's, '1's, '2's etc.
+ * to the required format, which is an array of 0s, 1s, 2s, etc.
+ * For example, "0000011111000" is converted to {0,0,0,0,0,1,1,1,1,1,0,0,0}
+ * The caller is responsible for freeing the returned array. */
+formtype *
+convert_typeform(const char *typeform_string) {
+	int len = strlen(typeform_string);
+	formtype *typeform = malloc(len * sizeof(formtype));
+	int i;
+	for (i = 0; i < len; i++) typeform[i] = typeform_string[i] - '0';
+	return typeform;
+}
+
+void
+update_typeform(const char *typeform_string, formtype *typeform, const typeforms kind) {
+	int len = strlen(typeform_string);
+	int i;
+	for (i = 0; i < len; i++)
+		if (typeform_string[i] != ' ') typeform[i] |= kind;
 }
 
 int

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -68,9 +68,22 @@ check_inpos(const char *tableList, const char *str, const int *expected_poslist)
 int
 check_outpos(const char *tableList, const char *str, const int *expected_poslist);
 
-/* Check if the cursor position is where you expect it to be after
- * translating str. Return 0 if the translation is as expected and 1
- * otherwise. */
+/** Check the cursor positions for a translation
+ *
+ * For a given input string iterate over all initial cursor positions
+ * and check if the returned cursor position equals the one in
+ * expected_pos at the same index.
+ *
+ * Note: This check always translates with compbrlAtCursor and does
+ * not check the translation. This would not make sense anyway as the
+ * translation changes depending on the initial cursor position. For
+ * that reason this function is no longer used in checkyaml.
+ *
+ * @return Return 0 if the cursor position for each initial position
+ * in the input string equals the one in expected_pos at the same
+ * index and 1 otherwise.
+ * @deprecated use the check function instead
+ */
 int
 check_cursor_pos(const char *tableList, const char *str, const int *expected_pos);
 

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -1,16 +1,15 @@
 /* liblouis Braille Translation and Back-Translation Library
 
-   Copyright (C) 2012 James Teh <jamie@nvaccess.org>
-   Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
-   Copyright (C) 2015 Mike Gray <mgray@aph.org>
-   Copyright (C) 2010-2016 Swiss Library for the Blind, Visually Impaired and Print
-   Disabled
-   Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
+ Copyright (C) 2012 James Teh <jamie@nvaccess.org>
+ Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
+ Copyright (C) 2015 Mike Gray <mgray@aph.org>
+ Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
+ Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
-   Copying and distribution of this file, with or without modification,
-   are permitted in any medium without royalty provided the copyright
-   notice and this notice are preserved. This file is offered as-is,
-   without any warranty.
+ Copying and distribution of this file, with or without modification,
+ are permitted in any medium without royalty provided the copyright
+ notice and this notice are preserved. This file is offered as-is,
+ without any warranty.
 */
 
 /* Functionality to check a translation. This is mostly needed for the
@@ -21,6 +20,47 @@
  */
 
 #include "liblouis.h"
+
+typedef struct {
+	const formtype *typeform;
+	const int cursorPos;
+	const int mode;
+	const int direction;
+	const int diagnostics;
+	const int *expected_inputPos;
+	const int *expected_outputPos;
+	const int expected_cursorPos;
+} optional_test_params;
+
+/** Check a translation
+ *
+ * Check if an input string is translated as expected.
+ *
+ * @param tableList comma separated list of tables
+ * @param input string to translate
+ * @param expected expected output
+ * @param typeform (optional) the typeform for this translation. If not specified it
+ * defaults to NULL.
+ * @param mode (optional) the translation mode. If not specified it defaults to 0.
+ * @param cursorPos (optional) the cursor position for this translation. If not specified
+ * it defaults to -1.
+ * @param direction (optional) 0 for forward translation, 1 for backwards translation. If
+ * not specified it defaults to 0.
+ * @param diagnostics (optional) Print diagnostic output on failure if diagnostics is not
+ * 0. If not specified it defaults to 1.
+ * @return Return 0 if the translation is as expected and 1 otherwise.
+ */
+#define check(tables, input, expected, ...)                                      \
+	check_base(tables, input, expected, (optional_test_params){.typeform = NULL, \
+												.cursorPos = -1,                 \
+												.mode = 0,                       \
+												.direction = 0,                  \
+												.diagnostics = 1,                \
+												__VA_ARGS__ })
+
+int
+check_base(const char *tableList, const char *input, const char *expected,
+		optional_test_params in);
 
 int
 check_inpos(const char *tableList, const char *str, const int *expected_poslist);
@@ -33,63 +73,6 @@ check_outpos(const char *tableList, const char *str, const int *expected_poslist
  * otherwise. */
 int
 check_cursor_pos(const char *tableList, const char *str, const int *expected_pos);
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected);
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation_with_mode(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, int mode);
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation_with_cursorpos(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, const int *cursorPos);
-
-/* Check if a string is translated as expected. Return 0 if the
- * translation is as expected and 1 otherwise. */
-int
-check_translation_full(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected, int mode, const int *cursorPos);
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected);
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation_with_mode(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, int mode);
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation_with_cursorpos(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, const int *cursorPos);
-
-/* Check if a string is backtranslated as expected. Return 0 if the
- * backtranslation is as expected and 1 otherwise. */
-int
-check_backtranslation_full(const char *tableList, const char *str,
-		const formtype *typeform, const char *expected, int mode, const int *cursorPos);
-
-/* Check if a string is translated as expected for the given direction
- * (0 = forward, backward otherwise). Return 0 if the translation is
- * as expected and 1 otherwise. Print diagnostic output on failure if
- * diagnostics is not 0. */
-int
-check_full(const char *tableList, const char *str, const formtype *typeform,
-		const char *expected, int mode, const int *cursorPos, int direction,
-		int diagnostics);
 
 /* Check if a string is hyphenated as expected. Return 0 if the
  * hyphenation is as expected and 1 otherwise. */

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -12,7 +12,11 @@
  without any warranty.
 */
 
-/* Functionality to check a translation. This is mostly needed for the
+/**
+ * @file
+ * @brief Test helper functions
+ *
+ * Functionality to check a translation. This is mostly needed for the
  * tests in ../tests but it is also needed for lou_checkyaml. So this
  * functionality is packaged up in what automake calls a convenience
  * library, a lib that is solely built at compile time but never
@@ -21,6 +25,10 @@
 
 #include "liblouis.h"
 
+/** Optional parameters for a test
+ *
+ * Used to define optional and named arguments for the check() macro
+ */
 typedef struct {
 	const formtype *typeform;
 	const int cursorPos;
@@ -55,6 +63,11 @@ typedef struct {
  * @param diagnostics (optional) Print diagnostic output on failure if diagnostics is not
  * 0. If not specified it defaults to 1.
  * @return Return 0 if the translation is as expected and 1 otherwise.
+ *
+ * An example how to invoke this is shown below:
+ * ~~~~~~~~~~~~~~~~~~~~~~
+ * result = check(table, word, expected_translation, .typeform = typeform, .cursorPos = 5);
+ * ~~~~~~~~~~~~~~~~~~~~~~
  */
 #define check(tables, input, expected, ...)                                      \
 	check_base(tables, input, expected, (optional_test_params){.typeform = NULL, \
@@ -82,23 +95,27 @@ check_base(const char *tableList, const char *input, const char *expected,
  * translation changes depending on the initial cursor position. For
  * that reason this function is no longer used in checkyaml.
  *
- * @return Return 0 if the cursor position for each initial position
- * in the input string equals the one in expected_pos at the same
- * index and 1 otherwise.
- * @deprecated use the check function instead
+ * @return 0 if the cursor position for each initial position in the
+ * input string equals the one in expected_pos at the same index and 1
+ * otherwise.
+ * @deprecated use the check() function instead
  */
 int
 check_cursor_pos(const char *tableList, const char *str, const int *expected_pos);
 
-/* Check if a string is hyphenated as expected. Return 0 if the
- * hyphenation is as expected and 1 otherwise. */
+/** Check if a string is hyphenated as expected.
+ *
+ * @return 0 if the hyphenation is as expected and 1 otherwise.
+ */
 int
 check_hyphenation(const char *tableList, const char *str, const char *expected);
 
-/* Helper function to convert a typeform string of '0's, '1's, '2's etc.
- * to the required format, which is an array of 0s, 1s, 2s, etc.
- * For example, "0000011111000" is converted to {0,0,0,0,0,1,1,1,1,1,0,0,0}
- * The caller is responsible for freeing the returned array. */
+/** Helper function to convert a typeform string of '0's, '1's, '2's etc. to the required format,
+ *
+ * which is an array of 0s, 1s, 2s, etc. For example, "0000011111000"
+ * is converted to {0,0,0,0,0,1,1,1,1,1,0,0,0} The caller is
+ * responsible for freeing the returned array.
+ */
 formtype *
 convert_typeform(const char *typeform_string);
 

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -3,7 +3,8 @@
    Copyright (C) 2012 James Teh <jamie@nvaccess.org>
    Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
    Copyright (C) 2015 Mike Gray <mgray@aph.org>
-   Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
+   Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print
+   Disabled
    Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
    Copying and distribution of this file, with or without modification,

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -62,12 +62,6 @@ int
 check_base(const char *tableList, const char *input, const char *expected,
 		optional_test_params in);
 
-int
-check_inpos(const char *tableList, const char *str, const int *expected_poslist);
-
-int
-check_outpos(const char *tableList, const char *str, const int *expected_poslist);
-
 /** Check the cursor positions for a translation
  *
  * For a given input string iterate over all initial cursor positions

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -66,7 +66,9 @@ typedef struct {
  *
  * An example how to invoke this is shown below:
  * ~~~~~~~~~~~~~~~~~~~~~~
- * result = check(table, word, expected_translation, .typeform = typeform, .cursorPos = 5);
+ * result = check(table, word, expected_translation,
+ *                .typeform = typeform,
+ *                .cursorPos = 5);
  * ~~~~~~~~~~~~~~~~~~~~~~
  */
 #define check(tables, input, expected, ...)                                      \
@@ -110,11 +112,13 @@ check_cursor_pos(const char *tableList, const char *str, const int *expected_pos
 int
 check_hyphenation(const char *tableList, const char *str, const char *expected);
 
-/** Helper function to convert a typeform string of '0's, '1's, '2's etc. to the required format,
+/** Helper function to convert a typeform string to the required format
  *
- * which is an array of 0s, 1s, 2s, etc. For example, "0000011111000"
- * is converted to {0,0,0,0,0,1,1,1,1,1,0,0,0} The caller is
- * responsible for freeing the returned array.
+ * In other words convert a string of '0's, '1's, '2's etc. to an
+ * array of 0s, 1s, 2s, etc. For example, "0000011111000" is converted
+ * to {0,0,0,0,0,1,1,1,1,1,0,0,0}.
+ *
+ * The caller is responsible for freeing the returned array.
  */
 formtype *
 convert_typeform(const char *typeform_string);

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -42,8 +42,14 @@ typedef struct {
  * @param typeform (optional) the typeform for this translation. If not specified it
  * defaults to NULL.
  * @param mode (optional) the translation mode. If not specified it defaults to 0.
+ * @param expected_inputPos (optional) the expected input positions. If not specified
+ * it defaults to NULL.
+ * @param expected_outputPos (optional) the expected input positions. If not specified
+ * it defaults to NULL.
  * @param cursorPos (optional) the cursor position for this translation. If not specified
  * it defaults to -1.
+ * @param expected_cursorPos (optional) the expected cursor position after this
+ * translation. If not specified it defaults to -1.
  * @param direction (optional) 0 for forward translation, 1 for backwards translation. If
  * not specified it defaults to 0.
  * @param diagnostics (optional) Print diagnostic output on failure if diagnostics is not
@@ -53,6 +59,9 @@ typedef struct {
 #define check(tables, input, expected, ...)                                      \
 	check_base(tables, input, expected, (optional_test_params){.typeform = NULL, \
 												.cursorPos = -1,                 \
+												.expected_cursorPos = -1,        \
+												.expected_inputPos = NULL,       \
+												.expected_outputPos = NULL,      \
 												.mode = 0,                       \
 												.direction = 0,                  \
 												.diagnostics = 1,                \

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -1,15 +1,15 @@
 /* liblouis Braille Translation and Back-Translation Library
 
- Copyright (C) 2012 James Teh <jamie@nvaccess.org>
- Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
- Copyright (C) 2015 Mike Gray <mgray@aph.org>
- Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
- Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
+   Copyright (C) 2012 James Teh <jamie@nvaccess.org>
+   Copyright (C) 2014 Mesar Hameed <mesar.hameed@gmail.com>
+   Copyright (C) 2015 Mike Gray <mgray@aph.org>
+   Copyright (C) 2010-2017 Swiss Library for the Blind, Visually Impaired and Print Disabled
+   Copyright (C) 2016-2017 Davy Kager <mail@davykager.nl>
 
- Copying and distribution of this file, with or without modification,
- are permitted in any medium without royalty provided the copyright
- notice and this notice are preserved. This file is offered as-is,
- without any warranty.
+   Copying and distribution of this file, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved. This file is offered as-is,
+   without any warranty.
 */
 
 /**

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -580,12 +580,10 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 	int result = 0;
 	char **table = tables;
 	while (*table) {
-		if (inPos || outPos || cursorPos) {
+		if (cursorPos) {
 			result |= check(*table, word, translation, .typeform = typeform, .mode = mode,
 					.direction = direction, .diagnostics = !xfail);
-			if (inPos) result |= check_inpos(*table, word, inPos);
-			if (outPos) result |= check_outpos(*table, word, outPos);
-			if (cursorPos) result |= check_cursor_pos(*table, word, cursorPos);
+			result |= check_cursor_pos(*table, word, cursorPos);
 		} else if (hyphenation) {
 			result |= check_hyphenation(*table, word, translation);
 		} else {
@@ -595,6 +593,7 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 			// they must have the same mapping (i.e. the emphasis classes
 			// must be defined in the same order).
 			result |= check(*table, word, translation, .typeform = typeform, .mode = mode,
+					.expected_inputPos = inPos, .expected_outputPos = outPos,
 					.direction = direction, .diagnostics = !xfail);
 		}
 		table++;

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -376,18 +376,23 @@ read_cursorPos(yaml_parser_t *parser, int *cursorPos, int *expected_cursorPos, i
 		if (!yaml_parser_parse(parser, &event) || (event.type != YAML_SCALAR_EVENT))
 			yaml_error(YAML_SCALAR_EVENT, &event);
 		*cursorPos = parse_number((const char *)event.data.scalar.value,
-				"cursor position before", event.start_mark.line + 1);
+				"cursor position", event.start_mark.line + 1);
+		if ((0 > *cursorPos) || (*cursorPos >= wrdlen))
+			error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
+					"Cursor position (%i) outside of input string of length %i\n",
+					*cursorPos, wrdlen);
 		yaml_event_delete(&event);
 		if (!yaml_parser_parse(parser, &event) || (event.type != YAML_SCALAR_EVENT))
-			yaml_error(YAML_SCALAR_EVENT, &event);
+			error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
+					"Too few cursor positions, 2 are expected (before and after)\n");
 		*expected_cursorPos = parse_number((const char *)event.data.scalar.value,
-				"cursor position after", event.start_mark.line + 1);
-		yaml_event_delete(&event);
+				"expected cursor position", event.start_mark.line + 1);
 		if ((0 > *expected_cursorPos) || (*expected_cursorPos >= wrdlen))
 			error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
 					"Expected cursor position (%i) outside of output string of length "
 					"%i\n",
-					*cursorPos, translen);
+					*expected_cursorPos, translen);
+		yaml_event_delete(&event);
 		if (!yaml_parser_parse(parser, &event) || (event.type != YAML_SEQUENCE_END_EVENT))
 			error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
 					"Too many cursor positions, only 2 are expected (before and "
@@ -397,13 +402,13 @@ read_cursorPos(yaml_parser_t *parser, int *cursorPos, int *expected_cursorPos, i
 		/* it's just a single value: just read the initial cursor position */
 		*cursorPos = parse_number((const char *)event.data.scalar.value,
 				"cursor position before", event.start_mark.line + 1);
+		if ((0 > *cursorPos) || (*cursorPos >= wrdlen))
+			error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
+					"Cursor position (%i) outside of input string of length %i\n",
+					*cursorPos, wrdlen);
 		*expected_cursorPos = -1;
 		yaml_event_delete(&event);
 	}
-	if ((0 > *cursorPos) || (*cursorPos >= wrdlen))
-		error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
-				"Cursor position (%i) outside of input string of length %i\n", *cursorPos,
-				wrdlen);
 }
 
 void

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -581,8 +581,8 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 	char **table = tables;
 	while (*table) {
 		if (inPos || outPos || cursorPos) {
-			result |= check_full(
-					*table, word, typeform, translation, mode, NULL, direction, !xfail);
+			result |= check(*table, word, translation, .typeform = typeform, .mode = mode,
+					.direction = direction, .diagnostics = !xfail);
 			if (inPos) result |= check_inpos(*table, word, inPos);
 			if (outPos) result |= check_outpos(*table, word, outPos);
 			if (cursorPos) result |= check_cursor_pos(*table, word, cursorPos);
@@ -594,8 +594,8 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 			// means that if we are testing multiple tables at the same time
 			// they must have the same mapping (i.e. the emphasis classes
 			// must be defined in the same order).
-			result |= check_full(
-					*table, word, typeform, translation, mode, NULL, direction, !xfail);
+			result |= check(*table, word, translation, .typeform = typeform, .mode = mode,
+					.direction = direction, .diagnostics = !xfail);
 		}
 		table++;
 	}


### PR DESCRIPTION
The YAML test suite now supports everything that the C-based tests support, i.e. you can invoke translations and test for input our output positions, you can test with a specific cursor position and you can test for a specific resulting cursor position. At the same time you can specify any mode.

The tests that contained cursor positions have been migrated to the new syntax and are now essentially the same as they were in the json tests.

Some of the cursor position YAML tests had `FIXME`s in them. These have been double checked with the original json tests and are now correct in the sense that they test the same as the original json tests and also behave the same.

Thanks to optional and named arguments the API of `brl_checks.h` has been massively reduced.
