### PR TITLE
Enable automake to generate dependencies for libbrlcheck.la

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -14,7 +14,7 @@ lou_compare_CPPFLAGS = $(AM_CPPFLAGS) -w
 LDADD =							\
 	$(top_builddir)/liblouis/liblouis.la		\
 	$(top_builddir)/tools/gnulib/libgnutools.la	\
-	$(top_builddir)/tools/libbrlcheck.la		\
+	libbrlcheck.la		\
 	$(LTLIBINTL)
 
 # libbrlcheck is a convenience library that contains functionality to


### PR DESCRIPTION
This fixes build against automake 1.16.