### PR TITLE
Implement a isValidMode function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,11 +23,13 @@ issues]].
 ** Other changes
 - Updated the ~lou_allround~ and ~lou_trace~ test tools to include all
   the mode flags described in the documentation of the
-  ~lou_translateString()~ function. Thanks to Bue Vester-Andersen
+  ~lou_translateString()~ function, thanks to Bue Vester-Andersen
 
 ** Deprecation notice
 
 ** Backwards incompatible changes
+- The ~pass1Only~ flag has been deprecated for a while and is now
+  removed from the code, thanks to Bue Vester-Andersen.
 
 ** New, renamed or removed tables
 *** New

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -799,6 +799,11 @@ _lou_logMessage(logLevels level, const char *format, ...);
 
 extern int translation_direction;
 
+/**
+ * Return true if given translation mode is valid.
+ */
+int isValidMode(int mode);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -803,7 +803,7 @@ extern int translation_direction;
  * Return 1 if given translation mode is valid. Return 0 otherwise.
  */
 int EXPORT_CALL
-isValidMode(int mode);
+_lou_isValidMode(int mode);
 
 #ifdef __cplusplus
 }

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -800,9 +800,9 @@ _lou_logMessage(logLevels level, const char *format, ...);
 extern int translation_direction;
 
 /**
- * Return true if given translation mode is valid.
+ * Return 1 if given translation mode is valid. Return 0 otherwise.
  */
-int
+int EXPORT_CALL
 isValidMode(int mode);
 
 #ifdef __cplusplus

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -802,7 +802,8 @@ extern int translation_direction;
 /**
  * Return true if given translation mode is valid.
  */
-int isValidMode(int mode);
+int
+isValidMode(int mode);
 
 #ifdef __cplusplus
 }

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -99,8 +99,7 @@ typedef enum {
 	noContractions = 1,
 	compbrlAtCursor = 2,
 	dotsIO = 4,
-	// for historic reasons 8 is free
-	pass1Only = 16,  // defunct
+	// for historic reasons 8 and 16 are free
 	compbrlLeftCursor = 32,
 	ucBrl = 64,
 	noUndefinedDots = 128,

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -176,6 +176,10 @@ _lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int 
 		return 0;
 	const TranslationTableHeader *table = lou_getTable(tableList);
 	if (table == NULL) return 0;
+
+	if (!isValidMode(mode))
+		_lou_logMessage(LOG_ERROR, "Invalid mode parameter: %d", mode);
+
 	if (!stringBufferPool) initStringBufferPool();
 	for (idx = 0; idx < stringBufferPool->size; idx++) releaseStringBuffer(idx);
 	{
@@ -225,10 +229,6 @@ _lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int 
 	} else {
 		appliedRules = NULL;
 		maxAppliedRules = 0;
-	}
-
-	if (mode & pass1Only) {
-		_lou_logMessage(LOG_WARN, "warning: pass1Only mode is no longer supported.");
 	}
 
 	posMapping = posMapping1;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -177,7 +177,7 @@ _lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int 
 	const TranslationTableHeader *table = lou_getTable(tableList);
 	if (table == NULL) return 0;
 
-	if (!isValidMode(mode))
+	if (!_lou_isValidMode(mode))
 		_lou_logMessage(LOG_ERROR, "Invalid mode parameter: %d", mode);
 
 	if (!stringBufferPool) initStringBufferPool();

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1123,7 +1123,7 @@ _lou_translateWithTracing(const char *tableList, const widechar *inbufx, int *in
 			LOG_ALL, "Performing translation: tableList=%s, inlen=%d", tableList, *inlen);
 	_lou_logWidecharBuf(LOG_ALL, "Inbuf=", inbufx, *inlen);
 
-	if (!isValidMode(mode))
+	if (!_lou_isValidMode(mode))
 		_lou_logMessage(LOG_ERROR, "Invalid mode parameter: %d", mode);
 
 	table = lou_getTable(tableList);

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1123,9 +1123,8 @@ _lou_translateWithTracing(const char *tableList, const widechar *inbufx, int *in
 			LOG_ALL, "Performing translation: tableList=%s, inlen=%d", tableList, *inlen);
 	_lou_logWidecharBuf(LOG_ALL, "Inbuf=", inbufx, *inlen);
 
-	if (mode & pass1Only) {
-		_lou_logMessage(LOG_WARN, "warning: pass1Only mode is no longer supported.");
-	}
+	if (!isValidMode(mode))
+		_lou_logMessage(LOG_ERROR, "Invalid mode parameter: %d", mode);
 
 	table = lou_getTable(tableList);
 	if (table == NULL || *inlen < 0 || *outlen < 0) return 0;

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -238,3 +238,18 @@ _lou_debugHook(void) {
 	printf("%s\n", hook);
 }
 #endif
+
+const int validTranslationModes[] = { noContractions, compbrlAtCursor, dotsIO,
+	compbrlLeftCursor, ucBrl, noUndefinedDots, partialTrans };
+
+int
+isValidMode(int mode) {
+	for (int i = 0; i < (sizeof(validTranslationModes) / sizeof(*validTranslationModes));
+			i++) {
+		if (validTranslationModes[i] == mode) {
+			return 1;
+		}
+	}
+	return 0;
+}
+

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -243,7 +243,7 @@ const int validTranslationModes[] = { noContractions, compbrlAtCursor, dotsIO,
 	compbrlLeftCursor, ucBrl, noUndefinedDots, partialTrans };
 
 int EXPORT_CALL
-isValidMode(int mode) {
+_lou_isValidMode(int mode) {
 	for (int i = 0; i < (sizeof(validTranslationModes) / sizeof(*validTranslationModes));
 			i++) {
 		if (validTranslationModes[i] == mode) {

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -242,7 +242,7 @@ _lou_debugHook(void) {
 const int validTranslationModes[] = { noContractions, compbrlAtCursor, dotsIO,
 	compbrlLeftCursor, ucBrl, noUndefinedDots, partialTrans };
 
-int
+int EXPORT_CALL
 isValidMode(int mode) {
 	for (int i = 0; i < (sizeof(validTranslationModes) / sizeof(*validTranslationModes));
 			i++) {

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -252,4 +252,3 @@ isValidMode(int mode) {
 	}
 	return 0;
 }
-


### PR DESCRIPTION
and use that to check mode input. This is turn is then used to reject any deprecated modes such as pass1Only

This is IMHO a cleaner implementation of #645. It also removes the pass1Only flag.

The layout of the code is a bit odd. We have an array (`validTranslationModes[]` in `utils.c`) that contains all the valid modes. Naturally this is very tightly coupled to the enum type declaration in `liblouis.h.in`. Maybe these two declarions should be closer together.

Also since this is really an internal helper function it should maybe not be in `internal.h` which is despite its name semi-public

Also the other functions in `utils.c` also seem to be publicly exported functions, whereas `isValidMode` is strictly internal. Should it go into another utils file?