### PR TITLE
Fix leaks when using default table resolver

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -147,6 +147,9 @@ static short gOpcodeLengths[CTO_None] = { 0 };
 static void
 compileError(FileInfo *nested, char *format, ...);
 
+static void
+free_tablefiles(char **tables);
+
 static int
 getAChar(FileInfo *nested) {
 	/* Read a big endian, little endian or ASCII 8 file and convert it to
@@ -4460,7 +4463,11 @@ copyStringArray(char **array) {
 
 char **EXPORT_CALL
 _lou_resolveTable(const char *tableList, const char *base) {
-	return copyStringArray((*tableResolver)(tableList, base));
+	char **tableFiles = (*tableResolver)(tableList, base);
+	char **result = copyStringArray(tableFiles);
+	if (tableResolver == &_lou_defaultTableResolver)
+		free_tablefiles(tableFiles);
+	return result;
 }
 
 /**


### PR DESCRIPTION
_lou_resolveTable() should clean up the list of resolved tables returned from the default resolver, since a copy is returned to caller.