### PR TITLE
fr-bfu-g2.ctb: backtranslation fixes about 'a', 'e' and 'y'

### DIFF
--- a/tables/fr-bfu-g2.ctb
+++ b/tables/fr-bfu-g2.ctb
@@ -721,12 +721,10 @@ word (la 236-123-1
 ### 2. Mots représentés par un seul symbole
 ###
 
+word a 1
 word A 1
 word à 12356
 word À 12356
-word E 15
-word Y 13456
-
 word ai 34
 word au 13
 word aux 13-1346
@@ -799,6 +797,7 @@ word uns 136-234
 word vous 1236
 word vous) 1236-1256-356
 word y 13456
+word Y 13456
 
 before apost sufword c 14
 before apost sufword d 145
@@ -1317,6 +1316,8 @@ word douloureux		145-123-1346
 word doute		145-1256
 word doutes		145-1256-234
 word duquel		145-136-12345-123
+word e 15
+word E 15
 prfword effectif		15-124-124
 prfword effectifs		15-124-124-234
 prfword effective		15-124-1236

--- a/tests/braille-specs/fr-bfu-g2.yaml
+++ b/tests/braille-specs/fr-bfu-g2.yaml
@@ -1105,6 +1105,12 @@ table:
   __assert-match: fr-bfu-g2.ctb
 flags: {testmode: backward}
 tests:
+    - - Isolated letters (lower)
+      - ⠁ ⠰⠃ ⠰⠉ ⠰⠙ ⠑ ⠰⠋ ⠰⠛ ⠰⠓ ⠰⠊ ⠰⠚ ⠰⠅ ⠰⠇ ⠰⠍ ⠰⠝ ⠰⠕ ⠰⠏ ⠰⠟ ⠰⠗ ⠰⠎ ⠰⠞ ⠰⠥ ⠰⠧ ⠰⠺ ⠰⠭ ⠽ ⠰⠵ ⠷ ⠰⠯
+      - a b c d e f g h i j k l m n o p q r s t u v w x y z à ç
+    - - Isolated letters (upper)
+      - ⠨⠁ ⠰⠨⠃ ⠰⠨⠉ ⠰⠨⠙ ⠨⠑ ⠰⠨⠋ ⠰⠨⠛ ⠰⠨⠓ ⠰⠨⠊ ⠰⠨⠚ ⠰⠨⠅ ⠰⠨⠇ ⠰⠨⠍ ⠰⠨⠝ ⠰⠨⠕ ⠰⠨⠏ ⠰⠨⠟ ⠰⠨⠗ ⠰⠨⠎ ⠰⠨⠞ ⠰⠨⠥ ⠰⠨⠧ ⠰⠨⠺ ⠰⠨⠭ ⠨⠽ ⠰⠨⠵ ⠨⠷ ⠰⠨⠯
+      - A B C D E F G H I J K L M N O P Q R S T U V W X Y Z À Ç
     - ["⠨⠁⠠⠡ ⠰⠃⠠⠱ ⠠⠡⠣⠼⠼⠨⠺ ⠨⠁⠠⠡⠱⠫⠫ ⠰⠨⠉⠠⠣⠨⠊",
        "A1 b5 1200W A1566 C2I"]
     - ["⠰⠍⠲⠰⠞⠲⠰⠎⠲", "m.t.s."]
@@ -2250,6 +2256,7 @@ tests:
     - ["⠤⠫", "complet"]
     - ["⠤⠫⠍", "complément"]
     - ["⠤⠫⠍⠗", "complémentaire"]
+
     - ["¨bj! ¨bj?", "Bonjour! Bonjour?"]
     - ["⠠⠷⠦⠡⠖⠡⠴⠤⠦⠩⠹⠖⠡⠹⠴⠾", "[(1+1)-(34+14)]"]
     - ["⠠⠦⠡⠖⠡⠴⠈⠣⠤⠣⠌⠣", "(1+1)^2-2/2"]
@@ -2261,3 +2268,4 @@ tests:
       - bien tyrol... tournais. tournais... aligator. aligator... transistor...
     - - l c⠰ û u *s)umê. c⠰)
       - le cor est un instrument. cor)
+    - ["⠨⠊ ⠽ ⠁", "Il y a"]


### PR DESCRIPTION
This PR fixes some backtranslation errors about 'a', 'e' and 'y' isolated in french grade 2 table.
Before: "⠁ ⠑ ⠽" -> "A E Y" instead of "a e y". It was necessary to escape them with letsign ("⠰⠁ ⠰⠑ ⠰⠽").
It also adds some yaml tests for that.