### PR TITLE
Norwegian: fix tests for handling of punctuation when there's two or more capital words

### DIFF
--- a/tests/braille-specs/no_harness.yaml
+++ b/tests/braille-specs/no_harness.yaml
@@ -372,7 +372,8 @@ tests:
   - [DEN BESTE BURSDAGEN jeg har hatt var da jeg fylte åtte., ⠠⠠⠠⠙⠑⠝ ⠃⠑⠎⠞⠑ ⠃⠥⠗⠎⠙⠁⠛⠑⠝⠠ ⠚⠑⠛ ⠓⠁⠗ ⠓⠁⠞⠞ ⠧⠁⠗ ⠙⠁ ⠚⠑⠛ ⠋⠽⠇⠞⠑ ⠡⠞⠞⠑⠄,]
   # Headlines
   - [EN ROSE MED TORNER, ⠠⠠⠠⠑⠝ ⠗⠕⠎⠑ ⠍⠑⠙ ⠞⠕⠗⠝⠑⠗⠠]
-  - [EN ROSE! MED 15 TORNER., ⠠⠠⠠⠑⠝ ⠗⠕⠎⠑⠖ ⠍⠑⠙ ⠼⠁⠑ ⠞⠕⠗⠝⠑⠗⠄⠠]
+  - [EN ROSE! MED 15 TORNER., ⠠⠠⠠⠑⠝ ⠗⠕⠎⠑⠖ ⠍⠑⠙ ⠼⠁⠑ ⠞⠕⠗⠝⠑⠗⠠⠄, xfail: "period and endcaps switched"]
+  - ["EN ROSE! MED 15 TORNER?", ⠠⠠⠠⠑⠝ ⠗⠕⠎⠑⠖ ⠍⠑⠙ ⠼⠁⠑ ⠞⠕⠗⠝⠑⠗⠠⠢, xfail: "question mark and encdaps switched"]
   - [SAK 27/07 SØKNAD OM ØKONOMISK STØTTE FOR 2007, ⠠⠠⠠⠎⠁⠅ ⠼⠃⠛⠌⠼⠚⠛ ⠎⠪⠅⠝⠁⠙ ⠕⠍ ⠪⠅⠕⠝⠕⠍⠊⠎⠅ ⠎⠞⠪⠞⠞⠑ ⠋⠕⠗ ⠼⠃⠚⠚⠛⠠, {xfail: not implemented yet}]
   # Numeric characters
   - ['1', ⠼⠁]


### PR DESCRIPTION
See: nlbdev/pipeline#214

Currently capitalized words are prefixed with "⠠⠠" (6-6). When there are multiple capitalized words after each other, then the first word should be prefixed with "⠠⠠⠠" (6-6-6) and the last word should be suffixed with "⠠" (6).

(PR only contains updated tests. Needs implementation.)