### PR TITLE
Update the Dutch tables to the braille standard 2017.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ issues]].
 - Defined the undefined character for the Czech tables thanks to Jan
   Hegr.
 - Improvements to Unified English braille thanks to Mike Gray
+- Updated the Dutch table to the new 2017.1 braille standard thanks to
+  Davy Kager.
 
 ** Other changes
 - Updated the ~lou_allround~ test tool to include all the mode flags

--- a/tables/nl-BE-g0.utb
+++ b/tables/nl-BE-g0.utb
@@ -2,7 +2,7 @@
 #  Copyright (C) 2010, 2011 by DocArch <http://www.docarch.be>
 #  Copyright (C) 2014 by Bert Frees
 #  Copyright (C) 2014 by CBB <http://www.cbb.nl>
-#  Copyright (C) 2015, 2016 by Dedicon <http://www.dedicon.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
 #
 #  This file is part of liblouis.
 #
@@ -22,17 +22,16 @@
 #
 # -------------------------------------------------------------------------------
 #
-#  Dutch Braille as used in the Netherlands
+#  Dutch Braille as used in Belgium
 #
 #     Created by Bert Frees <bertfrees@gmail.com>
 #     Modified by Henri Apperloo <h.apperloo@cbb.nl>
 #     Modified by Davy Kager <DavyKager@dedicon.nl>
 #
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
-#                Van toepassing vanaf 1 september 2005 »
-#              (Federatie Slechtzienden- en Blindenbelang en 
-#                Belgische Confederatie voor Blinden en Slechtzienden, 2005)
-#               [https://cdn.rawgit.com/liblouis/braille-specs/master/Belgium/Eindtekst-zonder-voorblad-dec-2005.doc][1]
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
 #          and: « World Braille Usage (3rd edition) »
 #               [https://cdn.rawgit.com/liblouis/braille-specs/master/world-braille-usage-third-edition.pdf][2]
 #
@@ -63,13 +62,6 @@ uplow       \x00D5\x00F5  246,246             Õõ                  LATIN CAPITA
 
 punctuation \x007B        12356               {                   LEFT CURLY BRACKET
 punctuation \x007D        23456               }                   RIGHT CURLY BRACKET
-
-# Middle dot
-# Definition missing from standard
-# Belgium uses "5-256"
-# The Netherlands use "56"
-
-math        \x00B7        5-256               ·                   MIDDLE DOT
 
 # Greek letters
 # Clear definition missing from standard

--- a/tables/nl-BE-g0.utb
+++ b/tables/nl-BE-g0.utb
@@ -31,7 +31,7 @@
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
 #                Van toepassing vanaf 19 april 2018 »
 #              (Braille Autoriteit, 2018)
-#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
+#               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
 #          and: « World Braille Usage (3rd edition) »
 #               [https://cdn.rawgit.com/liblouis/braille-specs/master/world-braille-usage-third-edition.pdf][2]
 #

--- a/tables/nl-NL-g0.utb
+++ b/tables/nl-NL-g0.utb
@@ -2,7 +2,7 @@
 #  Copyright (C) 2010, 2011 by DocArch <http://www.docarch.be>
 #  Copyright (C) 2014 by Bert Frees
 #  Copyright (C) 2014 by CBB <http://www.cbb.nl>
-#  Copyright (C) 2015, 2016 by Dedicon <http://www.dedicon.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
 #
 #  This file is part of liblouis.
 #
@@ -29,10 +29,9 @@
 #     Modified by Davy Kager <DavyKager@dedicon.nl>
 #
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
-#                Van toepassing vanaf 1 september 2005 »
-#              (Federatie Slechtzienden- en Blindenbelang en 
-#                Belgische Confederatie voor Blinden en Slechtzienden, 2005)
-#               [https://cdn.rawgit.com/liblouis/braille-specs/master/Belgium/Eindtekst-zonder-voorblad-dec-2005.doc][1]
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
 #          and: « World Braille Usage (3rd edition) »
 #               [https://cdn.rawgit.com/liblouis/braille-specs/master/world-braille-usage-third-edition.pdf][2]
 #
@@ -68,21 +67,6 @@ punctuation \x007B        12356               {                   LEFT CURLY BRA
 punctuation \x007D        23456               }                   RIGHT CURLY BRACKET
 # punctuation \x007D        3456                }                   RIGHT CURLY BRACKET
 # punctuation \x007D        6-23456             }                   RIGHT CURLY BRACKET
-
-# Vertical line
-# Definition missing from standard
-# Dedicon uses dots "1456"
-# CBB uses dots "123456"
-
-sign        \x007C        1456                |                   VERTICAL LINE
-# sign        \x007C        123456              |                   VERTICAL LINE
-
-# Middle dot
-# Definition missing from standard
-# Belgium uses "5-256"
-# The Netherlands use "56"
-
-sign        \x00B7        56                  ·                   MIDDLE DOT
 
 # Greek letters
 # Clear definition missing from standard

--- a/tables/nl-NL-g0.utb
+++ b/tables/nl-NL-g0.utb
@@ -31,7 +31,7 @@
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
 #                Van toepassing vanaf 19 april 2018 »
 #              (Braille Autoriteit, 2018)
-#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
+#               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
 #          and: « World Braille Usage (3rd edition) »
 #               [https://cdn.rawgit.com/liblouis/braille-specs/master/world-braille-usage-third-edition.pdf][2]
 #

--- a/tables/nl-chardefs.uti
+++ b/tables/nl-chardefs.uti
@@ -31,7 +31,7 @@
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
 #                Van toepassing vanaf 19 april 2018 »
 #              (Braille Autoriteit, 2018)
-#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
+#               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
 #
 # ----------------------------------------------------------------------------------------------
 

--- a/tables/nl-chardefs.uti
+++ b/tables/nl-chardefs.uti
@@ -2,7 +2,7 @@
 #  Copyright (C) 2010, 2011 by DocArch <http://www.docarch.be>
 #  Copyright (C) 2014 by Bert Frees
 #  Copyright (C) 2014 by CBB <http://www.cbb.nl>
-#  Copyright (C) 2015, 2016 by Dedicon <http://www.dedicon.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
 #
 #  This file is part of liblouis.
 #
@@ -22,17 +22,16 @@
 #
 #-------------------------------------------------------------------------------
 #
-#  Dutch Braille based on the braille standard of 2005
+#  Dutch Braille based on the braille standard of 2017
 #
 #     Created by Bert Frees <bertfrees@gmail.com>
 #     Modified by Henri Apperloo <h.apperloo@cbb.nl>
 #     Modified by Davy Kager <DavyKager@dedicon.nl>
 #
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
-#                Van toepassing vanaf 1 september 2005 »
-#              (Federatie Slechtzienden- en Blindenbelang en 
-#                Belgische Confederatie voor Blinden en Slechtzienden, 2005)
-#               [https://cdn.rawgit.com/liblouis/braille-specs/master/Belgium/Eindtekst-zonder-voorblad-dec-2005.doc][1]
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
 #
 # ----------------------------------------------------------------------------------------------
 
@@ -101,9 +100,10 @@ punctuation \x003F        26                  ?                   QUESTION MARK
 sign        \x0040        345                 @                   COMMERCIAL AT
 punctuation \x005B        12356               [                   LEFT SQUARE BRACKET
 punctuation \x005D        23456               ]                   RIGHT SQUARE BRACKET
