### PR TITLE
Patch Python bindings to support both 16 and 32 bit widechars, add more functions from the liblouis api

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -3449,7 +3449,7 @@ void lou_registerLogCallback (
 @end example
 
 This function can be used to register a custom logging callback. The
-callback must take a single argument, the message string. By default
+callback must take two arguments, the log level and the message string. By default
 log messages are printed to stderr, or if a filename was specified
 with @code{lou_logFile} then messages are logged to that
 file. @code{lou_registerLogCallback} overrides the default

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -193,7 +193,7 @@ void EXPORT_CALL
 lou_logFile(const char *filename);
 
 /**
- * Read a character from a file, whether big-encian, little-endian or ASCII8
+ * Read a character from a file, whether big-endian, little-endian or ASCII8
  *
  * and return it as an integer. EOF at end of file. Mode = 1 on first
  * call, any other value thereafter

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -33,6 +33,7 @@ function for information about how liblouis searches for these tables.
 @author: Eitan Isaacson <eitan@ascender.com>
 @author: Michael Whapples <mwhapples@aim.com>
 @author: Davy Kager <mail@davykager.nl>
+@author: Leonard de Ruijter (Babbage B.V.) <alderuijter@gmail.com>
 """
 
 from ctypes import *
@@ -49,20 +50,11 @@ def _createTypeformbuf(length, typeform=None):
     """Creates a typeform buffer for liblouis calls"""
     return (c_ushort*length)(*typeform) if typeform else (c_ushort*length)()
 
-createStr = None
+createEncodedByeString = None
 if sys.version_info[0] == 2:
-    createStr = lambda x: unicode(x)
+    createEncodedByeString = lambda x: unicode(x).encode(conversionEncoding)
 else:
-    createStr = lambda x: str(x)
-
-#{ Module Configuration
-#: Specifies the number by which the input length should be multiplied
-#: to calculate the maximum output length.
-#: @type: int
-# This default will handle the case where every input character is
-# undefined in the translation table.
-outlenMultiplier = 4 + sizeof(c_wchar) * 2
-#}
+    createEncodedByeString = lambda x: str(x).encode(conversionEncoding)
 
 try:
     # Native win32
@@ -79,31 +71,48 @@ liblouis.lou_version.restype = c_char_p
 liblouis.lou_charSize.restype = c_int
 
 liblouis.lou_translateString.argtypes = (
-    c_char_p, c_wchar_p, POINTER(c_int), c_wchar_p, 
+    c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char), 
          POINTER(c_int), POINTER(c_ushort), POINTER(c_char), c_int)
 
 liblouis.lou_translate.argtypes = (
-    c_char_p, c_wchar_p, POINTER(c_int), c_wchar_p, 
+    c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char), 
          POINTER(c_int), POINTER(c_ushort), POINTER(c_char), 
          POINTER(c_int), POINTER(c_int), POINTER(c_int), c_int)
 
 liblouis.lou_backTranslateString.argtypes = (
-         c_char_p, c_wchar_p, POINTER(c_int), c_wchar_p,
+         c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char),
          POINTER(c_int), POINTER(c_ushort), POINTER(c_char), c_int)
 
 liblouis.lou_backTranslate.argtypes = (
-         c_char_p, c_wchar_p, POINTER(c_int), c_wchar_p, POINTER(c_int),
+         c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char), POINTER(c_int),
          POINTER(c_ushort), POINTER(c_char), POINTER(c_int), POINTER(c_int),
          POINTER(c_int), c_int)
 
 liblouis.lou_hyphenate.argtypes = (
-         c_char_p, c_wchar_p, c_int, POINTER(c_char), c_int)
+         c_char_p, POINTER(c_char), c_int, POINTER(c_char), c_int)
 
 liblouis.lou_checkTable.argtypes = (c_char_p,)
 
 liblouis.lou_compileString.argtypes = (c_char_p, c_char_p)
 
 liblouis.lou_getTypeformForEmphClass.argtypes = (c_char_p, c_char_p)
+
+#{ Module Configuration
+#: Specifies the charSize (in bytes) used by liblouis.
+#: This is fetched once using L{liblouis.lou_charSize}.
+#: Call it directly, since L{charSize} is not yet defined.
+#: @type: int
+wideCharBytes = liblouis.lou_charSize()
+#: Specifies the number by which the input length should be multiplied
+#: to calculate the maximum output length.
+#: @type: int
+# This default will handle the case where every input character is
+# undefined in the translation table.
+outlenMultiplier = 4 + wideCharBytes * 2
+#: Specifies the encoding to use when converting from byte strings to unicode strings.
+#: @type: str
+conversionEncoding = "utf_%d_le" % (wideCharBytes * 8)
+#}
 
 def version():
     """Obtain version information for liblouis.
@@ -142,10 +151,10 @@ def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     @see: lou_translate in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createStr(inbuf)
-    inlen = c_int(len(inbuf))
+    inbuf = createEncodedByeString(inbuf)
+    inlen = c_int(len(inbuf)/wideCharBytes)
     outlen = c_int(inlen.value*outlenMultiplier)
-    outbuf = create_unicode_buffer(outlen.value)
+    outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
     if typeform:
         typeformbuf = _createTypeformbuf(outlen.value, typeform)
@@ -158,7 +167,7 @@ def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
         raise RuntimeError("Can't translate: tables %s, inbuf %s, typeform %s, cursorPos %s, mode %s"%(tableList, inbuf, typeform, cursorPos, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.value, inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
 
 def translateString(tableList, inbuf, typeform=None, mode=0):
     """Translate a string of characters.
@@ -177,10 +186,10 @@ def translateString(tableList, inbuf, typeform=None, mode=0):
     @see: lou_translateString in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createStr(inbuf)
-    inlen = c_int(len(inbuf))
+    inbuf = createEncodedByeString(inbuf)
+    inlen = c_int(len(inbuf)/wideCharBytes)
     outlen = c_int(inlen.value*outlenMultiplier)
-    outbuf = create_unicode_buffer(outlen.value)
+    outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
     if typeform:
         typeformbuf = _createTypeformbuf(outlen.value, typeform)
@@ -190,7 +199,7 @@ def translateString(tableList, inbuf, typeform=None, mode=0):
         raise RuntimeError("Can't translate: tables %s, inbuf %s, typeform %s, mode %s"%(tableList, inbuf, typeform, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.value
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding)
 
 def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     """Back translates a string of characters, providing position information.
@@ -213,10 +222,10 @@ def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     @see: lou_backTranslate in the liblouis documentation.
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createStr(inbuf)
-    inlen = c_int(len(inbuf))
+    inbuf = createEncodedByeString(inbuf)
+    inlen = c_int(len(inbuf)/wideCharBytes)
     outlen = c_int(inlen.value * outlenMultiplier)
-    outbuf = create_unicode_buffer(outlen.value)
+    outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
     if isinstance(typeform, list):
         typeformbuf = _createTypeformbuf(outlen.value)
@@ -229,7 +238,7 @@ def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
         raise RuntimeError("Can't back translate: tables %s, inbuf %s, typeform %s, cursorPos %d, mode %d"%(tableList, inbuf, typeform, cursorPos, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.value, inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
 
 def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     """Back translate from Braille.
@@ -248,10 +257,10 @@ def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     @see: lou_backTranslateString in the liblouis documentation.
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createStr(inbuf)
-    inlen = c_int(len(inbuf))
+    inbuf = createEncodedByeString(inbuf)
+    inlen = c_int(len(inbuf)/wideCharBytes)
     outlen = c_int(inlen.value * outlenMultiplier)
-    outbuf = create_unicode_buffer(outlen.value)
+    outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
     if isinstance(typeform, list):
         typeformbuf = _createTypeformbuf(outlen.value)
@@ -260,7 +269,7 @@ def backTranslateString(tableList, inbuf, typeform=None, mode=0):
         raise RuntimeError("Can't back translate: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.value
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding)
 
 def hyphenate(tableList, inbuf, mode=0):
     """Get information for hyphenation.
@@ -281,8 +290,8 @@ def hyphenate(tableList, inbuf, mode=0):
     @see: lou_hyphenate in the liblouis documentation.
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createStr(inbuf)
-    inlen = c_int(len(inbuf))
+    inbuf = createEncodedByeString(inbuf)
+    inlen = c_int(len(inbuf)/wideCharBytes)
     hyphen_string = create_string_buffer(inlen.value + 1) 
     if not liblouis.lou_hyphenate(tablesString, inbuf, inlen, hyphen_string, mode):
         raise RuntimeError("Can't hyphenate: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
@@ -353,11 +362,6 @@ ucBrl = 64
 noUndefinedDots = 128
 partialTrans = 256
 #}
-
-if charSize() == 2 and sys.maxunicode != 65535:
-    raise Exception("mismatch in Unicode width: liblouis is 2 and python isn't")
-elif charSize() == 4 and sys.maxunicode != 1114111:
-    raise Exception("mismatch in Unicode width: liblouis is 4 and python isn't")
 
 if __name__ == '__main__':
     # Just some common tests.

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -51,7 +51,7 @@ def _createTypeformbuf(length, typeform=None):
     return (c_ushort*length)(*typeform) if typeform else (c_ushort*length)()
 
 createEncodedByeString = None
-if sys.version_info[0] == 2:
+if sys.version_info.major == 2:
     createEncodedByeString = lambda x: unicode(x).encode(conversionEncoding)
 else: # sys.version_info[0] == 3
     createEncodedByeString = lambda x: str(x).encode(conversionEncoding)

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -152,7 +152,7 @@ def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     """
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByeString(inbuf)
-    inlen = c_int(len(inbuf)/wideCharBytes)
+    inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value*outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
@@ -187,7 +187,7 @@ def translateString(tableList, inbuf, typeform=None, mode=0):
     """
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByeString(inbuf)
-    inlen = c_int(len(inbuf)/wideCharBytes)
+    inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value*outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
@@ -223,7 +223,7 @@ def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     """
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByeString(inbuf)
-    inlen = c_int(len(inbuf)/wideCharBytes)
+    inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value * outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
@@ -258,7 +258,7 @@ def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     """
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByeString(inbuf)
-    inlen = c_int(len(inbuf)/wideCharBytes)
+    inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value * outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
@@ -291,7 +291,7 @@ def hyphenate(tableList, inbuf, mode=0):
     """
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByeString(inbuf)
-    inlen = c_int(len(inbuf)/wideCharBytes)
+    inlen = c_int(len(inbuf) // wideCharBytes)
     hyphen_string = create_string_buffer(inlen.value + 1) 
     if not liblouis.lou_hyphenate(tablesString, inbuf, inlen, hyphen_string, mode):
         raise RuntimeError("Can't hyphenate: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -18,6 +18,11 @@
 # License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
 # 
 
+from __future__ import unicode_literals
+from ctypes import *
+import atexit
+import sys
+
 """Liblouis Python ctypes bindings
 These bindings allow you to use the liblouis braille translator and back-translator library from within Python.
 This documentation is only a Python helper.
@@ -36,11 +41,6 @@ function for information about how liblouis searches for these tables.
 @author: Leonard de Ruijter (Babbage B.V.) <alderuijter@gmail.com>
 """
 
-from ctypes import *
-import struct
-import atexit
-import sys
-
 # Some general utility functions
 def _createTablesString(tablesList):
     """Creates a tables string for liblouis calls"""
@@ -53,15 +53,17 @@ def _createTypeformbuf(length, typeform=None):
 createEncodedByeString = None
 if sys.version_info[0] == 2:
     createEncodedByeString = lambda x: unicode(x).encode(conversionEncoding)
-else:
+else: # sys.version_info[0] == 3
     createEncodedByeString = lambda x: str(x).encode(conversionEncoding)
 
 try:
     # Native win32
     _loader = windll
+    _functype = WINFUNCTYPE
 except NameError:
     # Unix/Cygwin
     _loader = cdll
+    _functype = CFUNCTYPE
 liblouis = _loader["###LIBLOUIS_SONAME###"]
 
 atexit.register(liblouis.lou_free)
@@ -96,6 +98,24 @@ liblouis.lou_checkTable.argtypes = (c_char_p,)
 liblouis.lou_compileString.argtypes = (c_char_p, c_char_p)
 
 liblouis.lou_getTypeformForEmphClass.argtypes = (c_char_p, c_char_p)
+
+liblouis.lou_dotsToChar.argtypes = (
+    c_char_p, POINTER(c_char), POINTER(c_char), 
+         c_int, c_int)
+
+liblouis.lou_charToDots.argtypes = (
+    c_char_p, POINTER(c_char), POINTER(c_char), 
+         c_int, c_int)
+
+liblouis.lou_readCharFromFile.argtypes = (c_char_p, POINTER(c_int))
+
+logcallback = _functype(None, c_int, c_char_p)
+
+liblouis.lou_registerLogCallback.restype = None
+liblouis.lou_registerLogCallback.argtypes = (logcallback,)
+
+liblouis.lou_setLogLevel.restype = None
+liblouis.lou_setLogLevel.argtypes = (c_int,)
 
 #{ Module Configuration
 #: Specifies the charSize (in bytes) used by liblouis.
@@ -336,11 +356,78 @@ def getTypeformForEmphClass(tableList, emphClass):
     tablesString = _createTablesString(tableList)
     return liblouis.lou_getTypeformForEmphClass(tablesString, emphClass)
 
+def dotsToChar(tableList, inbuf):
+    """"Convert a string of dot patterns to a string of characters according to the specifications in tableList.
+    @param tableList: A list of translation tables.
+    @type tableList: list of str
+    @param inbuf: a string of dot patterns, either in liblouis format or Unicode braille.
+    @type inbuf: str
+    @raise RuntimeError: If a complete conversion could not be done.
+    @see: lou_dotsToChar in the liblouis documentation
+    """
+    tablesString = _createTablesString(tableList)
+    inbuf = createEncodedByeString(inbuf)
+    length = c_int(len(inbuf) // wideCharBytes)
+    outbuf = create_string_buffer(length.value * wideCharBytes)
+    if not liblouis.lou_dotsToChar(tablesString, inbuf, outbuf, length, 0):
+        raise RuntimeError("Can't convert dots to char: tables %s, inbuf %s"%(tableList, inbuf))
+    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding)
+
+def charToDots(tableList, inbuf, mode=0):
+    """"Convert a string of characterss to a string of dot patterns according to the specifications in tableList.
+    @param tableList: A list of translation tables.
+    @type tableList: list of str
+    @param inbuf: a string of characters.
+    @type inbuf: str
+    @param mode: The translation mode; add multiple values for a combined mode.
+    @type mode: int
+    @raise RuntimeError: If a complete conversion could not be done.
+    @see: lou_charToDOts in the liblouis documentation
+    """
+    tablesString = _createTablesString(tableList)
+    inbuf = createEncodedByeString(inbuf)
+    length = c_int(len(inbuf) // wideCharBytes)
+    outbuf = create_string_buffer(length.value * wideCharBytes)
+    if not liblouis.lou_charToDots(tablesString, inbuf, outbuf, length, mode):
+        raise RuntimeError("Can't convert char to dots: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
+    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding)
+
+def registerLogCallback(logcallback):
+    """Register logging callbacks.
+    Set to C{None} for default callback.
+    @param logcallback: The callback to use.
+        The callback must take two arguments:
+        @param level: The log level on which a message is logged.
+        @type level: int
+        @param message: The logged message.
+            Note that the callback should provide its own ASCII decoding routine.
+        @type message: bytes
+
+        Example callback:
+
+        @louis.logcallback
+        def incomingLouisLog(level, message):
+            print("Message %s logged at level %d" % (message.decode("ASCII"), level))
+
+    @type logcallback: L{logcallback}
+    """
+    return liblouis.lou_registerLogCallback(logcallback)
+
+def setLogLevel(level):
+	"""Set the level for logging callback to be called at.
+	@param level: one of the C{LOG_*} constants.
+	@type level: int
+	@raise ValueError: If an invalid log level is provided.
+	"""
+	if level not in logLevels:
+		raise ValueError("Level %d is an invalid log level"%level)
+	return liblouis.lou_setLogLevel(level)
+
 #{ Typeforms
 plain_text = 0x0000
-italic = 0x0001       # emph_1
-underline = 0x0002    # emph_2
-bold = 0x0004         # emph_3
+emph_1 = comp_emph_1 = italic = 0x0001
+emph_2 = comp_emph_2 = underline = 0x0002
+emph_3 = comp_emph_3 = bold = 0x0004
 emph_4 = 0x0008
 emph_5 = 0x0010
 emph_6 = 0x0020
@@ -362,6 +449,18 @@ ucBrl = 64
 noUndefinedDots = 128
 partialTrans = 256
 #}
+
+#{ logLevels
+LOG_ALL = 0
+LOG_DEBUG = 10000
+LOG_INFO = 20000
+LOG_WARN = 30000
+LOG_ERROR = 40000
+LOG_FATAL = 50000
+LOG_OFF = 60000
+#}
+
+logLevels = (LOG_ALL, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL, LOG_OFF)
 
 if __name__ == '__main__':
     # Just some common tests.

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -18,11 +18,6 @@
 # License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
 # 
 
-from __future__ import unicode_literals
-from ctypes import *
-import atexit
-import sys
-
 """Liblouis Python ctypes bindings
 These bindings allow you to use the liblouis braille translator and back-translator library from within Python.
 This documentation is only a Python helper.
@@ -40,6 +35,11 @@ function for information about how liblouis searches for these tables.
 @author: Davy Kager <mail@davykager.nl>
 @author: Leonard de Ruijter (Babbage B.V.) <alderuijter@gmail.com>
 """
+
+from __future__ import unicode_literals
+from ctypes import *
+import atexit
+import sys
 
 # Some general utility functions
 def _createTablesString(tablesList):
@@ -106,8 +106,6 @@ liblouis.lou_dotsToChar.argtypes = (
 liblouis.lou_charToDots.argtypes = (
     c_char_p, POINTER(c_char), POINTER(c_char), 
          c_int, c_int)
-
-liblouis.lou_readCharFromFile.argtypes = (c_char_p, POINTER(c_int))
 
 logcallback = _functype(None, c_int, c_char_p)
 


### PR DESCRIPTION
Fixes #187 
Fixes #55
Related to https://github.com/nvaccess/nvda/issues/6695

The Python bindings do not yet support wide characters. This pr fixes this, while also removing the exception raising in case python and liblouis char sizes differ.

Implementation strategy based on ideas proposed by @jcsteh in https://github.com/nvaccess/nvda/issues/6695#issuecomment-320538695

1. The Python bindings need to know the number of bits used for widechar (16 or 32) by the compiled liblouis. This is accomplished by once calling lou_charSize when initializing the module, saving the value to wideCharBytes
2. Use utf_32_le for 32 bit widechars, and utf_16_le for 16 bit widechars.
3. Tell ctypes to use c_char_p instead of c_wchar_p so that we get raw bytes. use POINTER(c_char) instead of c_char_p. c_char_p is meant for null terminated strings, and we really don't want these strings to be single null terminated strings 😊
4. When passing unicode strings to liblouis, first encode them using the encoding from 2.
5. After obtaining unicode strings from liblouis, decode them.

### Added functions
Additionally the following functions have been added to the wrapper

* dotsToChar
* charToDots
* setLogLevel
* registerLogCallback

### Testing performed
Created an NVDA build from source using this code based on liblouis 3.6, since current master fails with NVDA's build system, both with 2 and 4 bit widechars. Both worked as expected in the end, i.e. with emoji's, NVDA printed \y followed by the expected hex identifier.

### To be done
We really need to make sure this doesn't break on linux and doesn't cause failure with surrogate pairs. However, I'm not sure what's the best way to test this. Anyhow, I propose not to include this in liblouis 3.7 for now.

cc @dkager @jcsteh @mwhapples @Andre9642