### PR TITLE
Remove compbrl handling from for_updatePositions

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3422,8 +3422,7 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		case CTO_UpperCase:
 			/* Only needs special handling if not within compbrl and
 			 * the table defines a capital sign. */
-			if (!(mode & (compbrlAtCursor | compbrlLeftCursor) && pos >= compbrlStart &&
-						pos <= compbrlEnd) &&
+			if (!(mode & (compbrlAtCursor | compbrlLeftCursor)) &&
 					(transRule->dotslen == 1 &&
 							table->emphRules[capsRule][letterOffset])) {
 				putCharacter(curCharDef->lowercase, table, &pos, *input, output,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1363,14 +1363,7 @@ for_updatePositions(const widechar *outChars, int inLength, int outLength, int s
 		return 0;
 	memcpy(&output->chars[output->length], outChars, outLength * CHARSIZE);
 	if (!*cursorStatus) {
-		if ((mode & (compbrlAtCursor | compbrlLeftCursor))) {
-			if ((*pos >= compbrlStart) && (*pos < compbrlEnd)) {
-				*cursorStatus = 2;
-				return doCompTrans(compbrlStart, compbrlEnd, table, pos, mode, input,
-						output, posMapping, emphasisBuffer, transNoteBuffer, transRule,
-						cursorPosition, cursorStatus, compbrlStart, compbrlEnd);
-			}
-		} else if (*cursorPosition >= *pos && *cursorPosition < (*pos + inLength)) {
+		if (*cursorPosition >= *pos && *cursorPosition < (*pos + inLength)) {
 			*cursorPosition = output->length;
 			*cursorStatus = 1;
 		} else if (input.chars[*cursorPosition] == 0 &&

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3624,7 +3624,7 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 }
 
 int EXPORT_CALL
-lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length) {
+lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode) {
 	const TranslationTableHeader *table;
 	int k;
 	widechar dots;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3624,7 +3624,8 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 }
 
 int EXPORT_CALL
-lou_dotsToChar(const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode) {
+lou_dotsToChar(
+		const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode) {
 	const TranslationTableHeader *table;
 	int k;
 	widechar dots;


### PR DESCRIPTION
This code removes the dead code to handle `compbrl` from the `for_updatePositions` function as it is now handled 

- The first commit simply removes that code
- Some parameters that were used by the removed code are no longer needed. Hence the second commit removes the unused parameters in all involved functions
- The third commit removes a test that is now always true since the same condition is tested further up in the while loop

This PR fixes #502