### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/tables/nl-BE-g0.utb
+++ b/tables/nl-BE-g0.utb
@@ -33,7 +33,7 @@
 #              (Braille Autoriteit, 2018)
 #               [https://github.com/liblouis/braille-specs/tree/master/dutch][1]
 #          and: « World Braille Usage (3rd edition) »
-#               [https://cdn.rawgit.com/liblouis/braille-specs/master/world-braille-usage-third-edition.pdf][2]
+#               [https://cdn.combinatronics.com/liblouis/braille-specs/master/world-braille-usage-third-edition.pdf][2]
 #
 # ----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.