### PR TITLE
Fix backtranslation of numbers in Dutch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -142,6 +142,7 @@ TABLE CONTRIBUTORS
   Lars Bjørndal <lars@handytech.no>, <lars@lamasti.net>
   Leon Ungier <Leon.Ungier@ViewPlus.com> from ViewPlus Technologies, Inc. <www.viewplus.com>
   Leona Holloway <Leona.Holloway@visionaustralia.org> from Vision Australia
+  Leonard de Ruijter from Babbage B.V. <www.babbage.com>
   Mateja Jenčič
   Michel Such <michel.such@free.fr>
   Mike Sivill <mike.sivill@viewplustechnologies.com> from ViewPlus Technologies, Inc.

--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,8 @@ issues]].
 - The Mongolian table has been improved and there is now also support
   for grade 2 thanks to Tsengel Maidar.
 - Minor updates to the Danish tables thanks to Bue Vester-Andersen
+- Fix back translation of numbers in Dutch, Finnish and Canadian
+  French, thanks to Leonard de Ruijter.
 ** Other changes
 *** Improved documentation
 - Extend the documentation on multipass opcodes. Thanks to Dave Mielke

--- a/tables/fi.utb
+++ b/tables/fi.utb
@@ -42,6 +42,7 @@
 # Includes
 include latinLetterDef6Dots.uti
 include digits6Dots.uti
+include litdigits6Dots.uti
 include braille-patterns.cti
 
 # Finnish-specific letters

--- a/tables/fr-ca-g1.utb
+++ b/tables/fr-ca-g1.utb
@@ -88,6 +88,7 @@ punctuation - 36		trait d'union
 sign # 3456					dièse
 
 include digits6Dots.uti
+include litdigits6Dots.uti
 
 sign \x00A8 46			diaeresis sign
 # always n 34				divisé par

--- a/tables/nl-chardefs.uti
+++ b/tables/nl-chardefs.uti
@@ -92,6 +92,7 @@ punctuation \x002E        256                 .                   FULL STOP
 math        \x002F        34                  /                   SOLIDUS
 
 include digits6Dots.uti
+include litdigits6Dots.uti
 
 punctuation \x003A        25                  :                   COLON
 punctuation \x003B        23                  ;                   SEMICOLON

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -174,6 +174,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/iu-ca-g1_harness.yaml		  \
 	braille-specs/ko-2006-g2_harness.yaml		  \
 	braille-specs/ko-g2_harness.yaml		  \
+	braille-specs/litdigits6Dots_backward.yaml	  \
 	braille-specs/lt_harness.yaml			  \
 	braille-specs/lt-6dot_harness.yaml		  \
 	braille-specs/lv_harness.yaml			  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -60,6 +60,7 @@ EXTRA_DIST =					\
 	iu-ca-g1_harness.yaml			\
 	ko-2006-g2_harness.yaml			\
 	ko-g2_harness.yaml			\
+	litdigits6Dots_backward.yaml		\
 	lt-6dot_harness.yaml			\
 	lt_harness.yaml				\
 	lv_harness.yaml				\

--- a/tests/braille-specs/litdigits6Dots_backward.yaml
+++ b/tests/braille-specs/litdigits6Dots_backward.yaml
@@ -1,0 +1,17 @@
+display: unicode.dis
+
+# Tests for tables that use literary 6 dots notation for numbers, e.g. [⠼⠁, 1]
+table: [en-ueb-g1.ctb]
+table: [en-us-g1.ctb]
+table: [fi.utb]
+table: [fr-ca-g1.utb]
+table: [nl-NL-g0.utb]
+table: [nl-BE-g0.utb]
+flags: {testmode: backward}
+tests:
+  - - Lowercase letters
+    - ⠁ ⠃ ⠉ ⠙ ⠑ ⠋ ⠛ ⠓ ⠊ ⠚ ⠅ ⠇ ⠍ ⠝ ⠕ ⠏ ⠟ ⠗ ⠎ ⠞ ⠥ ⠧ ⠺ ⠭ ⠽ ⠵
+    - a b c d e f g h i j k l m n o p q r s t u v w x y z
+  - - Single digits
+    - ⠼⠁ ⠼⠃ ⠼⠉ ⠼⠙ ⠼⠑ ⠼⠋ ⠼⠛ ⠼⠓ ⠼⠊ ⠼⠚
+    - 1 2 3 4 5 6 7 8 9 0

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -14,6 +14,9 @@ tests:
   - - Single digits
     - 1 2 3 4 5 6 7 8 9 0
     - ⠼⠁ ⠼⠃ ⠼⠉ ⠼⠙ ⠼⠑ ⠼⠋ ⠼⠛ ⠼⠓ ⠼⠊ ⠼⠚
+  - - Digits followed by lowercase letters
+    - 1a 1.a 1,a 1:a
+    - ⠼⠁⠠⠁ ⠼⠁⠲⠠⠁ ⠼⠁⠂⠠⠁ ⠼⠁⠒⠠⠁
   - - Punctuation
     - '. , ? ! ; : - …'
     - ⠲ ⠂ ⠢ ⠖ ⠆ ⠒ ⠤ ⠲⠲⠲
@@ -185,3 +188,18 @@ tests:
     - ⠸⠧⠑⠞⠛⠑⠙⠗⠥⠅⠞
     - typeform:
         bold: '++++++++++'
+
+table:
+  locale: nl
+  grade: 0
+  __assert-match: nl.tbl # nl-NL-g0.utb
+table:
+  locale: nl-BE
+  grade: 0
+  __assert-match: nl_BE.tbl # nl-BE-g0.utb
+flags: {testmode: backward}
+tests:
+  - - Digits followed by lowercase letters
+    - ⠼⠁⠠⠁ ⠼⠁⠲⠠⠁ ⠼⠁⠂⠠⠁ ⠼⠁⠒⠠⠁
+    - 1a 1.a 1,a 1:a
+    - xfail: true


### PR DESCRIPTION
This is based on the workaround used by UEB, including both litdigits6Dots.uti and digits6Dots.uti. I only applied these to Dutch, as I am not at all involved with the other tables mentioned in #486.