### PR TITLE
No longer mark = as deprecated

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,10 @@ issues]].
 *** Improved documentation
 - Extend the documentation on multipass opcodes. Thanks to Dave Mielke
   and Christian Egli.
+- Remove the deprecation note of the '=' dots operand. While there are
+  still problems with back-translation we will not remove support for
+  it. See also the discussion in the [[https://github.com/liblouis/liblouis/issues/500][github issue]].
+
 *** Major overhaul of the YAML test suite
 - Due to problems in the cursor position computation the YAML test
   suite was improved to support proper testing of cursor position also

--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ if test x"${MAKEINFO_FOUND}" = xyes
 then
   MAKEINFO_VERSION_REQ=5
   AC_MSG_CHECKING([for makeinfo version >= $MAKEINFO_VERSION_REQ])
-  MAKEINFO_VERSION=`makeinfo --version | sed -ne 's/^\(makeinfo\|texi2any\) .* \([[0-9]][[0-9]]*\)\.[[0-9]][[0-9]]*$/\2/p'`
+  MAKEINFO_VERSION=`makeinfo --version | sed -ne 's/^\(makeinfo\|texi2any\) .* \([[0-9]][[0-9]]*\)\.[[0-9]][[0-9]]*.*$/\2/p'`
   if test x$MAKEINFO_VERSION = x -o 0$MAKEINFO_VERSION -lt $MAKEINFO_VERSION_REQ
   then
     AC_MSG_RESULT([no])

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -1048,9 +1048,10 @@ The dots operand defines the braille representation for the characters
 operand. It may also be specified as an equals sign (@samp{=}). This
 means that the the default representation for each character
 (@pxref{Character-Definition Opcodes}) within the sequence is to be
-used. Note however that the @samp{=} shortcut for dot patterns is
-deprecated. Dot patterns should be written out. Otherwise
-back-translation may not be correct.
+used. Note however that the @samp{=} shortcut for dot patterns has a
+known bug@footnote{See
+@url{https://github.com/liblouis/liblouis/issues/500#issuecomment-365753137}.}
+that might cause problems when back-translating.
 
 In what follows the word @samp{characters} means a sequence of one or
 more consecutive letters between spaces and/or punctuation marks.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -123,6 +123,7 @@ dist_yaml_TESTS =				\
 	yaml/capsword_for_back.yaml		\
 	yaml/chr-us-g1_harness.yaml		\
 	yaml/compbrlAtCursor_with_equals.yaml	\
+	yaml/broken_equals_operand.yaml		\
 	yaml/da-dk-g08.yaml			\
 	yaml/da-dk-g16-dictionary_harness.yaml	\
 	yaml/da-dk-g16-lit.yaml			\

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -8,6 +8,7 @@ stEXTRA_DIST =					\
 	capsword_for_back.yaml			\
 	chr-us-g1_harness.yaml			\
 	compbrlAtCursor_with_equals.yaml	\
+	broken_equals_operand.yaml		\
 	da-dk-g08.yaml				\
 	da-dk-g16-dictionary_harness.yaml	\
 	da-dk-g16-lit.yaml			\

--- a/tests/yaml/broken_equals_operand.yaml
+++ b/tests/yaml/broken_equals_operand.yaml
@@ -1,0 +1,52 @@
+# See https://github.com/liblouis/liblouis/issues/500
+
+# The reason the `=` operand works most of the time is the fact that
+# most of the time, a given dot pattern will back-translate to its
+# original characters if no rules tell the back-translator otherwise.
+
+# It will not work when the "=" rule exists to circumvent another rule
+# that would also affect back-translation, e.g. if a table contains
+# the following rules:
+
+# always ooo 135-135
+# word foobar =
+
+# The dot pattern 124-135-135-12-1235 will back-translate to fooobar
+# as specified by the first rule.
+
+# Not a very practical example, I admit, but it demonstrates the
+# problem.
+
+# I think the = operand is originally a good idea, because it is a
+# clear way of saying that the string should be matched by the basic
+# dot pattern. If it were to work also for back-translation, perhaps
+# the = sign should be replaced internally by the corresponding dot
+# pattern at compile time.
+
+table: |
+  include tables/unicode.dis
+  include tables/latinLetterDef6Dots.uti
+  include tables/unicode-braille.utb
+  
+  always ooo 135-135
+  word foobar =
+
+tests:
+  -
+    - foobar
+    - ⠋⠕⠕⠃⠁⠗
+
+table: |
+  include tables/unicode.dis
+  include tables/latinLetterDef6Dots.uti
+  include tables/unicode-braille.utb
+  
+  always ooo 135-135
+  word foobar =
+
+flags: {testmode: backward}
+tests:
+  -
+    - ⠋⠕⠕⠃⠁⠗
+    - foobar
+    - xfail: See https://github.com/liblouis/liblouis/issues/500


### PR DESCRIPTION
- Fixed the documentation accordingly and 
- added Bues test case