### PR TITLE
Disable case sensitivity checks when capitalization is not enabled

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3310,6 +3310,7 @@ doOpcode:
 	}
 
 	case CTO_BegCapsPhrase:
+		(*table)->usesCapitalization = 1;
 		tmp_offset = (*table)->emphRules[capsRule][begPhraseOffset];
 		ok = compileBrailleIndicator(nested, "first word capital sign",
 				CTO_BegCapsPhraseRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
@@ -3317,6 +3318,7 @@ doOpcode:
 		(*table)->emphRules[capsRule][begPhraseOffset] = tmp_offset;
 		break;
 	case CTO_EndCapsPhrase:
+		(*table)->usesCapitalization = 1;
 		switch (compileBeforeAfter(nested, &lastToken)) {
 		case 1:  // before
 			if ((*table)->emphRules[capsRule][endPhraseAfterOffset]) {
@@ -3349,18 +3351,21 @@ doOpcode:
 		}
 		break;
 	case CTO_BegCaps:
+		(*table)->usesCapitalization = 1;
 		tmp_offset = (*table)->emphRules[capsRule][begOffset];
 		ok = compileBrailleIndicator(nested, "first letter capital sign", CTO_BegCapsRule,
 				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
 		(*table)->emphRules[capsRule][begOffset] = tmp_offset;
 		break;
 	case CTO_EndCaps:
+		(*table)->usesCapitalization = 1;
 		tmp_offset = (*table)->emphRules[capsRule][endOffset];
 		ok = compileBrailleIndicator(nested, "last letter capital sign", CTO_EndCapsRule,
 				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
 		(*table)->emphRules[capsRule][endOffset] = tmp_offset;
 		break;
 	case CTO_CapsLetter:
+		(*table)->usesCapitalization = 1;
 		tmp_offset = (*table)->emphRules[capsRule][letterOffset];
 		ok = compileBrailleIndicator(nested, "single letter capital sign",
 				CTO_CapsLetterRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
@@ -3368,18 +3373,21 @@ doOpcode:
 		(*table)->emphRules[capsRule][letterOffset] = tmp_offset;
 		break;
 	case CTO_BegCapsWord:
+		(*table)->usesCapitalization = 1;
 		tmp_offset = (*table)->emphRules[capsRule][begWordOffset];
 		ok = compileBrailleIndicator(nested, "capital word", CTO_BegCapsWordRule,
 				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
 		(*table)->emphRules[capsRule][begWordOffset] = tmp_offset;
 		break;
 	case CTO_EndCapsWord:
+		(*table)->usesCapitalization = 1;
 		tmp_offset = (*table)->emphRules[capsRule][endWordOffset];
 		ok = compileBrailleIndicator(nested, "capital word stop", CTO_EndCapsWordRule,
 				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
 		(*table)->emphRules[capsRule][endWordOffset] = tmp_offset;
 		break;
 	case CTO_LenCapsPhrase:
+		(*table)->usesCapitalization = 1;
 		ok = (*table)->emphRules[capsRule][lenPhraseOffset] =
 				compileNumber(nested, &lastToken);
 		break;
@@ -3836,6 +3844,7 @@ doOpcode:
 
 	case CTO_CapsModeChars:
 
+		(*table)->usesCapitalization = 1;
 		c = NULL;
 		ok = 1;
 		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -499,6 +499,8 @@ typedef struct { /* translation table */
 	int syllables;
 	int usesSequences;
 	int usesNumericMode;
+	/** whether this table uses capitalization. 1 if yes, 0 otherwise */
+	int usesCapitalization;
 	TranslationTableOffset tableSize;
 	TranslationTableOffset bytesUsed;
 	TranslationTableOffset undefined;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -196,6 +196,7 @@ dist_yaml_TESTS =				\
 	yaml/lt-6dot_harness.yaml		\
 	yaml/lt_harness.yaml			\
 	yaml/lv_harness.yaml			\
+	yaml/mixed-case.yaml			\
 	yaml/mn-MN_harness.yaml			\
 	yaml/multipass-backward.yaml		\
 	yaml/multipass-forward.yaml		\

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -82,6 +82,7 @@ stEXTRA_DIST =					\
 	lt-6dot_harness.yaml			\
 	lt_harness.yaml				\
 	lv_harness.yaml				\
+	mixed-case.yaml				\
 	mn-MN_harness.yaml			\
 	multipass-backward.yaml			\
 	multipass-forward.yaml			\

--- a/tests/yaml/mixed-case.yaml
+++ b/tests/yaml/mixed-case.yaml
@@ -1,0 +1,65 @@
+# Tests for #507: mixed lower and upper case.
+
+# we define a very simple table and just test whether the word rule
+# matches when we encounter mixed case input. Since we do not define
+# any caps rules we expect liblouis to ignore capitalization
+table: |
+  uplow Ii 24
+  uplow Mm 134
+  uplow Tt  2345
+  word mit 2345
+
+tests:
+  - [mit, t]
+  - [Mit, t]
+  - [MIT, t]
+  - [mIt, t]
+  - [miT, t]
+
+# same test as above basically but this time using an always rule
+# instead of a word rule
+table: |
+  uplow Ii 24
+  uplow Mm 134
+  uplow Tt  2345
+  always mit 2345
+
+tests:
+  - [mit, t]
+  - [Mit, t]
+  - [MIT, t]
+  - [mIt, t]
+  - [miT, t]
+
+# here's another test similar to the first one just using a different
+# input text
+table: |
+  uplow Aa 1
+  uplow Mm 134
+  uplow Nn  1345
+  word man 134
+
+tests:
+  - [man, m]
+  - [Man, m]
+  - [MAN, m]
+  - [maN, m]
+  - [mAn, m]
+
+# when enabling capitalization using a capsletter rule everything
+# works as expected
+table: |
+  uplow Ii 24
+  uplow Mm 134
+  uplow Tt  2345
+  always mit 2345
+  sign $ 46
+  capsletter 46
+
+tests:
+  - [mit, t]
+  - [Mit, $t]
+  - [MIT, t]
+  - [mIt, m$it]
+  - [miT, mi$t]
+


### PR DESCRIPTION
When a table does not define any capitalization opcodes we would expect liblouis to allow contractions regardless of any capitalization, be it at the beginning or in the middle of a word.

This patch introduces a new attribute of the table struct `usesCapitalization` that is set to 1 if the table contains any capitalization opcodes. The translation then only does capitalization emphasis handling if this attribute is set to 1. Also checks whether a rule can apply across capitalization changes are also only done for tables that have capitalization opcodes.

Fixes #507