### PR TITLE
Fix build error when UNICODE is defined

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -523,7 +523,7 @@ static List *
 listDir(List *list, char *dirName) {
 	static char glob[MAXSTRING];
 	static char fileName[MAXSTRING];
-	WIN32_FIND_DATA ffd;
+	WIN32_FIND_DATAA ffd;
 	HANDLE hFind;
 	sprintf(glob, "%s%c%c", dirName, DIR_SEP, '*');
 	hFind = FindFirstFileA(glob, &ffd);


### PR DESCRIPTION
When UNICODE is defined as preprocessor macro, Liblouis refuses to build as part of NVDA because WIN32_FIND_DATA translates to WIN32_FIND_DATAW. This pr explicitly uses the WIN32_FIND_DATAA type.

Having said that, I'm not sure whether liblouis should keep on using the ANSI version of FindFirstFile. But, it looks like Liblouis' API is quite char (not w_char_t) oriented.