### PR TITLE
Fix warnings such as -Wunused-parameter, etc

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1413,8 +1413,7 @@ deallocateRuleNames(RuleName **ruleNames) {
 }
 
 static int
-compileSwapDots(FileInfo *nested, CharsString *source, CharsString *dest,
-		TranslationTableHeader *table) {
+compileSwapDots(FileInfo *nested, CharsString *source, CharsString *dest) {
 	int k = 0;
 	int kk = 0;
 	CharsString dotsSource;
@@ -1451,12 +1450,12 @@ compileSwap(FileInfo *nested, TranslationTableOpcode opcode, int *lastToken,
 	if (opcode == CTO_SwapCc || opcode == CTO_SwapCd) {
 		if (!parseChars(nested, &ruleChars, &matches)) return 0;
 	} else {
-		if (!compileSwapDots(nested, &matches, &ruleChars, *table)) return 0;
+		if (!compileSwapDots(nested, &matches, &ruleChars)) return 0;
 	}
 	if (opcode == CTO_SwapCc) {
 		if (!parseChars(nested, &ruleDots, &replacements)) return 0;
 	} else {
-		if (!compileSwapDots(nested, &replacements, &ruleDots, *table)) return 0;
+		if (!compileSwapDots(nested, &replacements, &ruleDots)) return 0;
 	}
 	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
 				noback, nofor, table))
@@ -4239,25 +4238,6 @@ compileString(const char *inString, CharacterClass **characterClasses,
 	nested.linelen = k;
 	return compileRule(&nested, characterClasses, characterClassAttribute, opcodeLengths,
 			newRuleOffset, newRule, ruleNames, table);
-}
-
-static int
-makeDoubleRule(TranslationTableOpcode opcode, TranslationTableOffset *singleRule,
-		TranslationTableOffset *doubleRule, TranslationTableOffset *newRuleOffset,
-		TranslationTableRule **newRule, int noback, int nofor,
-		TranslationTableHeader **table) {
-	CharsString dots;
-	TranslationTableRule *rule;
-	if (!*singleRule || *doubleRule) return 1;
-	rule = (TranslationTableRule *)&(*table)->ruleArea[*singleRule];
-	memcpy(dots.chars, &rule->charsdots[0], rule->dotslen * CHARSIZE);
-	memcpy(&dots.chars[rule->dotslen], &rule->charsdots[0], rule->dotslen * CHARSIZE);
-	dots.length = 2 * rule->dotslen;
-	if (!addRule(NULL, opcode, NULL, &dots, 0, 0, newRuleOffset, newRule, noback, nofor,
-				table))
-		return 0;
-	*doubleRule = *newRuleOffset;
-	return 1;
 }
 
 static int

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4242,19 +4242,10 @@ compileString(const char *inString, CharacterClass **characterClasses,
 
 static int
 setDefaults(TranslationTableHeader *table) {
-	//  makeDoubleRule (CTO_FirstWordItalRule,
-	//  &table->emphRules[emph1Rule][lastWordBeforeOffset],
-	//		  &table->emphRules[emph1Rule][firstWordOffset]);
 	if (!table->emphRules[emph1Rule][lenPhraseOffset])
 		table->emphRules[emph1Rule][lenPhraseOffset] = 4;
-	//  makeDoubleRule (CTO_FirstWordUnderRule,
-	//  &table->emphRules[emph2Rule][lastWordBeforeOffset],
-	//		  &table->emphRules[emph2Rule][firstWordOffset]);
 	if (!table->emphRules[emph2Rule][lenPhraseOffset])
 		table->emphRules[emph2Rule][lenPhraseOffset] = 4;
-	//  makeDoubleRule (CTO_FirstWordBoldRule,
-	//  &table->emphRules[emph3Rule][lastWordBeforeOffset],
-	//		  &table->emphRules[emph3Rule][firstWordOffset]);
 	if (!table->emphRules[emph3Rule][lenPhraseOffset])
 		table->emphRules[emph3Rule][lenPhraseOffset] = 4;
 	if (table->numPasses == 0) table->numPasses = 1;

--- a/liblouis/maketable.c
+++ b/liblouis/maketable.c
@@ -299,6 +299,8 @@ find_matching_rules(widechar *text, int text_len, widechar *braille, int braille
 			case CTO_NoCross:
 				memset(data, '0', rule->charslen - 1);
 				debug("%s", data);
+			default:
+				break;
 			}
 			free(data_save);
 			return 1;
@@ -381,7 +383,7 @@ findRelevantRules(widechar *text, widechar **rules_str) {
 	TranslationTableCharacter *character;
 	TranslationTableRule *rule;
 	TranslationTableRule **rules;
-	int hash_len, k, l, m, n;
+	int hash_len, k, m, n;
 	for (text_len = 0; text[text_len]; text_len++)
 		;
 	for (rules_len = 0; rules_str[rules_len]; rules_len++)

--- a/liblouis/pattern.c
+++ b/liblouis/pattern.c
@@ -88,7 +88,7 @@ findCharOrDots(widechar c, int m) {
 }
 
 static int
-checkAttr(const widechar c, const TranslationTableCharacterAttributes a, int m) {
+checkAttr(const widechar c, const TranslationTableCharacterAttributes a) {
 	static widechar prevc = 0;
 	static TranslationTableCharacterAttributes preva = 0;
 	if (c != prevc) {
@@ -1322,7 +1322,7 @@ pattern_check_attrs(const widechar input_char, const widechar *expr_data) {
 	int attrs;
 
 	attrs = ((expr_data[0] << 16) | expr_data[1]) & ~(CTC_EndOfInput | CTC_EmpMatch);
-	if (!checkAttr(input_char, attrs, 0)) return 0;
+	if (!checkAttr(input_char, attrs)) return 0;
 	return 1;
 }
 

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -202,11 +202,11 @@ _lou_showDots(widechar const *dots, int length) {
 /**
  * Mapping between character attribute and textual representation
  */
-const static intCharTupple attributeMapping[] = {
+static const intCharTupple attributeMapping[] = {
 	{ CTC_Space, 's' }, { CTC_Letter, 'l' }, { CTC_Digit, 'd' }, { CTC_Punctuation, 'p' },
 	{ CTC_UpperCase, 'U' }, { CTC_LowerCase, 'u' }, { CTC_Math, 'm' }, { CTC_Sign, 'S' },
 	{ CTC_LitDigit, 'D' }, { CTC_Class1, 'w' }, { CTC_Class2, 'x' }, { CTC_Class3, 'y' },
-	{ CTC_Class4, 'z' }, 0,
+	{ CTC_Class4, 'z' }, { 0, 0 },
 };
 
 /**

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -294,7 +294,7 @@ parse_number(const char *number, char *name, int file_line) {
 }
 
 int *
-read_inPos(yaml_parser_t *parser, int wrdlen, int translen) {
+read_inPos(yaml_parser_t *parser, int translen) {
 	int *pos = malloc(sizeof(int) * translen);
 	int i = 0;
 	yaml_event_t event;
@@ -501,7 +501,7 @@ read_options(yaml_parser_t *parser, int wordLen, int translationLen, int *xfail,
 			*typeform = read_typeforms(parser, wordLen);
 		} else if (!strcmp(option_name, "inputPos")) {
 			yaml_event_delete(&event);
-			*inPos = read_inPos(parser, wordLen, translationLen);
+			*inPos = read_inPos(parser, translationLen);
 		} else if (!strcmp(option_name, "outputPos")) {
 			yaml_event_delete(&event);
 			*outPos = read_outPos(parser, wordLen, translationLen);
@@ -733,7 +733,8 @@ main(int argc, char *argv[]) {
 	// FIXME: problem with this is that
 	// LOUIS_TABLEPATH=$(top_srcdir)/tables,... does not work anymore because
 	// $(top_srcdir) == .. (not an absolute path)
-	chdir(dir_name);
+	if (chdir(dir_name))
+		error(EXIT_FAILURE, EIO, "Cannot change directory to %s", dir_name);
 
 	// register custom table resolver
 	lou_registerTableResolver(&customTableResolver);

--- a/tools/lou_tableinfo.c
+++ b/tools/lou_tableinfo.c
@@ -85,6 +85,7 @@ main(int argc, char **argv) {
 		fprintf(stderr, "Try `%s --help' for more information.\n", program_name);
 		exit(EXIT_FAILURE);
 	} else if (optind == argc - 1) {
+		// const char *table = argv[optind];
 		fprintf(stderr, "Not supported yet\n");
 		exit(EXIT_FAILURE);
 	} else if (optind == argc - 2) {

--- a/tools/lou_tableinfo.c
+++ b/tools/lou_tableinfo.c
@@ -85,7 +85,6 @@ main(int argc, char **argv) {
 		fprintf(stderr, "Try `%s --help' for more information.\n", program_name);
 		exit(EXIT_FAILURE);
 	} else if (optind == argc - 1) {
-		const char *table = argv[optind];
 		fprintf(stderr, "Not supported yet\n");
 		exit(EXIT_FAILURE);
 	} else if (optind == argc - 2) {


### PR DESCRIPTION
-Wunused-parameter
-Wunused-but-set-variable
-Wunused-function
-Wunused-result
-Wunused-variable
-Wold-style-declaration
-Wmissing-braces
-Wswitch

This is related to #322 but doesn't actually fix any warnings that are
mentioned in there. It does however fix some warnings that are listed
in
https://www.freelists.org/post/liblouis-liblouisxml/liblouis-340-has-been-released,1