### PR TITLE
Fix some warnings

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -3246,8 +3246,7 @@ int lou_dotsToChar (
   const char *tableList,
   const widechar *inbuf,
   widechar *outbuf,
-  int length,
-  int mode)
+  int length)
 @end example
 
 This function takes a widechar string in @code{inbuf} consisting of dot 

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1413,8 +1413,7 @@ deallocateRuleNames(RuleName **ruleNames) {
 }
 
 static int
-compileSwapDots(FileInfo *nested, CharsString *source, CharsString *dest,
-		TranslationTableHeader *table) {
+compileSwapDots(FileInfo *nested, CharsString *source, CharsString *dest) {
 	int k = 0;
 	int kk = 0;
 	CharsString dotsSource;
@@ -1451,12 +1450,12 @@ compileSwap(FileInfo *nested, TranslationTableOpcode opcode, int *lastToken,
 	if (opcode == CTO_SwapCc || opcode == CTO_SwapCd) {
 		if (!parseChars(nested, &ruleChars, &matches)) return 0;
 	} else {
-		if (!compileSwapDots(nested, &matches, &ruleChars, *table)) return 0;
+		if (!compileSwapDots(nested, &matches, &ruleChars)) return 0;
 	}
 	if (opcode == CTO_SwapCc) {
 		if (!parseChars(nested, &ruleDots, &replacements)) return 0;
 	} else {
-		if (!compileSwapDots(nested, &replacements, &ruleDots, *table)) return 0;
+		if (!compileSwapDots(nested, &replacements, &ruleDots)) return 0;
 	}
 	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
 				noback, nofor, table))
@@ -4239,25 +4238,6 @@ compileString(const char *inString, CharacterClass **characterClasses,
 	nested.linelen = k;
 	return compileRule(&nested, characterClasses, characterClassAttribute, opcodeLengths,
 			newRuleOffset, newRule, ruleNames, table);
-}
-
-static int
-makeDoubleRule(TranslationTableOpcode opcode, TranslationTableOffset *singleRule,
-		TranslationTableOffset *doubleRule, TranslationTableOffset *newRuleOffset,
-		TranslationTableRule **newRule, int noback, int nofor,
-		TranslationTableHeader **table) {
-	CharsString dots;
-	TranslationTableRule *rule;
-	if (!*singleRule || *doubleRule) return 1;
-	rule = (TranslationTableRule *)&(*table)->ruleArea[*singleRule];
-	memcpy(dots.chars, &rule->charsdots[0], rule->dotslen * CHARSIZE);
-	memcpy(&dots.chars[rule->dotslen], &rule->charsdots[0], rule->dotslen * CHARSIZE);
-	dots.length = 2 * rule->dotslen;
-	if (!addRule(NULL, opcode, NULL, &dots, 0, 0, newRuleOffset, newRule, noback, nofor,
-				table))
-		return 0;
-	*doubleRule = *newRuleOffset;
-	return 1;
 }
 
 static int

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -141,8 +141,7 @@ lou_hyphenate(
 		const char *tableList, const widechar *inbuf, int inlen, char *hyphens, int mode);
 LIBLOUIS_API
 int EXPORT_CALL
-lou_dotsToChar(
-		const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode);
+lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length);
 LIBLOUIS_API
 int EXPORT_CALL
 lou_charToDots(const char *tableList, const widechar *inbuf, widechar *outbuf, int length,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3744,8 +3744,7 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 }
 
 int EXPORT_CALL
