### PR TITLE
Make equals operand work with back-translation

### DIFF
--- a/tests/yaml/broken_equals_operand.yaml
+++ b/tests/yaml/broken_equals_operand.yaml
@@ -25,24 +25,19 @@
 
 table: |
   include tables/unicode.dis
+  punctuation ; 56
   include tables/latinLetterDef6Dots.uti
+  uplow Óó 56-135,56-135
   include tables/unicode-braille.utb
   
   always ooo 135-135
   word foobar =
+  word fóóbar =
 
 tests:
-  -
-    - foobar
+  - - foobar
     - ⠋⠕⠕⠃⠁⠗
-
-table: |
-  include tables/unicode.dis
-  include tables/latinLetterDef6Dots.uti
-  include tables/unicode-braille.utb
-  
-  always ooo 135-135
-  word foobar =
+  - ["fóóbar", "⠋⠰⠕⠰⠕⠃⠁⠗"]
 
 flags: {testmode: backward}
 tests:


### PR DESCRIPTION
How does this currently work in forward trans with chars that take up two or more Braille cells? The function getdotsforchar() only returns one widechar and seems to assume that there is a single cell representation for each char, which is false for most or all literary tables.