### PR TITLE
Tidy up mode flags in lou_allround.c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,24 @@
 liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 
+* Noteworthy changes in release 3.8.0 (2018-12-XX)
+
+** New features
+
+** Bug fixes
+
+** Braille table improvements
+
+** Other changes
+
+** Deprecation notice
+
+** Backwards incompatible changes
+
+** New, renamed or removed tables
+*** New
+*** Renamed
+*** Removed
+
 * Noteworthy changes in release 3.7.0 (2018-09-03)
 This release implements major improvements for back-translation thanks
 to concerted efforts by Bue Vester-Andersen, Bert Frees, Timothy Lee

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 ** Braille table improvements
 
 ** Other changes
+- Updated the lou_allround test tool to include all the mode flags
+  described in the documentation of the lou_translateString() function.
+  Thanks to Bue Vester-Andersen
 
 ** Deprecation notice
 

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -145,15 +145,19 @@ getCommands(void) {
 			printf("Reset mode");
 			if (getYN()) mode = 0;
 			printf("No contractions");
-			mode |= getYN();
-			printf("Computer braille at cursor");
-			mode |= 2 * getYN();
+			mode |= noContractions * getYN();
+			printf("Computer Braille at cursor");
+			mode |= compbrlAtCursor * getYN();
 			printf("Dots input and output");
-			mode |= 4 * getYN();
-			printf("8-dot computer braille");
-			mode |= 8 * getYN();
+			mode |= dotsIO * getYN();
+			printf("Computer Braille left of cursor");
+			mode |= compbrlLeftCursor * getYN();
+			printf("Unicode Braille");
+			mode |= ucBrl * getYN();
+			printf("No undefined dots");
+			mode |= noUndefinedDots * getYN();
 			printf("Partial back-translation");
-			mode |= 256 * getYN();
+			mode |= partialTrans * getYN();
 			break;
 		case 'l':
 			printf("Do you want to test input and output lengths");

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -152,8 +152,8 @@ getCommands(void) {
 			mode |= 4 * getYN();
 			printf("8-dot computer braille");
 			mode |= 8 * getYN();
-			printf("Pass1 only");
-			mode |= 16 * getYN();
+			printf("Partial back-translation");
+			mode |= 32 * getYN();
 			break;
 		case 'l':
 			printf("Do you want to test input and output lengths");

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -153,7 +153,7 @@ getCommands(void) {
 			printf("8-dot computer braille");
 			mode |= 8 * getYN();
 			printf("Partial back-translation");
-			mode |= 32 * getYN();
+			mode |= 256 * getYN();
 			break;
 		case 'l':
 			printf("Do you want to test input and output lengths");


### PR DESCRIPTION
Solves #642 
Also, now the flags are refered to by name instead of absolute values.
Other things we could do in this PR:
- Remove the last traces of pass1Only in liblouis.h and lou_translatestring.c.
- Add the most commonly used modes as command line parameters to the other tools, e.g. -p or --partialTrans.