-sign        \x005E        34                  ^                   CIRCUMFLEX ACCENT
+sign        \x005E        346                 ^                   CIRCUMFLEX ACCENT
 sign        \x005F        456                 _                   LOW LINE
 punctuation \x0060        3                   `                   GRAVE ACCENT
+sign        \x007C        1456                |                   VERTICAL LINE
 
 
 # ----------------------------------------------------------------------------------------------
@@ -132,10 +132,11 @@ sign        \x00A3        1234                £                   POUND SIGN
 sign        \x00A5        13456               ¥                   YEN SIGN
 sign        \x00A7        346                 §                   SECTION SIGN
 punctuation \x00AB        2356                «                   LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-punctuation \x00AD        367                 ­                   SOFT HYPHEN
+punctuation \x00AD        36                 ­                   SOFT HYPHEN
 sign        \x00B1        235-36              ±                   PLUS-MINUS SIGN
 sign        \x00B4        3                   ´                   ACUTE ACCENT
 sign        \x00B5        56-134              µ                   MICRO SIGN
+math        \x00B7        236                 ·                   MIDDLE DOT
 punctuation \x00BB        2356                »                   RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
 punctuation \x00BF        26                  ¿                   INVERTED QUESTION MARK
 math        \x00D7        236                 ×                   MULTIPLICATION SIGN
@@ -208,10 +209,10 @@ sign        \x0099        5-2345-134          ™                   <control> - 
 sign        \x00A9        5-14                ©                   COPYRIGHT SIGN
 sign        \x00AE        5-1235              ®                   REGISTERED SIGN
 sign        \x00B0        4-356               °                   DEGREE SIGN
-math        \x00B2        34-3456-12          ²                   SUPERSCRIPT TWO
-math        \x00B3        34-3456-14          ³                   SUPERSCRIPT THREE
+math        \x00B2        346-3456-12         ²                   SUPERSCRIPT TWO
+math        \x00B3        346-3456-14         ³                   SUPERSCRIPT THREE
 sign        \x00B8        45                  ¸                   CEDILLA
-sign        \x00B9        34-3456-1           ¹                   SUPERSCRIPT ONE
+sign        \x00B9        346-3456-1          ¹                   SUPERSCRIPT ONE
 sign        \x00BA        4-356               º                   MASCULINE ORDINAL INDICATOR
 math        \x00BC        3456-1-34-3456-145  ¼                   VULGAR FRACTION ONE QUARTER
 math        \x00BD        3456-1-34-3456-12   ½                   VULGAR FRACTION ONE HALF
@@ -251,14 +252,14 @@ sign        \x2030        123456-123456       ‰                   PER MILLE SI
 # Unicode 2070..209F  Superscripts and Subscripts
 # ----------------------------------------------------------------------------------------------
 
-math        \x2070        34-3456-245         ⁰                   SUPERSCRIPT ZERO
-math        \x2074        34-3456-145         ⁴                   SUPERSCRIPT FOUR
-math        \x2075        34-3456-15          ⁵                   SUPERSCRIPT FIVE
-math        \x2076        34-3456-124         ⁶                   SUPERSCRIPT SIX
-math        \x2077        34-3456-1245        ⁷                   SUPERSCRIPT SEVEN
-math        \x2078        34-3456-125         ⁸                   SUPERSCRIPT EIGHT
-math        \x2079        34-3456-24          ⁹                   SUPERSCRIPT NINE
-math        \x207F        34-1345             ⁿ                   SUPERSCRIPT LATIN SMALL LETTER N
+math        \x2070        346-3456-245        ⁰                   SUPERSCRIPT ZERO
+math        \x2074        346-3456-145        ⁴                   SUPERSCRIPT FOUR
+math        \x2075        346-3456-15         ⁵                   SUPERSCRIPT FIVE
+math        \x2076        346-3456-124        ⁶                   SUPERSCRIPT SIX
+math        \x2077        346-3456-1245       ⁷                   SUPERSCRIPT SEVEN
+math        \x2078        346-3456-125        ⁸                   SUPERSCRIPT EIGHT
+math        \x2079        346-3456-24         ⁹                   SUPERSCRIPT NINE
+math        \x207F        346-1345            ⁿ                   SUPERSCRIPT LATIN SMALL LETTER N
 math        \x2080        16-356              ₀                   SUBSCRIPT ZERO
 math        \x2081        16-2                ₁                   SUBSCRIPT ONE
 math        \x2082        16-23               ₂                   SUBSCRIPT TWO

--- a/tables/nl-g0.uti
+++ b/tables/nl-g0.uti
@@ -31,7 +31,7 @@
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
 #                Van toepassing vanaf 19 april 2018 »
 #              (Braille Autoriteit, 2018)
-#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
+#               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
 #
 # ----------------------------------------------------------------------------------------------
 

--- a/tables/nl-g0.uti
+++ b/tables/nl-g0.uti
@@ -2,7 +2,7 @@
 #  Copyright (C) 2010-2011 by DocArch <http://www.docarch.be>
 #  Copyright (C) 2014-2015 by Bert Frees
 #  Copyright (C) 2014 by CBB <http://www.cbb.nl>
-#  Copyright (C) 2015, 2016 by Dedicon <http://www.dedicon.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
 #
 #  This file is part of liblouis.
 #
@@ -22,17 +22,16 @@
 #
 # -------------------------------------------------------------------------------
 #
-#  Dutch Braille based on the braille standard of 2005
+#  Dutch Braille based on the braille standard of 2017
 #
 #     Created by Bert Frees <bertfrees@gmail.com>
 #     Modified by Henri Apperloo <h.apperloo@cbb.nl>
 #     Modified by Davy Kager <DavyKager@dedicon.nl>
 #
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
-#                Van toepassing vanaf 1 september 2005 »
-#              (Federatie Slechtzienden- en Blindenbelang en 
-#                Belgische Confederatie voor Blinden en Slechtzienden, 2005)
-#               [https://cdn.rawgit.com/liblouis/braille-specs/master/Belgium/Eindtekst-zonder-voorblad-dec-2005.doc][1]
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard/][1]
 #
 # ----------------------------------------------------------------------------------------------
 
@@ -62,8 +61,8 @@ endnum  \x2030 0-123456-123456
 
 # isgelijkteken =
 begword \x003D   2356-0
-midword \x003D 0-2356
-endword \x003D 0-2356-0
+midword \x003D 0-2356-0
+endword \x003D 0-2356
 
 # plusteken +
 begword \x002B   235-0
@@ -95,8 +94,11 @@ noback joinnum \x00A3 1234
 
 noback joinnum \x00A5 13456
 
-# Eén
-noback context ["E"]"\x00E9"  @123456
+# §1.34 verticale streep | (spatie voor en na) [1]
+
+begword \x007C   1456-0
+midword \x007C 0-1456-0
+endword \x007C 0-1456
 
 # §3.6 Graad-, minuut- en secondeteken [1]
 noback context $d["''"] @4-35-35
@@ -130,7 +132,7 @@ noback pass3       $d[@6]@456             ?
 # "second meaning" sign because its first meaning is EXCLAMATION MARK.
 
 class    plusamp                     +&     # 2nd class = $x
-class    noplusamp                   -.'    # 3rd class = $y
+class    noplusamp                   .'‘’   # 3rd class = $y
 noback pass4    %noplusamp[]%plusamp        @5
 noback pass4    $l[]%plusamp                @5
 noback pass4    [@235a]%plusamp             @235-5
@@ -169,12 +171,13 @@ emphletter underline 456
 # §2.12 Hoofdletters [1]
 
 # Certain characters can appear within an uppercase string without cancelling
-# the uppercase "state". These characters are - (HYPHEN MINUS), + (PLUS SIGN), &
-# (AMPERSAND), . (FULL STOP) and ' (APOSTROPHE).
-capsmodechars -+&.'
+# the uppercase "state". These characters are + (PLUS SIGN), & (AMPERSAND),
+# . (FULL STOP), ' (APOSTROPHE), ‘ (LEFT SINGLE QUOTATION MARK)
+# and ’ (RIGHT SINGLE QUOTATION MARK).
+capsmodechars +&.'‘’
 # The same goes for the emphasis "state". This is not yet supported.
 # See: https://github.com/liblouis/liblouis/issues/116
-#emphmodechars -+&.'
+#emphmodechars +&.'
 
 lencapsphrase 4
 begcapsword 45

--- a/tables/nl.tbl
+++ b/tables/nl.tbl
@@ -5,6 +5,7 @@
 #+contraction:no
 #+grade:0
 #+hyphenation:yes
+#+version:2017.1
 
 # TODO: Please correct the metadata above. It is not meant to be
 # accurate nor complete. It hasn't been verified by the table

--- a/tables/nl_BE.tbl
+++ b/tables/nl_BE.tbl
@@ -5,6 +5,7 @@
 #+contraction:no
 #+grade:0
 #+hyphenation:yes
+#+version:2017.1
 
 # TODO: Please correct the metadata above. It is not meant to be
 # accurate nor complete. It hasn't been verified by the table

--- a/tests/braille-specs/nl-NL-g0_harness.yaml
+++ b/tests/braille-specs/nl-NL-g0_harness.yaml
@@ -1,9 +1,48 @@
+#
+#  Copyright (C) 2010-2011 by DocArch <http://www.docarch.be>
+#  Copyright (C) 2014-2015 by Bert Frees
+#  Copyright (C) 2014 by CBB <http://www.cbb.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# -------------------------------------------------------------------------------
+#
+#  Dutch Braille based on the braille standard of 2017
+#
+#     Created by Bert Frees <bertfrees@gmail.com>
+#     Modified by Henri Apperloo <h.apperloo@cbb.nl>
+#     Modified by Davy Kager <DavyKager@dedicon.nl>
+#
+#     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
+#
+# ----------------------------------------------------------------------------------------------
+
 display: unicode.dis
 table:
   locale: nl
   grade: 0
   __assert-match: nl.tbl # nl-NL-g0.utb
 tests:
+  # §2.2 Alfabetwisselingsteken
+  # §2.12 Hoofdletters
   - - Some Greek uppercase
     - Α Β Γ
     - ⠰⠨⠁ ⠰⠨⠃ ⠰⠨⠛

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -1,3 +1,40 @@
+#
+#  Copyright (C) 2010-2011 by DocArch <http://www.docarch.be>
+#  Copyright (C) 2014-2015 by Bert Frees
+#  Copyright (C) 2014 by CBB <http://www.cbb.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# -------------------------------------------------------------------------------
+#
+#  Dutch Braille based on the braille standard of 2017
+#
+#     Created by Bert Frees <bertfrees@gmail.com>
+#     Modified by Henri Apperloo <h.apperloo@cbb.nl>
+#     Modified by Davy Kager <DavyKager@dedicon.nl>
+#
+#     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
+#
+# ----------------------------------------------------------------------------------------------
+
 display: unicode.dis
 table:
   locale: nl
@@ -44,21 +81,38 @@ tests:
   - - u accent
     - ü û ù
     - ⠳ ⠱ ⠾
+  # §2.19 Punt
   - [beletselteken ..., ⠃⠑⠇⠑⠞⠎⠑⠇⠞⠑⠅⠑⠝ ⠲⠲⠲]
   - ['Vul in ei of ij: p..n, r..s.', ⠨⠧⠥⠇ ⠊⠝ ⠑⠊ ⠕⠋ ⠊⠚⠒ ⠏⠲⠲⠝⠂ ⠗⠲⠲⠎⠲]
+  # §2.1 Aanhalingstekens
+  # §2.5 Apostrof/weglatingsteken
   - ['''enkele aanhalingstekens''', ⠄⠑⠝⠅⠑⠇⠑ ⠁⠁⠝⠓⠁⠇⠊⠝⠛⠎⠞⠑⠅⠑⠝⠎⠄]
   - ['"dubbele aanhalingstekens"', ⠶⠙⠥⠃⠃⠑⠇⠑ ⠁⠁⠝⠓⠁⠇⠊⠝⠛⠎⠞⠑⠅⠑⠝⠎⠶]
   - [“dubbele aanhalingstekens”, ⠶⠙⠥⠃⠃⠑⠇⠑ ⠁⠁⠝⠓⠁⠇⠊⠝⠛⠎⠞⠑⠅⠑⠝⠎⠶]
+  - [SMS'je, ⠘⠎⠍⠎⠄⠠⠚⠑]
+  - [SMS’je, ⠘⠎⠍⠎⠄⠠⠚⠑]
+  # §2.10 Haakjes
   - [(ronde haakjes), ⠦⠗⠕⠝⠙⠑ ⠓⠁⠁⠅⠚⠑⠎⠴]
   - ['[vierkante haakjes]', ⠷⠧⠊⠑⠗⠅⠁⠝⠞⠑ ⠓⠁⠁⠅⠚⠑⠎⠾]
+  # §2.23 Zeldzaam voorkomende tekens
   - [copyright ©, ⠉⠕⠏⠽⠗⠊⠛⠓⠞ ⠐⠉]
+  - [paragraaf §, ⠏⠁⠗⠁⠛⠗⠁⠁⠋ ⠬]
+  - [registered ®, ⠗⠑⠛⠊⠎⠞⠑⠗⠑⠙ ⠐⠗]
+  - [trademark ™, ⠞⠗⠁⠙⠑⠍⠁⠗⠅ ⠐⠞⠍]
+  # §2.17 Muntsymbolen/valutatekens
   - [dollar $, ⠙⠕⠇⠇⠁⠗ ⠙]
   - [euro €, ⠑⠥⠗⠕ ⠑]
   - [pond £, ⠏⠕⠝⠙ ⠏]
   - [yen ¥, ⠽⠑⠝ ⠽]
-  - [paragraaf §, ⠏⠁⠗⠁⠛⠗⠁⠁⠋ ⠬]
-  - [registered ®, ⠗⠑⠛⠊⠎⠞⠑⠗⠑⠙ ⠐⠗]
-  - [trademark ™, ⠞⠗⠁⠙⠑⠍⠁⠗⠅ ⠐⠞⠍]
+  - ['€ 12,35', ⠑⠼⠁⠃⠂⠉⠑]
+  - ['€12,35', ⠑⠼⠁⠃⠂⠉⠑]
+  - ['$ 10,00', ⠙⠼⠁⠚⠂⠚⠚]
+  - ['$10,00', ⠙⠼⠁⠚⠂⠚⠚]
+  - ['£ 65,47', ⠏⠼⠋⠑⠂⠙⠛]
+  - ['£65,47', ⠏⠼⠋⠑⠂⠙⠛]
+  - [¥ 100.000, ⠽⠼⠁⠚⠚⠲⠚⠚⠚]
+  - [¥100.000, ⠽⠼⠁⠚⠚⠲⠚⠚⠚]
+  # §3.1 Het cijferteken
   - ['1.234.567,89', ⠼⠁⠲⠃⠉⠙⠲⠑⠋⠛⠂⠓⠊]
   - [050-12 34 56, ⠼⠚⠑⠚⠤⠼⠁⠃ ⠼⠉⠙ ⠼⠑⠋]
   - [050/78 90 12, ⠼⠚⠑⠚⠌⠼⠛⠓ ⠼⠊⠚ ⠼⠁⠃]
@@ -75,6 +129,13 @@ tests:
   - ['15e, 27ste', ⠼⠁⠑⠠⠑⠂ ⠼⠃⠛⠎⠞⠑]
   - ['10a, 10A', ⠼⠁⠚⠠⠁⠂ ⠼⠁⠚⠨⠁]
   - [12.b, ⠼⠁⠃⠲⠠⠃]
+  - [31-07-2010, ⠼⠉⠁⠤⠼⠚⠛⠤⠼⠃⠚⠁⠚]
+  - [31/07/2010, ⠼⠉⠁⠌⠼⠚⠛⠌⠼⠃⠚⠁⠚]
+  - [16.30 tot 21.30 uur, ⠼⠁⠋⠲⠉⠚ ⠞⠕⠞ ⠼⠃⠁⠲⠉⠚ ⠥⠥⠗]
+  - ['16:30 tot 21:30 uur', ⠼⠁⠋⠒⠉⠚ ⠞⠕⠞ ⠼⠃⠁⠒⠉⠚ ⠥⠥⠗]
+  - [x_1 = 0, ⠭⠸⠼⠁ ⠶ ⠼⠚]
+  - ['x,1', ⠭⠂⠼⠁]
+  # §3.2 De basisrekentekens
   - [1 + 2 = 3, ⠼⠁ ⠖ ⠼⠃ ⠶ ⠼⠉]
   - [9 - 5 = 4, ⠼⠊ ⠤ ⠼⠑ ⠶ ⠼⠙]
   - [3 x 3 = 9, ⠼⠉ ⠭ ⠼⠉ ⠶ ⠼⠊]
@@ -85,20 +146,28 @@ tests:
   - [8 / 4 = 2, ⠼⠓ ⠌ ⠼⠙ ⠶ ⠼⠃]
   - [8 ÷ 4 = 2, ⠼⠓ ⠲ ⠼⠙ ⠶ ⠼⠃]
   - [65+-kaart, ⠼⠋⠑⠐⠖⠤⠅⠁⠁⠗⠞]
+  - [65+'er, ⠼⠋⠑⠐⠖⠄⠑⠗]
   - [40-jarige, ⠼⠙⠚⠤⠚⠁⠗⠊⠛⠑]
+  # §2.18 Procent- en promilleteken
+  # §3.4 Procent- en promilleteken
   - ['79,5 %', ⠼⠛⠊⠂⠑ ⠿]
   - [15%, ⠼⠁⠑ ⠿]
   - ['79,5 ‰', ⠼⠛⠊⠂⠑ ⠿⠿]
   - [15‰, ⠼⠁⠑ ⠿⠿]
+  # §3.6 Graad-, minuut- en secondeteken
   - ['37,8° C', ⠼⠉⠛⠂⠓⠈⠴ ⠨⠉]
+  - [Een hoek van 27° 30'., ⠨⠑⠑⠝ ⠓⠕⠑⠅ ⠧⠁⠝ ⠼⠃⠛⠈⠴ ⠼⠉⠚⠈⠔⠲]
+  - [Het record is 3' 5''., ⠨⠓⠑⠞ ⠗⠑⠉⠕⠗⠙ ⠊⠎ ⠼⠉⠈⠔ ⠼⠑⠈⠔⠔⠲]
+  - [57° 38' noorderbreedte, ⠼⠑⠛⠈⠴ ⠼⠉⠓⠈⠔ ⠝⠕⠕⠗⠙⠑⠗⠃⠗⠑⠑⠙⠞⠑]
+  # §3.5 Oppervlakte- en inhoudsmaten
   - [65 m², ⠼⠋⠑ ⠍⠬⠼⠃]
   - [65 m^2, ⠼⠋⠑ ⠍⠬⠼⠃]
   - [1.000 cm³, ⠼⠁⠲⠚⠚⠚ ⠉⠍⠬⠼⠉]
   - [1.000 cm^3, ⠼⠁⠲⠚⠚⠚ ⠉⠍⠬⠼⠉]
+  # §3.3 Breuken
   - [½ kg - 1/2 kg, ⠼⠁⠌⠼⠃ ⠅⠛ ⠤ ⠼⠁⠌⠼⠃ ⠅⠛]
   - [¼ l - 1/4 l, ⠼⠁⠌⠼⠙ ⠇ ⠤ ⠼⠁⠌⠼⠙ ⠇]
-  - [SMS'je, ⠘⠎⠍⠎⠄⠠⠚⠑]
-  - [SMS’je, ⠘⠎⠍⠎⠄⠠⠚⠑]
+  # §2.12 Hoofdletters
   - [Winston Churchill, ⠨⠺⠊⠝⠎⠞⠕⠝ ⠨⠉⠓⠥⠗⠉⠓⠊⠇⠇]
   - [MacLean, ⠨⠍⠁⠉⠨⠇⠑⠁⠝]
   - [AMSTERDAM en BRUSSEL, ⠘⠁⠍⠎⠞⠑⠗⠙⠁⠍ ⠑⠝ ⠘⠃⠗⠥⠎⠎⠑⠇]
@@ -134,9 +203,15 @@ tests:
   - [W.F. Hermans, ⠘⠺⠲⠋⠲ ⠨⠓⠑⠗⠍⠁⠝⠎]
   - [FAQ's, ⠘⠋⠁⠟⠄⠠⠎]
   - [VTM'er, ⠘⠧⠞⠍⠄⠠⠑⠗]
-  - [65+'er, ⠼⠋⠑⠐⠖⠄⠑⠗]
   - ['SLAAT DE VLAM IN DE PAN, DEK DE VUURHAARD DAN AF MET EEN BRANDWERENDE DEKEN OF
       EEN VOCHTIGE DOEK.', ⠘⠘⠎⠇⠁⠁⠞ ⠙⠑ ⠧⠇⠁⠍ ⠊⠝ ⠙⠑ ⠏⠁⠝⠂ ⠙⠑⠅ ⠙⠑ ⠧⠥⠥⠗⠓⠁⠁⠗⠙ ⠙⠁⠝ ⠁⠋ ⠍⠑⠞ ⠑⠑⠝ ⠃⠗⠁⠝⠙⠺⠑⠗⠑⠝⠙⠑ ⠙⠑⠅⠑⠝ ⠕⠋ ⠑⠑⠝ ⠧⠕⠉⠓⠞⠊⠛⠑ ⠘⠙⠕⠑⠅⠲]
+  - [Eén, ⠨⠑⠿⠝]
+    # This test was previously:
+    # [Eén, ⠨⠿⠿⠝]
+    # However, there is nothing in the braille standard
+    # to suggest that this replacement (E to É) should occur.
+  - [É-U, ⠨⠿⠤⠨⠥]
+  # §2.13 Internettekens
   - [lisa_dirk@yahoo.com, ⠇⠊⠎⠁⠸⠙⠊⠗⠅⠜⠽⠁⠓⠕⠕⠲⠉⠕⠍]
   - ['http://www.avh.asso.fr/', ⠓⠞⠞⠏⠒⠌⠌⠺⠺⠺⠲⠁⠧⠓⠲⠁⠎⠎⠕⠲⠋⠗⠌]
   - ['C:\\Documents and Settings', ⠨⠉⠒⠐⠡⠨⠙⠕⠉⠥⠍⠑⠝⠞⠎ ⠁⠝⠙ ⠨⠎⠑⠞⠞⠊⠝⠛⠎]
@@ -145,44 +220,27 @@ tests:
   - ['ja |nee', ⠚⠁ ⠹ ⠝⠑⠑]
   - ['ja| nee', ⠚⠁ ⠹ ⠝⠑⠑]
   - ['ja|nee', ⠚⠁ ⠹ ⠝⠑⠑]
-  - ['€ 12,35', ⠑⠼⠁⠃⠂⠉⠑]
-  - ['€12,35', ⠑⠼⠁⠃⠂⠉⠑]
-  - ['$ 10,00', ⠙⠼⠁⠚⠂⠚⠚]
-  - ['$10,00', ⠙⠼⠁⠚⠂⠚⠚]
-  - ['£ 65,47', ⠏⠼⠋⠑⠂⠙⠛]
-  - ['£65,47', ⠏⠼⠋⠑⠂⠙⠛]
-  - [¥ 100.000, ⠽⠼⠁⠚⠚⠲⠚⠚⠚]
-  - [¥100.000, ⠽⠼⠁⠚⠚⠲⠚⠚⠚]
-  - [Eén, ⠨⠑⠿⠝]
-    # This test was previously:
-    # [Eén, ⠨⠿⠿⠝]
-    # However, there is nothing in the braille standard
-    # to suggest that this replacement (E to É) should occur.
-  - [É-U, ⠨⠿⠤⠨⠥]
+  - [no_reply@skynet.be, ⠝⠕⠸⠗⠑⠏⠇⠽⠜⠎⠅⠽⠝⠑⠞⠲⠃⠑]
+  # §2.2 Alfabetwisselingsteken
   - [cañon, ⠉⠁⠻⠕⠝]
   - [α β γ, ⠰⠁ ⠰⠃ ⠰⠛] # Some Greek lowercase
-  - [31-07-2010, ⠼⠉⠁⠤⠼⠚⠛⠤⠼⠃⠚⠁⠚]
-  - [31/07/2010, ⠼⠉⠁⠌⠼⠚⠛⠌⠼⠃⠚⠁⠚]
-  - [16.30 tot 21.30 uur, ⠼⠁⠋⠲⠉⠚ ⠞⠕⠞ ⠼⠃⠁⠲⠉⠚ ⠥⠥⠗]
-  - ['16:30 tot 21:30 uur', ⠼⠁⠋⠒⠉⠚ ⠞⠕⠞ ⠼⠃⠁⠒⠉⠚ ⠥⠥⠗]
-  - [Een hoek van 27° 30'., ⠨⠑⠑⠝ ⠓⠕⠑⠅ ⠧⠁⠝ ⠼⠃⠛⠈⠴ ⠼⠉⠚⠈⠔⠲]
-  - [Het record is 3' 5''., ⠨⠓⠑⠞ ⠗⠑⠉⠕⠗⠙ ⠊⠎ ⠼⠉⠈⠔ ⠼⠑⠈⠔⠔⠲]
-  - [57° 38' noorderbreedte, ⠼⠑⠛⠈⠴ ⠼⠉⠓⠈⠔ ⠝⠕⠕⠗⠙⠑⠗⠃⠗⠑⠑⠙⠞⠑]
-  - [no_reply@skynet.be, ⠝⠕⠸⠗⠑⠏⠇⠽⠜⠎⠅⠽⠝⠑⠞⠲⠃⠑]
-  - [x_1 = 0, ⠭⠸⠼⠁ ⠶ ⠼⠚]
-  - ['x,1', ⠭⠂⠼⠁]
+  # §2.1 Aanhalingstekens
   - - '''s morgens, baby''s, Alex'' boeken, de jaren ''90'
     - ⠄⠎ ⠍⠕⠗⠛⠑⠝⠎⠂ ⠃⠁⠃⠽⠄⠎⠂ ⠨⠁⠇⠑⠭⠄ ⠃⠕⠑⠅⠑⠝⠂ ⠙⠑ ⠚⠁⠗⠑⠝ ⠄⠼⠊⠚
+  # §2.10 Haakjes
   - - Een typist(e) moet heel precies werken.
     - ⠨⠑⠑⠝ ⠞⠽⠏⠊⠎⠞⠦⠑⠴ ⠍⠕⠑⠞ ⠓⠑⠑⠇ ⠏⠗⠑⠉⠊⠑⠎ ⠺⠑⠗⠅⠑⠝⠲
+  # §3.2 De basisrekentekens
   - - 'Deze wandkaart heeft een schaal van 1 : 7.500.'
     - ⠨⠙⠑⠵⠑ ⠺⠁⠝⠙⠅⠁⠁⠗⠞ ⠓⠑⠑⠋⠞ ⠑⠑⠝ ⠎⠉⠓⠁⠁⠇ ⠧⠁⠝ ⠼⠁ ⠒ ⠼⠛⠲⠑⠚⠚⠲
+  - - Op zijn laatste rapport stond voor wiskunde een 6+.
+    - ⠨⠕⠏ ⠵⠊⠚⠝ ⠇⠁⠁⠞⠎⠞⠑ ⠗⠁⠏⠏⠕⠗⠞ ⠎⠞⠕⠝⠙ ⠧⠕⠕⠗ ⠺⠊⠎⠅⠥⠝⠙⠑ ⠑⠑⠝ ⠼⠋⠐⠖⠲
+  # §2.16 Liggend streepje
   - - Hij vertelde – zonder het te beseffen – een goede mop.
     - ⠨⠓⠊⠚ ⠧⠑⠗⠞⠑⠇⠙⠑ ⠤ ⠵⠕⠝⠙⠑⠗ ⠓⠑⠞ ⠞⠑ ⠃⠑⠎⠑⠋⠋⠑⠝ ⠤ ⠑⠑⠝ ⠛⠕⠑⠙⠑ ⠍⠕⠏⠲
   - - groente- en fruithandel
     - ⠛⠗⠕⠑⠝⠞⠑⠤ ⠑⠝ ⠋⠗⠥⠊⠞⠓⠁⠝⠙⠑⠇
-  - - Op zijn laatste rapport stond voor wiskunde een 6+.
-    - ⠨⠕⠏ ⠵⠊⠚⠝ ⠇⠁⠁⠞⠎⠞⠑ ⠗⠁⠏⠏⠕⠗⠞ ⠎⠞⠕⠝⠙ ⠧⠕⠕⠗ ⠺⠊⠎⠅⠥⠝⠙⠑ ⠑⠑⠝ ⠼⠋⠐⠖⠲
+  # §2.8 Drukwijzigingsteken
   - - Landt je vader op Schiphol?
     - ⠨⠇⠁⠝⠙⠸⠞ ⠚⠑ ⠧⠁⠙⠑⠗ ⠕⠏ ⠨⠎⠉⠓⠊⠏⠓⠕⠇⠢
     - typeform:
@@ -237,6 +295,7 @@ tests:
     - ⠸⠧⠑⠞⠛⠑⠙⠗⠥⠅⠞
     - typeform:
         bold: '++++++++++'
+  # Misc
   - - Not part of the braille standard
     - 'CO₂-uitstoot: 158 g CO₂/km'
     - ⠘⠉⠕⠡⠆⠤⠥⠊⠞⠎⠞⠕⠕⠞⠒ ⠼⠁⠑⠓ ⠛ ⠘⠉⠕⠡⠆⠌⠅⠍

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -18,11 +18,11 @@ tests:
     - 1a 1.a 1,a 1:a
     - ⠼⠁⠠⠁ ⠼⠁⠲⠠⠁ ⠼⠁⠂⠠⠁ ⠼⠁⠒⠠⠁
   - - Punctuation
-    - '. , ? ! ; : - …'
-    - ⠲ ⠂ ⠢ ⠖ ⠆ ⠒ ⠤ ⠲⠲⠲
+    - '. , ? ! ; : - … [ ]'
+    - ⠲ ⠂ ⠢ ⠖ ⠆ ⠒ ⠤ ⠲⠲⠲ ⠷ ⠾
   - - Symbols
-    - '@ # % ‰ & * = + _ / \\ < > ~'
-    - ⠜ ⠐⠼ ⠿ ⠿⠿ ⠯ ⠔ ⠶ ⠖ ⠸ ⠌ ⠐⠡ ⠐⠪ ⠐⠕ ⠐⠢
+    - '@ # % ‰ ^ & * = + _ / \\ < > ~ | ±'
+    - ⠜ ⠐⠼ ⠿ ⠿⠿ ⠬ ⠯ ⠔ ⠶ ⠖ ⠸ ⠌ ⠐⠡ ⠐⠪ ⠐⠕ ⠐⠢ ⠹ ⠖⠤
   - - a accent
     - ä â à
     - ⠜ ⠡ ⠷
@@ -68,7 +68,7 @@ tests:
   - - Number grouping (not implemented)
     - 1 297 381 euro
     - ⠼⠁⠲⠃⠊⠛⠲⠉⠓⠁ ⠑⠥⠗⠕
-    - {xfail: true}
+    - xfail: true
   - ['1e, 1ste', ⠼⠁⠠⠑⠂ ⠼⠁⠎⠞⠑]
   - ['2e, 2de', ⠼⠃⠠⠑⠂ ⠼⠃⠠⠙⠑]
   - ['3e, 3de', ⠼⠉⠠⠑⠂ ⠼⠉⠠⠙⠑]
@@ -77,7 +77,12 @@ tests:
   - [12.b, ⠼⠁⠃⠲⠠⠃]
   - [1 + 2 = 3, ⠼⠁ ⠖ ⠼⠃ ⠶ ⠼⠉]
   - [9 - 5 = 4, ⠼⠊ ⠤ ⠼⠑ ⠶ ⠼⠙]
+  - [3 x 3 = 9, ⠼⠉ ⠭ ⠼⠉ ⠶ ⠼⠊]
+  - [3 * 3 = 9, ⠼⠉ ⠔ ⠼⠉ ⠶ ⠼⠊]
+  - [3 · 3 = 9, ⠼⠉ ⠦ ⠼⠉ ⠶ ⠼⠊]
   - [3 × 3 = 9, ⠼⠉ ⠦ ⠼⠉ ⠶ ⠼⠊]
+  - ['8 : 4 = 2', ⠼⠓ ⠒ ⠼⠙ ⠶ ⠼⠃]
+  - [8 / 4 = 2, ⠼⠓ ⠌ ⠼⠙ ⠶ ⠼⠃]
   - [8 ÷ 4 = 2, ⠼⠓ ⠲ ⠼⠙ ⠶ ⠼⠃]
   - [65+-kaart, ⠼⠋⠑⠐⠖⠤⠅⠁⠁⠗⠞]
   - [40-jarige, ⠼⠙⠚⠤⠚⠁⠗⠊⠛⠑]
@@ -86,30 +91,43 @@ tests:
   - ['79,5 ‰', ⠼⠛⠊⠂⠑ ⠿⠿]
   - [15‰, ⠼⠁⠑ ⠿⠿]
   - ['37,8° C', ⠼⠉⠛⠂⠓⠈⠴ ⠨⠉]
-  - [65 m², ⠼⠋⠑ ⠍⠌⠼⠃]
-  - [1.000 cm³, ⠼⠁⠲⠚⠚⠚ ⠉⠍⠌⠼⠉]
+  - [65 m², ⠼⠋⠑ ⠍⠬⠼⠃]
+  - [65 m^2, ⠼⠋⠑ ⠍⠬⠼⠃]
+  - [1.000 cm³, ⠼⠁⠲⠚⠚⠚ ⠉⠍⠬⠼⠉]
+  - [1.000 cm^3, ⠼⠁⠲⠚⠚⠚ ⠉⠍⠬⠼⠉]
   - [½ kg - 1/2 kg, ⠼⠁⠌⠼⠃ ⠅⠛ ⠤ ⠼⠁⠌⠼⠃ ⠅⠛]
   - [¼ l - 1/4 l, ⠼⠁⠌⠼⠙ ⠇ ⠤ ⠼⠁⠌⠼⠙ ⠇]
-  - ['CO₂-uitstoot: 158 g CO₂/km', ⠘⠉⠕⠡⠆⠤⠥⠊⠞⠎⠞⠕⠕⠞⠒ ⠼⠁⠑⠓ ⠛ ⠘⠉⠕⠡⠆⠌⠅⠍]
+  - [SMS'je, ⠘⠎⠍⠎⠄⠠⠚⠑]
+  - [SMS’je, ⠘⠎⠍⠎⠄⠠⠚⠑]
   - [Winston Churchill, ⠨⠺⠊⠝⠎⠞⠕⠝ ⠨⠉⠓⠥⠗⠉⠓⠊⠇⠇]
   - [MacLean, ⠨⠍⠁⠉⠨⠇⠑⠁⠝]
+  - [AMSTERDAM en BRUSSEL, ⠘⠁⠍⠎⠞⠑⠗⠙⠁⠍ ⠑⠝ ⠘⠃⠗⠥⠎⠎⠑⠇]
+  - ['WMO, VDAB', ⠘⠺⠍⠕⠂ ⠘⠧⠙⠁⠃]
+  - [abCDef, ⠁⠃⠘⠉⠙⠠⠑⠋]
+  - [ONZE DIRECTEUR-GENERAAL WOONT IN BRUSSEL, ⠘⠘⠕⠝⠵⠑ ⠙⠊⠗⠑⠉⠞⠑⠥⠗⠤⠛⠑⠝⠑⠗⠁⠁⠇ ⠺⠕⠕⠝⠞ ⠊⠝ ⠘⠃⠗⠥⠎⠎⠑⠇]
+  - [Eghezée of Éghezée, ⠨⠑⠛⠓⠑⠵⠿⠑ ⠕⠋ ⠨⠿⠛⠓⠑⠵⠿⠑]
+  - [EGHEZEE of ÉGHEZÉE, ⠘⠑⠛⠓⠑⠵⠑⠑ ⠕⠋ ⠘⠿⠛⠓⠑⠵⠿⠑]
   - [Saint-Etienne of Saint-Étienne, ⠨⠎⠁⠊⠝⠞⠤⠨⠑⠞⠊⠑⠝⠝⠑ ⠕⠋ ⠨⠎⠁⠊⠝⠞⠤⠨⠿⠞⠊⠑⠝⠝⠑]
+  - [SAINT-ETIENNE of SAINT-ÉTIENNE, ⠘⠎⠁⠊⠝⠞⠤⠘⠑⠞⠊⠑⠝⠝⠑ ⠕⠋ ⠘⠎⠁⠊⠝⠞⠤⠘⠿⠞⠊⠑⠝⠝⠑]
+  - [BELGIE of BELGIË, ⠘⠃⠑⠇⠛⠊⠑ ⠕⠋ ⠘⠃⠑⠇⠛⠊⠫]
   - [Benedictus XVI, ⠨⠃⠑⠝⠑⠙⠊⠉⠞⠥⠎ ⠘⠭⠧⠊]
-  - [Jozef II-straat, ⠨⠚⠕⠵⠑⠋ ⠘⠊⠊⠤⠠⠎⠞⠗⠁⠁⠞]
+  - [Jozef II-straat, ⠨⠚⠕⠵⠑⠋ ⠘⠊⠊⠤⠎⠞⠗⠁⠁⠞]
   - [WO II, ⠘⠺⠕ ⠘⠊⠊]
   - [E.T.A., ⠘⠑⠲⠞⠲⠁⠲]
   - - Complex numbers mixed with letters (not fully implemented)
     - Zie refertes D-NE004W, D-NB007B en D-NB007BDK.
-    - ⠨⠵⠊⠑ ⠗⠑⠋⠑⠗⠞⠑⠎ ⠘⠙⠤⠝⠑⠼⠚⠚⠙⠺⠂ ⠘⠙⠤⠝⠃⠼⠚⠚⠛⠨⠃ ⠑⠝ ⠘⠙⠤⠝⠃⠼⠚⠚⠛⠘⠃⠙⠅⠲
-    - {xfail: true}
+    - ⠨⠵⠊⠑ ⠗⠑⠋⠑⠗⠞⠑⠎ ⠨⠙⠤⠘⠝⠑⠼⠚⠚⠙⠺⠂ ⠨⠙⠤⠘⠝⠃⠼⠚⠚⠛⠨⠃ ⠑⠝ ⠨⠙⠤⠘⠝⠃⠼⠚⠚⠛⠘⠃⠙⠅⠲
+    - xfail: true
   - [EEN woord in hoofdletters, ⠘⠑⠑⠝ ⠺⠕⠕⠗⠙ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
   - [TWEE WOORDEN in hoofdletters, ⠘⠞⠺⠑⠑ ⠘⠺⠕⠕⠗⠙⠑⠝ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
   - [DRIE WOORDEN IN hoofdletters, ⠘⠙⠗⠊⠑ ⠘⠺⠕⠕⠗⠙⠑⠝ ⠘⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
   - [MEER DAN DRIE WOORDEN in hoofdletters, ⠘⠘⠍⠑⠑⠗ ⠙⠁⠝ ⠙⠗⠊⠑ ⠘⠺⠕⠕⠗⠙⠑⠝ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
-  - [BTW-TARIEF volledig in hoofdletters, ⠘⠃⠞⠺⠤⠞⠁⠗⠊⠑⠋ ⠧⠕⠇⠇⠑⠙⠊⠛ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
-  - [BTW-tarief alleen btw in hoofdletters, ⠘⠃⠞⠺⠤⠠⠞⠁⠗⠊⠑⠋ ⠁⠇⠇⠑⠑⠝ ⠃⠞⠺ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
+  - [BTW-TARIEF volledig in hoofdletters, ⠘⠃⠞⠺⠤⠘⠞⠁⠗⠊⠑⠋ ⠧⠕⠇⠇⠑⠙⠊⠛ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
+  - [BTW-tarief alleen btw in hoofdletters, ⠘⠃⠞⠺⠤⠞⠁⠗⠊⠑⠋ ⠁⠇⠇⠑⠑⠝ ⠃⠞⠺ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
+  - [VN-verdrag, ⠘⠧⠝⠤⠧⠑⠗⠙⠗⠁⠛]
+  - [VN-Zeeverdrag, ⠘⠧⠝⠤⠨⠵⠑⠑⠧⠑⠗⠙⠗⠁⠛]
   - [P+R park and ride, ⠘⠏⠐⠖⠗ ⠏⠁⠗⠅ ⠁⠝⠙ ⠗⠊⠙⠑]
-  - [N-VA Nieuw-Vlaamse Alliantie, ⠘⠝⠤⠧⠁ ⠨⠝⠊⠑⠥⠺⠤⠨⠧⠇⠁⠁⠍⠎⠑ ⠨⠁⠇⠇⠊⠁⠝⠞⠊⠑]
+  - [N-VA Nieuw-Vlaamse Alliantie, ⠨⠝⠤⠘⠧⠁ ⠨⠝⠊⠑⠥⠺⠤⠨⠧⠇⠁⠁⠍⠎⠑ ⠨⠁⠇⠇⠊⠁⠝⠞⠊⠑]
   - [Firma Bossuyt & Zonen, ⠨⠋⠊⠗⠍⠁ ⠨⠃⠕⠎⠎⠥⠽⠞ ⠯ ⠨⠵⠕⠝⠑⠝]
   - ['C&A', ⠘⠉⠐⠯⠁]
   - ['CD&V Christen-Democratisch en Vlaams', ⠘⠉⠙⠐⠯⠧ ⠨⠉⠓⠗⠊⠎⠞⠑⠝⠤⠨⠙⠑⠍⠕⠉⠗⠁⠞⠊⠎⠉⠓ ⠑⠝ ⠨⠧⠇⠁⠁⠍⠎]
@@ -122,6 +140,11 @@ tests:
   - [lisa_dirk@yahoo.com, ⠇⠊⠎⠁⠸⠙⠊⠗⠅⠜⠽⠁⠓⠕⠕⠲⠉⠕⠍]
   - ['http://www.avh.asso.fr/', ⠓⠞⠞⠏⠒⠌⠌⠺⠺⠺⠲⠁⠧⠓⠲⠁⠎⠎⠕⠲⠋⠗⠌]
   - ['C:\\Documents and Settings', ⠨⠉⠒⠐⠡⠨⠙⠕⠉⠥⠍⠑⠝⠞⠎ ⠁⠝⠙ ⠨⠎⠑⠞⠞⠊⠝⠛⠎]
+  - ['Naam | Adresstraat 1 | 2018 Plaats', ⠨⠝⠁⠁⠍ ⠹ ⠨⠁⠙⠗⠑⠎⠎⠞⠗⠁⠁⠞ ⠼⠁ ⠹ ⠼⠃⠚⠁⠓ ⠨⠏⠇⠁⠁⠞⠎]
+  - ['ja | nee', ⠚⠁ ⠹ ⠝⠑⠑]
+  - ['ja |nee', ⠚⠁ ⠹ ⠝⠑⠑]
+  - ['ja| nee', ⠚⠁ ⠹ ⠝⠑⠑]
+  - ['ja|nee', ⠚⠁ ⠹ ⠝⠑⠑]
   - ['€ 12,35', ⠑⠼⠁⠃⠂⠉⠑]
   - ['€12,35', ⠑⠼⠁⠃⠂⠉⠑]
   - ['$ 10,00', ⠙⠼⠁⠚⠂⠚⠚]
@@ -130,24 +153,36 @@ tests:
   - ['£65,47', ⠏⠼⠋⠑⠂⠙⠛]
   - [¥ 100.000, ⠽⠼⠁⠚⠚⠲⠚⠚⠚]
   - [¥100.000, ⠽⠼⠁⠚⠚⠲⠚⠚⠚]
-  - [Eén, ⠨⠿⠿⠝]
-  - [É-U, ⠘⠿⠤⠥]
+  - [Eén, ⠨⠑⠿⠝]
+    # This test was previously:
+    # [Eén, ⠨⠿⠿⠝]
+    # However, there is nothing in the braille standard
+    # to suggest that this replacement (E to É) should occur.
+  - [É-U, ⠨⠿⠤⠨⠥]
   - [cañon, ⠉⠁⠻⠕⠝]
   - [α β γ, ⠰⠁ ⠰⠃ ⠰⠛] # Some Greek lowercase
-  - ['''s morgens, baby''s, Alex'' boeken, de jaren ''90', ⠄⠎ ⠍⠕⠗⠛⠑⠝⠎⠂ ⠃⠁⠃⠽⠄⠎⠂ ⠨⠁⠇⠑⠭⠄ ⠃⠕⠑⠅⠑⠝⠂ ⠙⠑ ⠚⠁⠗⠑⠝ ⠄⠼⠊⠚]
-  - [Een typist(e) moet heel precies werken., ⠨⠑⠑⠝ ⠞⠽⠏⠊⠎⠞⠦⠑⠴ ⠍⠕⠑⠞ ⠓⠑⠑⠇ ⠏⠗⠑⠉⠊⠑⠎ ⠺⠑⠗⠅⠑⠝⠲]
   - [31-07-2010, ⠼⠉⠁⠤⠼⠚⠛⠤⠼⠃⠚⠁⠚]
   - [31/07/2010, ⠼⠉⠁⠌⠼⠚⠛⠌⠼⠃⠚⠁⠚]
   - [16.30 tot 21.30 uur, ⠼⠁⠋⠲⠉⠚ ⠞⠕⠞ ⠼⠃⠁⠲⠉⠚ ⠥⠥⠗]
   - ['16:30 tot 21:30 uur', ⠼⠁⠋⠒⠉⠚ ⠞⠕⠞ ⠼⠃⠁⠒⠉⠚ ⠥⠥⠗]
-  - ['Deze wandkaart heeft een schaal van 1 : 7.500.', ⠨⠙⠑⠵⠑ ⠺⠁⠝⠙⠅⠁⠁⠗⠞ ⠓⠑⠑⠋⠞ ⠑⠑⠝ ⠎⠉⠓⠁⠁⠇ ⠧⠁⠝ ⠼⠁ ⠒ ⠼⠛⠲⠑⠚⠚⠲]
   - [Een hoek van 27° 30'., ⠨⠑⠑⠝ ⠓⠕⠑⠅ ⠧⠁⠝ ⠼⠃⠛⠈⠴ ⠼⠉⠚⠈⠔⠲]
   - [Het record is 3' 5''., ⠨⠓⠑⠞ ⠗⠑⠉⠕⠗⠙ ⠊⠎ ⠼⠉⠈⠔ ⠼⠑⠈⠔⠔⠲]
   - [57° 38' noorderbreedte, ⠼⠑⠛⠈⠴ ⠼⠉⠓⠈⠔ ⠝⠕⠕⠗⠙⠑⠗⠃⠗⠑⠑⠙⠞⠑]
   - [no_reply@skynet.be, ⠝⠕⠸⠗⠑⠏⠇⠽⠜⠎⠅⠽⠝⠑⠞⠲⠃⠑]
   - [x_1 = 0, ⠭⠸⠼⠁ ⠶ ⠼⠚]
-  - - x,1
-    - ⠭⠂⠼⠁
+  - ['x,1', ⠭⠂⠼⠁]
+  - - '''s morgens, baby''s, Alex'' boeken, de jaren ''90'
+    - ⠄⠎ ⠍⠕⠗⠛⠑⠝⠎⠂ ⠃⠁⠃⠽⠄⠎⠂ ⠨⠁⠇⠑⠭⠄ ⠃⠕⠑⠅⠑⠝⠂ ⠙⠑ ⠚⠁⠗⠑⠝ ⠄⠼⠊⠚
+  - - Een typist(e) moet heel precies werken.
+    - ⠨⠑⠑⠝ ⠞⠽⠏⠊⠎⠞⠦⠑⠴ ⠍⠕⠑⠞ ⠓⠑⠑⠇ ⠏⠗⠑⠉⠊⠑⠎ ⠺⠑⠗⠅⠑⠝⠲
+  - - 'Deze wandkaart heeft een schaal van 1 : 7.500.'
+    - ⠨⠙⠑⠵⠑ ⠺⠁⠝⠙⠅⠁⠁⠗⠞ ⠓⠑⠑⠋⠞ ⠑⠑⠝ ⠎⠉⠓⠁⠁⠇ ⠧⠁⠝ ⠼⠁ ⠒ ⠼⠛⠲⠑⠚⠚⠲
+  - - Hij vertelde – zonder het te beseffen – een goede mop.
+    - ⠨⠓⠊⠚ ⠧⠑⠗⠞⠑⠇⠙⠑ ⠤ ⠵⠕⠝⠙⠑⠗ ⠓⠑⠞ ⠞⠑ ⠃⠑⠎⠑⠋⠋⠑⠝ ⠤ ⠑⠑⠝ ⠛⠕⠑⠙⠑ ⠍⠕⠏⠲
+  - - groente- en fruithandel
+    - ⠛⠗⠕⠑⠝⠞⠑⠤ ⠑⠝ ⠋⠗⠥⠊⠞⠓⠁⠝⠙⠑⠇
+  - - Op zijn laatste rapport stond voor wiskunde een 6+.
+    - ⠨⠕⠏ ⠵⠊⠚⠝ ⠇⠁⠁⠞⠎⠞⠑ ⠗⠁⠏⠏⠕⠗⠞ ⠎⠞⠕⠝⠙ ⠧⠕⠕⠗ ⠺⠊⠎⠅⠥⠝⠙⠑ ⠑⠑⠝ ⠼⠋⠐⠖⠲
   - - Landt je vader op Schiphol?
     - ⠨⠇⠁⠝⠙⠸⠞ ⠚⠑ ⠧⠁⠙⠑⠗ ⠕⠏ ⠨⠎⠉⠓⠊⠏⠓⠕⠇⠢
     - typeform:
@@ -164,14 +199,28 @@ tests:
     - ⠸⠸⠄⠞ ⠨⠊⠎ ⠞⠊⠚⠙ ⠕⠍ ⠝⠁⠁⠗ ⠓⠥⠊⠎ ⠞⠑ ⠸⠛⠁⠁⠝⠲
     - typeform:
         bold: '++++++++++++++++++++++++++++++++'
-  - - ZUID-AFRIKA was zijn droom.
-    - ⠸⠘⠵⠥⠊⠙⠤⠁⠋⠗⠊⠅⠁ ⠺⠁⠎ ⠵⠊⠚⠝ ⠙⠗⠕⠕⠍⠲
+  - - waterplant
+    - ⠸⠺⠁⠞⠑⠗⠠⠏⠇⠁⠝⠞
     - typeform:
-        bold: '+++++++++++                '
-  - - BTW-tarieven
-    - ⠸⠘⠃⠞⠺⠤⠠⠞⠁⠗⠊⠑⠧⠑⠝
+        underline: '+++++     '
+  - - Emphasis and hyphens (not implemented)
+    - ZUID-AFRIKA was zijn droom.
+    - ⠸⠘⠵⠥⠊⠙⠤⠸⠘⠁⠋⠗⠊⠅⠁ ⠺⠁⠎ ⠵⠊⠚⠝ ⠙⠗⠕⠕⠍⠲
     - typeform:
-        bold: '++++        '
+        {bold: '+++++++++++                '}
+      xfail: true
+  - - Emphasis and hyphens (not implemented)
+    - BTW-tarieven
+    - ⠸⠘⠃⠞⠺⠤⠞⠁⠗⠊⠑⠧⠑⠝
+    - typeform:
+        {italic: '+++         '}
+      xfail: true
+  - - Emphasis and hyphens (not implemented)
+    - Zuid-Afrika
+    - ⠸⠨⠵⠥⠊⠙⠤⠸⠨⠁⠋⠗⠊⠅⠁
+    - typeform:
+        {bold: '+++++++++++'}
+      xfail: true
   - - 3de
     - ⠼⠉⠸⠙⠑
     - typeform:
@@ -188,6 +237,9 @@ tests:
     - ⠸⠧⠑⠞⠛⠑⠙⠗⠥⠅⠞
     - typeform:
         bold: '++++++++++'
+  - - Not part of the braille standard
+    - 'CO₂-uitstoot: 158 g CO₂/km'
+    - ⠘⠉⠕⠡⠆⠤⠥⠊⠞⠎⠞⠕⠕⠞⠒ ⠼⠁⠑⠓ ⠛ ⠘⠉⠕⠡⠆⠌⠅⠍
 
 table:
   locale: nl


### PR DESCRIPTION
This updates the Dutch tables to the [braille standard 2017](http://braille-autoriteit.org/algemeen-gebruik/versie-2017-van-zespunts-standaard).

There is still much more work to do beyond updating the braille standard:
* Finally make emphasis work analogous to capitalization, i.e. an `emphmodechars` opcode.
* Include all examples from the braille standard as tests, ordered by section.
* Remove tests/tweaks implemented by non-Braille Autoriteit agencies to get a purer table.
- Improve backtranslation.

I don't address these points in this PR. However, I do want to find a better way to handle the various types of single quotes in `capsmodechars`.