-lou_dotsToChar(
-		const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode) {
+lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length) {
 	const TranslationTableHeader *table;
 	int k;
 	widechar dots;

--- a/liblouis/maketable.c
+++ b/liblouis/maketable.c
@@ -299,6 +299,8 @@ find_matching_rules(widechar *text, int text_len, widechar *braille, int braille
 			case CTO_NoCross:
 				memset(data, '0', rule->charslen - 1);
 				debug("%s", data);
+			default:
+				break;
 			}
 			free(data_save);
 			return 1;
@@ -381,7 +383,7 @@ findRelevantRules(widechar *text, widechar **rules_str) {
 	TranslationTableCharacter *character;
 	TranslationTableRule *rule;
 	TranslationTableRule **rules;
-	int hash_len, k, l, m, n;
+	int hash_len, k, m, n;
 	for (text_len = 0; text[text_len]; text_len++)
 		;
 	for (rules_len = 0; rules_str[rules_len]; rules_len++)

--- a/liblouis/pattern.c
+++ b/liblouis/pattern.c
@@ -88,7 +88,7 @@ findCharOrDots(widechar c, int m) {
 }
 
 static int
-checkAttr(const widechar c, const TranslationTableCharacterAttributes a, int m) {
+checkAttr(const widechar c, const TranslationTableCharacterAttributes a) {
 	static widechar prevc = 0;
 	static TranslationTableCharacterAttributes preva = 0;
 	if (c != prevc) {
@@ -1322,7 +1322,7 @@ pattern_check_attrs(const widechar input_char, const widechar *expr_data) {
 	int attrs;
 
 	attrs = ((expr_data[0] << 16) | expr_data[1]) & ~(CTC_EndOfInput | CTC_EmpMatch);
-	if (!checkAttr(input_char, attrs, 0)) return 0;
+	if (!checkAttr(input_char, attrs)) return 0;
 	return 1;
 }
 

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -202,11 +202,11 @@ _lou_showDots(widechar const *dots, int length) {
 /**
  * Mapping between character attribute and textual representation
  */
-const static intCharTupple attributeMapping[] = {
+static const intCharTupple attributeMapping[] = {
 	{ CTC_Space, 's' }, { CTC_Letter, 'l' }, { CTC_Digit, 'd' }, { CTC_Punctuation, 'p' },
 	{ CTC_UpperCase, 'U' }, { CTC_LowerCase, 'u' }, { CTC_Math, 'm' }, { CTC_Sign, 'S' },
 	{ CTC_LitDigit, 'D' }, { CTC_Class1, 'w' }, { CTC_Class2, 'x' }, { CTC_Class3, 'y' },
-	{ CTC_Class4, 'z' }, 0,
+	{ CTC_Class4, 'z' }, { 0, 0 },
 };
 
 /**

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -294,7 +294,7 @@ parse_number(const char *number, char *name, int file_line) {
 }
 
 int *
-read_inPos(yaml_parser_t *parser, int wrdlen, int translen) {
+read_inPos(yaml_parser_t *parser, int translen) {
 	int *pos = malloc(sizeof(int) * translen);
 	int i = 0;
 	yaml_event_t event;
@@ -501,7 +501,7 @@ read_options(yaml_parser_t *parser, int wordLen, int translationLen, int *xfail,
 			*typeform = read_typeforms(parser, wordLen);
 		} else if (!strcmp(option_name, "inputPos")) {
 			yaml_event_delete(&event);
-			*inPos = read_inPos(parser, wordLen, translationLen);
+			*inPos = read_inPos(parser, translationLen);
 		} else if (!strcmp(option_name, "outputPos")) {
 			yaml_event_delete(&event);
 			*outPos = read_outPos(parser, wordLen, translationLen);
@@ -733,7 +733,8 @@ main(int argc, char *argv[]) {
 	// FIXME: problem with this is that
 	// LOUIS_TABLEPATH=$(top_srcdir)/tables,... does not work anymore because
 	// $(top_srcdir) == .. (not an absolute path)
-	chdir(dir_name);
+	if (chdir(dir_name))
+		error(EXIT_FAILURE, EIO, "Cannot change directory to %s", dir_name);
 
 	// register custom table resolver
 	lou_registerTableResolver(&customTableResolver);

--- a/tools/lou_tableinfo.c
+++ b/tools/lou_tableinfo.c
@@ -85,7 +85,6 @@ main(int argc, char **argv) {
 		fprintf(stderr, "Try `%s --help' for more information.\n", program_name);
 		exit(EXIT_FAILURE);
 	} else if (optind == argc - 1) {
-		const char *table = argv[optind];
 		fprintf(stderr, "Not supported yet\n");
 		exit(EXIT_FAILURE);
 	} else if (optind == argc - 2) {


### PR DESCRIPTION
Such as 

- -Wunused-parameter
- -Wunused-but-set-variable
- -Wunused-function
- -Wunused-result
- -Wunused-variable
- -Wold-style-declaration
- -Wmissing-braces
- -Wswitch

This PR is related but does not fix #322 

Also the second commit is controversial in that it actually changes the public API of liblouis just for the sake of fixing a warning.

