### PR TITLE
If test fails also print the associated table name

### DIFF
--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -280,6 +280,10 @@ check_base(const char *tableList, const char *input, const char *expected,
 			fprintf(stderr, "Expected: %d, received: %d\n", in.real_inlen, actualInlen);
 			retval = 1;
 		}
+		// on error print the table name, as it isn't always
+		// clear which table we are testing. In checkyaml for
+		// example you can define a test for multiple tables.
+		if (retval != 0) fprintf(stderr, "Table: %s\n", tableList);
 
 	fail:
 		free(inbuf);

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -284,9 +284,9 @@ check_base(const char *tableList, const char *input, const char *expected,
 		// clear which table we are testing. In checkyaml for
 		// example you can define a test for multiple tables.
 		if (retval != 0) {
-		  fprintf(stderr, "Table: %s\n", tableList);
-		  // add an empty line after each error
-		  fprintf(stderr, "\n");
+			fprintf(stderr, "Table: %s\n", tableList);
+			// add an empty line after each error
+			fprintf(stderr, "\n");
 		}
 
 	fail:

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -283,7 +283,11 @@ check_base(const char *tableList, const char *input, const char *expected,
 		// on error print the table name, as it isn't always
 		// clear which table we are testing. In checkyaml for
 		// example you can define a test for multiple tables.
-		if (retval != 0) fprintf(stderr, "Table: %s\n", tableList);
+		if (retval != 0) {
+		  fprintf(stderr, "Table: %s\n", tableList);
+		  // add an empty line after each error
+		  fprintf(stderr, "\n");
+		}
 
 	fail:
 		free(inbuf);

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -92,7 +92,7 @@ const char *event_names[] = { "YAML_NO_EVENT", "YAML_STREAM_START_EVENT",
 const char *encoding_names[] = { "YAML_ANY_ENCODING", "YAML_UTF8_ENCODING",
 	"YAML_UTF16LE_ENCODING", "YAML_UTF16BE_ENCODING" };
 
-const char *inline_table_prefix = "checkyaml_inline_";
+const char *inline_table_prefix = "checkyaml_inline_table_at_line_";
 
 char *file_name;
 
@@ -208,7 +208,7 @@ read_table(yaml_event_t *start_event, yaml_parser_t *parser, const char *display
 			// If the scalar ends with a newline, assume it is a block
 			// scalar, so treat as an inline table. (Is there a proper way
 			// to check for a block scalar?)
-			sprintf(table, "%s%d", inline_table_prefix, rand());
+			sprintf(table, "%s%d", inline_table_prefix, start_event->start_mark.line + 1);
 			p = event.data.scalar.value;
 			yaml_char_t *line_start = p;
 			int line_len = 0;


### PR DESCRIPTION
With the possibility to define one test for multiple tables in
checkyaml it is not always clear in which table a problem occurred.
This patch should help to locate the table that is the culprit for a
failed test.