### PR TITLE
Corrects dot pattern for anterior.

### DIFF
--- a/tables/en-us-g2.ctb
+++ b/tables/en-us-g2.ctb
@@ -87,7 +87,7 @@ midendword anda 12346-1 panda
 midword :// 156-34-34
 midword angh = Shanghai
 begword anted =
-always anterior 1-1345-2345-23456-24-135-1235
+always anterior 1-1345-2345-12456-24-135-1235
 begword anter =
 begword aqued = aqueduct
 always ar 345

--- a/tests/braille-specs/en-us-g2-dictionary_harness.yaml
+++ b/tests/braille-specs/en-us-g2-dictionary_harness.yaml
@@ -3247,7 +3247,7 @@ tests:
   - [antenna's, ⠁⠝⠞⠢⠝⠁⠄⠎]
   - [antennae, ⠁⠝⠞⠢⠝⠁⠑]
   - [antennas, ⠁⠝⠞⠢⠝⠁⠎]
-  - [anterior, ⠁⠝⠞⠻⠊⠕⠗, {xfail: true}]
+  - [anterior, ⠁⠝⠞⠻⠊⠕⠗]
   - [anteroom, ⠁⠝⠞⠑⠗⠕⠕⠍]
   - [anteroom's, ⠁⠝⠞⠑⠗⠕⠕⠍⠄⠎]
   - [anterooms, ⠁⠝⠞⠑⠗⠕⠕⠍⠎]


### PR DESCRIPTION
This changes the dot pattern for the "er" of "anterior" from 23456 to 12456.