### PR TITLE
Ensure that inputLength equals actualLength

### DIFF
--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -129,7 +129,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 			outputPos = malloc(sizeof(int) * inlen);
 		}
 		actualInlen = inlen;
-		for (int k = 0; k < 3; k++) {
+		for (int k = 1; k <= 3; k++) {
 			if (direction == 1) {
 				funcStatus = lou_backTranslate(tableList, inbuf, &actualInlen, outbuf,
 						&outlen, typeformbuf, NULL, outputPos, inputPos, &cursorPos,
@@ -146,18 +146,21 @@ check_base(const char *tableList, const char *input, const char *expected,
 			}
 			if (in.max_outlen >= 0 || inlen == actualInlen) {
 				break;
-			} else {
+			} else if (k < 3) {
 				// Hm, something is not quite right. Try again with a larger outbuf
 				free(outbuf);
-				int old_outlen = inlen * outlen_multiplier * k;
-				int new_outlen = inlen * outlen_multiplier * (k + 1);
-				outbuf = malloc(sizeof(widechar) * new_outlen);
+				outlen = inlen * outlen_multiplier * (k + 1);
+				outbuf = malloc(sizeof(widechar) * outlen);
+				if (expected_inputPos) {
+					free(inputPos);
+					inputPos = malloc(sizeof(int) * outlen);
+				}
 				fprintf(stderr,
 						"Warning: For %s: returned inlen (%d) differs from passed inlen "
 						"(%d) "
 						"using outbuf of size %d. Trying again with bigger outbuf "
 						"(%d).\n",
-						input, actualInlen, inlen, old_outlen, new_outlen);
+						input, actualInlen, inlen, inlen * outlen_multiplier * k, outlen);
 				actualInlen = inlen;
 			}
 		}

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -434,7 +434,7 @@ check_hyphenation(const char *tableList, const char *str, const char *expected) 
 		goto fail;
 	}
 
-	if (strlen(expected) != (int)hyphenatedlen ||
+	if (strlen(expected) != hyphenatedlen ||
 			strncmp(expected, (const char *)hyphenated, hyphenatedlen)) {
 		fprintf(stderr, "Input:    '%s'\n", str);
 		fprintf(stderr, "Expected: '%s'\n", expected);

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -247,7 +247,8 @@ check_base(const char *tableList, const char *input, const char *expected,
 		}
 		if (inlen != actualInlen) {
 			fprintf(stderr,
-					"Input length is not the same before as after the translation:\n");
+					"Unexpected error happened: input length is not the same before as "
+					"after the translation:\n");
 			fprintf(stderr, "Before: %d After: %d \n", inlen, actualInlen);
 			retval = 1;
 		}

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -144,7 +144,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 				retval = 1;
 				goto fail;
 			}
-			if (inlen == actualInlen) {
+			if (in.max_outlen >= 0 || inlen == actualInlen) {
 				break;
 			} else {
 				// Hm, something is not quite right. Try again with a larger outbuf
@@ -245,11 +245,17 @@ check_base(const char *tableList, const char *input, const char *expected,
 					in.expected_cursorPos, cursorPos);
 			retval = 1;
 		}
-		if (inlen != actualInlen) {
+		if (in.max_outlen < 0 && inlen != actualInlen) {
 			fprintf(stderr,
 					"Unexpected error happened: input length is not the same before as "
 					"after the translation:\n");
 			fprintf(stderr, "Before: %d After: %d \n", inlen, actualInlen);
+			retval = 1;
+		} else if (actualInlen > inlen) {
+			fprintf(stderr,
+					"Unexpected error happened: returned input length (%d) exceeds "
+					"total input length (%d)\n",
+					actualInlen, inlen);
 			retval = 1;
 		}
 

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -245,7 +245,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 					in.expected_cursorPos, cursorPos);
 			retval = 1;
 		}
-		if (in.max_outlen < 0 && inlen != actualInlen) {
+		if (in.max_outlen < 0 && inlen != actualInlen && direction != 1) {
 			fprintf(stderr,
 					"Unexpected error happened: input length is not the same before as "
 					"after the translation:\n");

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -91,6 +91,11 @@ check_base(const char *tableList, const char *input, const char *expected,
 		fprintf(stderr, "maxOutputLength not supported with testmode 'bothDirections'\n");
 		return 1;
 	}
+	if (in.real_inlen >= 0 && in.max_outlen < 0) {
+		fprintf(stderr,
+				"realInputLength not supported when maxOutputLength is not specified\n");
+		return 1;
+	}
 	while (1) {
 		widechar *inbuf, *outbuf, *expectedbuf;
 		int inlen = strlen(input);
@@ -121,6 +126,13 @@ check_base(const char *tableList, const char *input, const char *expected,
 			fprintf(stderr, "Cannot parse input string.\n");
 			retval = 1;
 			goto fail;
+		}
+		if (in.real_inlen > inlen) {
+			fprintf(stderr,
+					"expected realInputLength (%d) may not exceed total input length "
+					"(%d)\n",
+					in.real_inlen, inlen);
+			return 1;
 		}
 		if (expected_inputPos) {
 			inputPos = malloc(sizeof(int) * outlen);
@@ -259,6 +271,10 @@ check_base(const char *tableList, const char *input, const char *expected,
 					"Unexpected error happened: returned input length (%d) exceeds "
 					"total input length (%d)\n",
 					actualInlen, inlen);
+			retval = 1;
+		} else if (in.real_inlen >= 0 && in.real_inlen != actualInlen) {
+			fprintf(stderr, "Real input length failure:\n");
+			fprintf(stderr, "Expected: %d, received: %d\n", in.real_inlen, actualInlen);
 			retval = 1;
 		}
 

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -94,7 +94,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 	while (1) {
 		widechar *inbuf, *outbuf, *expectedbuf;
 		int inlen = strlen(input);
-		int actualInlen = inlen;;
+		int actualInlen;
 		const int outlen_multiplier = 4 + sizeof(widechar) * 2;
 		int outlen = inlen * outlen_multiplier;
 		int expectedlen = strlen(expected);
@@ -128,6 +128,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 		if (expected_outputPos) {
 			outputPos = malloc(sizeof(int) * inlen);
 		}
+		actualInlen = inlen;
 		for (int k = 0; k < 3; k++) {
 			if (direction == 1) {
 				funcStatus = lou_backTranslate(tableList, inbuf, &actualInlen, outbuf,

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -40,6 +40,7 @@ typedef struct {
 	const int *expected_outputPos;
 	const int expected_cursorPos;
 	const int max_outlen;
+	const int real_inlen;
 } optional_test_params;
 
 /** Check a translation
@@ -62,7 +63,10 @@ typedef struct {
  * translation. If not specified it defaults to -1.
  * @param max_outlen (optional) the maximum length of the output. If not specified it
  * defaults to -1.
-  * @param direction (optional) 0 for forward translation, 1 for backwards translation,
+ * @param real_inlen (optional) the length of the portion of the input corresponding to
+ * the returned output. Defaults to -1. May only be specified if max_outlen is also
+ * specified, and must be smaller than or equal to the total length of the input.
+ * @param direction (optional) 0 for forward translation, 1 for backwards translation,
  * 2 for both directions. If
 * not specified it defaults to 0.
  * @param diagnostics (optional) Print diagnostic output on failure if diagnostics is not
@@ -83,6 +87,7 @@ typedef struct {
 												.expected_inputPos = NULL,       \
 												.expected_outputPos = NULL,      \
 												.max_outlen = -1,                \
+												.real_inlen = -1,                \
 												.mode = 0,                       \
 												.direction = 0,                  \
 												.diagnostics = 1,                \


### PR DESCRIPTION
If not try a few more times with a larger output buffer

Fixes #495

AFAICT this implements what is asked for in the issue. However due to this change the test suite no longer passes. Is this a problem in this patch or in the test suite?