### PR TITLE
Remove the mode parameter from lou_dotsToChar

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -3246,8 +3246,7 @@ int lou_dotsToChar (
   const char *tableList,
   const widechar *inbuf,
   widechar *outbuf,
-  int length,
-  int mode)
+  int length)
 @end example
 
 This function takes a widechar string in @code{inbuf} consisting of dot 

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -141,8 +141,7 @@ lou_hyphenate(
 		const char *tableList, const widechar *inbuf, int inlen, char *hyphens, int mode);
 LIBLOUIS_API
 int EXPORT_CALL
-lou_dotsToChar(
-		const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode);
+lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length);
 LIBLOUIS_API
 int EXPORT_CALL
 lou_charToDots(const char *tableList, const widechar *inbuf, widechar *outbuf, int length,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3764,8 +3764,7 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 }
 
 int EXPORT_CALL
-lou_dotsToChar(
-		const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode) {
+lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length) {
 	const TranslationTableHeader *table;
 	int k;
 	widechar dots;


### PR DESCRIPTION
This fixes a -Wunused-parameter warning and basically makes the API
more honest, as it no longer pretend to do anything with the mode
param.

However is also changes the public API of liblouis, so I'm not sure we
should actully merge this change.

Related to #322