### PR TITLE
Update the Norwegian tables

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,8 +20,8 @@ issues]].
   are finally defined.
 - Fix a few issues with hungarian grade1 and grade2 Braille thanks to
   Attila Hammer.
-- Various improvements to Norwegian thanks to Jostein Austvik Jacobsen
-  and Ammar Usama from NLB.
+- Various improvements to Norwegian thanks to Lars Bjørndal, Jostein
+  Austvik Jacobsen, Ammar Usama and Bert Frees.
 
 ** Other changes
 

--- a/tables/no-no-chardefs6.uti
+++ b/tables/no-no-chardefs6.uti
@@ -2,13 +2,13 @@
 #
 #  Copyright (C) 2004-2008 ViewPlus Technologies, Inc. www.viewplus.com
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
-#  Copyright (C) 2009 Lars Bjørndal <lars@lamasti.net>
-#  Copyright (C) 2015 NLB Norwegian library of talking books and braille, http://www.nlb.no/
+#  Copyright (C) 2009-2019 Lars Bjørndal <lars@lamasti.net>
+#  Copyright (C) 2015-2018 NLB Norwegian library of talking books and braille, http://www.nlb.no/
 #
 #-copyright: 2004-2008, ViewPlus Technologies, Inc. www.viewplus.com
 #-copyright: 2004-2006, JJB Software, Inc. www.jjb-software.com
-#-copyright: 2009, Lars Bjørndal <lars@lamasti.net>
-#-copyright: 2015, NLB Norwegian library of talking books and braille, http://www.nlb.no/
+#-copyright: 2009-2019, Lars Bjørndal <lars@lamasti.net>
+#-copyright: 2015-2018, NLB Norwegian library of talking books and braille, http://www.nlb.no/
 #
 # Created June 9, 2005 by Leon Ungier <Leon.Ungier@ViewPlus.com> with
 # help and guidance from Lars Bjørndal <lars@lamasti.net>

--- a/tables/no-no-chardefs6.uti
+++ b/tables/no-no-chardefs6.uti
@@ -117,6 +117,7 @@ sign _ 456                   # low line x005F
 sign ` 45                    # grave accent x0060
 sign \x00AF 45               # macron
 sign \x0304 45               # combining macron
+uplow \x00C9\x00E9 123456    # e with acute é x00C9 / 00E9
 sign | 123456                # vertical line x007C
 sign ~ 1456                  # tilde x007E
 sign \x0080 15-136-1235-135  # Euro sign x0080
@@ -167,19 +168,18 @@ uplow Ψψ 13456               # psi
 uplow Ωω 2456                # omega
 
 uplow \x00C8\x00E8 2346      # e with grave è x00C8 / 00E8
-uplow \x00C9\x00E9 123456    # e with acute é x00C9 / 00E9
 uplow \x00CA\x00EA 126       # e with circumflex x00CA / 00EA
 uplow \x010C\x010D 146       # c with caron x00CE / 00EE
 uplow \x00CF\x00EF 34        # i with diaeresis x00CF / 00EF
 uplow \x00D4\x00F4 46-135    # o with circumflex ô x00D4 / 00F4
 uplow \x00CD\x00ED 126       # i with acute x00CD / 00ED
 uplow \x00C6\x00E6 345       # æ x00C6 / 00E6
+uplow Åå 16                  # A with ring above x00C5 / 00E5
 uplow \x00C1\x00E1 16        # a with acute x00C1 / 00E1
 uplow Øø 246                 # o with stroke
 uplow \X00DA\x00FA 12456     # u with acute x00DA / 00FA
 uplow \x00DC\x00FC 1256      # u with diaeresis x00FC
 uplow \x00DD\x00FD 12346     # y with acute x00FD
-uplow Åå 16                  # A with ring above x00C5 / 00E5
 uplow \x00C0\x00E0 12356     # a with grave x00C0 / 00E0
 uplow \x00C2\x00E2 46-1      # a with circumflex x00C2 / 00E2
 uplow Ää 345                 # A with diaeresis x00C4 / 00E4
@@ -193,7 +193,8 @@ uplow Đđ 1456                # d with stroke
 uplow Ðð 156                 # Eth
 uplow Ŋŋ 1246                # Eng
 uplow Þþ 35-2345             # Thorn
-uplow Üü 1245                # u with diaeresis
+#uplow Üü 1245                # u with diaeresis
+uplow Üü 1256                # u with diaeresis
 uplow Ŧŧ 1256                # t with stroke
 uplow Ṥṥ 156                 # Latin Letter S with Acute and Dot Above
 uplow Šš 156                 # Latin Letter S with Caron

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -11,12 +11,12 @@
 #+grade:0
 #
 #  Copyright (C) 2005 ViewPlus Technologies, Inc. www.viewplus.com
-#  Copyright (C) 2009 Lars Bjørndal <lars@lamasti.net>
-#  Copyright (C) 2015 NLB Norwegian library of talking books and braille, http://www.nlb.no/
+#  Copyright (C) 2009-2019 Lars Bjørndal <lars@lamasti.net>
+#  Copyright (C) 2015-2018 NLB Norwegian library of talking books and braille, http://www.nlb.no/
 #
 #-copyright: 2005, ViewPlus Technologies, Inc. www.viewplus.com
-#-copyright: 2009, Lars Bjørndal
-#-copyright: 2015, Norwegian library of talking books and braille (NLB), http://www.nlb.no/
+#-copyright: 2009-2019, Lars Bjørndal
+#-copyright: 2015-2018, Norwegian library of talking books and braille (NLB), http://www.nlb.no/
 #-license: LGPLv2.1
 #
 # Created June 9, 2005 by Leon Ungier <Leon.Ungier@ViewPlus.com> with

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -61,6 +61,7 @@
 #  <http://www.gnu.org/licenses/>.
 #
 
+include no-no.dis
 include no-no-chardefs6.uti
 include litdigits6Dots.uti
 include braille-patterns.cti # unicode braille
@@ -71,7 +72,7 @@ include braille-patterns.cti # unicode braille
 numsign 3456
 capsletter 6                    # single capital letter indicator
 begcapsword 6-6                  # a block of consecutive capital letters indicator
-endcapsword 56                   # TODO
+noback endcapsword 56                   # TODO
 
 emphclass italic
 emphclass underline
@@ -81,7 +82,7 @@ begemph italic 23
 begemph bold 6-3
 begemph underline 456
 
-endemph italic 56
+noback endemph italic 56
 endemph bold 6-3
 endemph underline 456
 
@@ -116,6 +117,8 @@ noback always ;\s; 0
 begcomp 126
 endcomp 345
 
+# We have to redefine the letter æ here to prevent back translation of it to result in a space
+uplow \x00C6\x00E6 345       # æ x00C6 / 00E6
 # URLs
 compbrl ://
 compbrl www.

--- a/tables/no-no-g1.ctb
+++ b/tables/no-no-g1.ctb
@@ -11,10 +11,10 @@
 #+grade:1
 #
 #  Copyright (C) 2005 ViewPlus Technologies, Inc. www.viewplus.com
-#  Copyright (C) 2009 Lars Bjørndal <lars@lamasti.net>
+#  Copyright (C) 2009-2014 Lars Bjørndal <lars@lamasti.net>
 #
 #-copyright: 2005, ViewPlus Technologies, Inc. www.viewplus.com
-#-copyright: 2009, Lars Bjørndal
+#-copyright: 2009-2014, Lars Bjørndal
 #-license: LGPLv2.1
 #
 # Created June 9, 2005 by Leon Ungier <Leon.Ungier@ViewPlus.com> with

--- a/tables/no-no-g3.ctb
+++ b/tables/no-no-g3.ctb
@@ -1,10 +1,10 @@
 # liblouis: Norwegian literary braille, 6-dot, contracted level 3
 #
 #  Copyright (C) 2005 ViewPlus Technologies, Inc. www.viewplus.com
-#  Copyright (C) 2005, 2012 Lars Bjørndal <lars@lamasti.net>
+#  Copyright (C) 2005-2012 Lars Bjørndal <lars@lamasti.net>
 #
 #-copyright: 2005, ViewPlus Technologies, Inc. www.viewplus.com
-#-copyright: 2005, 2012, Lars Bjørndal <lars@lamasti.net>
+#-copyright: 2005-2012, Lars Bjørndal <lars@lamasti.net>
 #-license: LGPLv2.1
 #
 # Created June 9, 2005 by Leon Ungier <Leon.Ungier@ViewPlus.com> with

--- a/tables/no-no-latinLetterDef6Dots_diacritics.uti
+++ b/tables/no-no-latinLetterDef6Dots_diacritics.uti
@@ -28,7 +28,8 @@
 
 uplow Áá 4-1          # Latin Letter a with Acute
 uplow Ćć 4-14         # Latin Letter C with Acute
-uplow Éé 4-15         # Latin Letter E with Acute
+# Commented out to get É become 6-123456 correct, defined in no-no-chardefs6.uti. More equivalent later in this file.
+#uplow Éé 4-15         # Latin Letter E with Acute
 uplow Ǵǵ 4-1245       # Latin Letter G with Acute
 uplow Íí 4-24         # Latin Letter I with Acute
 uplow Ḱḱ 4-13         # Latin Letter K with Acute
@@ -78,7 +79,7 @@ sign  ǅ  4-1356       # Latin Capital Letter D with Small Letter Z with Caron
 uplow Žž 4-1356       # Latin Letter Z with Caron
 uplow Ḉḉ 4-14         # Latin Letter C with Cedilla and Acute
 uplow Ḝḝ 4-15         # Latin Letter E with Cedilla and Breve
-uplow Çç 4-14         # Latin Letter C with Cedilla
+#uplow Çç 4-14         # Latin Letter C with Cedilla
 uplow Ḑḑ 4-145        # Latin Letter D with Cedilla
 uplow Ȩȩ 4-15         # Latin Letter E with Cedilla
 uplow Ģģ 4-1245       # Latin Letter G with Cedilla
@@ -112,7 +113,7 @@ uplow Ṱṱ 4-2345       # Latin Letter T with Circumflex Below
 uplow Ṷṷ 4-136        # Latin Letter U with Circumflex Below
 uplow Ââ 4-1          # Latin Letter a with Circumflex
 uplow Ĉĉ 4-14         # Latin Letter C with Circumflex
-uplow Êê 4-15         # Latin Letter E with Circumflex
+#uplow Êê 4-15         # Latin Letter E with Circumflex
 uplow Ĝĝ 4-1245       # Latin Letter G with Circumflex
 uplow Ĥĥ 4-125        # Latin Letter H with Circumflex
 uplow Îî 4-24         # Latin Letter I with Circumflex
@@ -148,13 +149,13 @@ uplow Ǟǟ 4-1          # Latin Letter a with Diaeresis and Macron
 uplow Ȫȫ 4-135        # Latin Letter O with Diaeresis and Macron
 uplow Ǖǖ 4-136        # Latin Letter U with Diaeresis and Macron
 uplow Ṳṳ 4-136        # Latin Letter U with Diaeresis Below
-uplow Ää 4-1          # Latin Letter a with Diaeresis
+#uplow Ää 4-1          # Latin Letter a with Diaeresis
 uplow Ëë 4-15         # Latin Letter E with Diaeresis
 uplow Ḧḧ 4-125        # Latin Letter H with Diaeresis
 uplow Ïï 4-24         # Latin Letter I with Diaeresis
-uplow Öö 4-135        # Latin Letter O with Diaeresis
+#uplow Öö 4-135        # Latin Letter O with Diaeresis
 lowercase  ẗ  4-2345  # Latin Small Letter T with Diaeresis
-uplow Üü 4-136        # Latin Letter U with Diaeresis
+#uplow Üü 4-136        # Latin Letter U with Diaeresis
 uplow Ẅẅ 4-2456       # Latin Letter W with Diaeresis
 uplow Ẍẍ 4-1346       # Latin Letter X with Diaeresis
 uplow Ÿÿ 4-13456      # Latin Letter Y with Diaeresis
@@ -221,11 +222,16 @@ lowercase  ɾ  4-1235  # Latin Small Letter R with Fishhook
 uplow Ꞗꞗ 4-12         # Latin Letter B with Flourish
 lowercase  ꬴ  4-15    # Latin Small Letter E with Flourish
 uplow Ꝓꝓ 4-1234       # Latin Letter P with Flourish
-uplow Àà 4-1          # Latin Letter a with Grave
-uplow Èè 4-15         # Latin Letter E with Grave
+# Commented out to get À become 6-12356 correct, defined in no-no-chardefs6.uti
+#uplow Àà 4-1          # Latin Letter a with Grave
+
+# Commented out to get È become 6-2346 correct, defined in no-no-chardefs6.uti
+#uplow Èè 4-15         # Latin Letter E with Grave
 uplow Ìì 45-24         # Latin Letter I with Grave
 uplow Ǹǹ 4-1345       # Latin Letter N with Grave
-uplow Òò 4-135        # Latin Letter O with Grave
+
+# Commented out to get Ò become 6-346 correct, defined in no-no-chardefs6.uti
+#uplow Òò 4-135        # Latin Letter O with Grave
 uplow Ùù 45-136        # Latin Letter U with Grave
 uplow Ẁẁ 4-2456       # Latin Letter W with Grave
 uplow Ỳỳ 4-13456      # Latin Letter Y with Grave

--- a/tables/no-no-latinLetterDef6Dots_diacritics.uti
+++ b/tables/no-no-latinLetterDef6Dots_diacritics.uti
@@ -1,6 +1,7 @@
 # liblouis: sub table for defining latin letters with diacritics, 6 dots.
 #
-#  Copyright (C) 2015 NLB Norwegian library of talking books and braille, http://www.nlb.no/
+#  Copyright (C) 2015-2016 NLB Norwegian library of talking books and braille, http://www.nlb.no/
+#  Copyright (C) 2019 Lars Bjørndal <lars@lamasti.net>
 #
 #-copyright: 2015, Norwegian library of talking books and braille (NLB), www.nlb.no
 #-license: LGPLv2.1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -136,6 +136,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/nl-NL-g0_harness.yaml		  \
 	braille-specs/nl-g0_harness.yaml		  \
 	braille-specs/no_8dot_harness.yaml		  \
+	braille-specs/no_backward.yaml			  \
 	braille-specs/no_g1_harness.yaml		  \
 	braille-specs/no_g2_harness.yaml		  \
 	braille-specs/no_harness.yaml			  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -79,6 +79,7 @@ EXTRA_DIST =					\
 	nl-NL-g0_harness.yaml			\
 	nl-g0_harness.yaml			\
 	no_8dot_harness.yaml			\
+	no_backward.yaml			\
 	no_g1_harness.yaml			\
 	no_g2_harness.yaml			\
 	no_harness.yaml				\

--- a/tests/braille-specs/no_backward.yaml
+++ b/tests/braille-specs/no_backward.yaml
@@ -1,0 +1,15 @@
+display: unicode.dis
+table:
+  locale: no
+  grade: 1
+  __assert-match: no-no-g1.ctb
+flags: {testmode: backward}
+tests:
+  - [⠠⠙ ⠉ ⠚, Du og jeg]
+  - [⠧⠗⠜⠇, vræl]
+  - [⠰⠠⠉ ⠅⠕⠍⠍⠱ ⠪ ⠰⠙, C kommer før d]
+  - ['⠠⠞⠗⠑ ⠝⠕⠗⠎⠅⠑ ⠎⠜⠗⠞⠑⠛⠝ ⠍⠡ ⠜ ⠰⠜⠂ ⠰⠪ ⠉ ⠡⠄', 'Tre norske særtegn må være æ, ø og å.']
+
+flags: {testmode: bothDirections}
+tests:
+  - [nlb.no, ⠣⠝⠇⠃⠄⠝⠕⠜, {xfail: true}]

--- a/tests/braille-specs/no_harness.yaml
+++ b/tests/braille-specs/no_harness.yaml
@@ -4,20 +4,31 @@ table:
   grade: 0
   dots: 6
   __assert-match: no-no-g0.utb
+
 tests:
   # Norwegian alphabet
   - [a b c d e f g h i j k l m n o p q r s t u v w x y z æ ø å Æ Ø Å, ⠁ ⠃ ⠉ ⠙ ⠑ ⠋ ⠛ ⠓ ⠊ ⠚ ⠅ ⠇ ⠍ ⠝ ⠕ ⠏ ⠟ ⠗ ⠎ ⠞ ⠥ ⠧ ⠺ ⠭ ⠽ ⠵ ⠜ ⠪ ⠡ ⠠⠜ ⠠⠪ ⠠⠡]
   # Letters used in Norwegian
   - [à, ⠷]
+  - [À, ⠠⠷]
   - [ä, ⠜]
+  - [Ä, ⠠⠜]
   - [ç, ⠯]
+  - [Ç, ⠠⠯]
   - [é, ⠿]
+  - [É, ⠠⠿]
   - [è, ⠮]
+  - [È, ⠠⠮]
   - [ê, ⠣]
+  - [Ê, ⠠⠣]
   - [ò, ⠬]
+  - [Ò, ⠠⠬]
   - [ö, ⠪]
+  - [Ö, ⠠⠪]
   - [ü, ⠳]
+  - [Ü, ⠠⠳]
   - [à, ⠷]
+  - [À, ⠠⠷]
   # Alphabets used in Norwegian
   - [vis à vis, ⠧⠊⠎ ⠷ ⠧⠊⠎] # Example 1
   - [à jour, ⠷ ⠚⠕⠥⠗] # Example 2
@@ -570,6 +581,7 @@ tests:
   - [Bildet kostet 125 SEK i Stockholm., ⠠⠃⠊⠇⠙⠑⠞ ⠅⠕⠎⠞⠑⠞ ⠼⠁⠃⠑ ⠠⠠⠎⠑⠅ ⠊ ⠠⠎⠞⠕⠉⠅⠓⠕⠇⠍⠄]
   - [Hytteleia i Århus var DKK 700 pr. døgn., ⠠⠓⠽⠞⠞⠑⠇⠑⠊⠁ ⠊ ⠠⠡⠗⠓⠥⠎ ⠧⠁⠗ ⠠⠠⠙⠅⠅ ⠼⠛⠚⠚ ⠏⠗⠄ ⠙⠪⠛⠝⠄]
   # Edb-sign
+  - ['http://nlb.no', ⠣⠓⠞⠞⠏⠒⠌⠌⠝⠇⠃⠄⠝⠕⠜]
   -
     - Hun har e-postadressen line@online.no.
     - ⠠⠓⠥⠝ ⠓⠁⠗ ⠑⠤⠏⠕⠎⠞⠁⠙⠗⠑⠎⠎⠑⠝ ⠣⠇⠊⠝⠑⠈⠕⠝⠇⠊⠝⠑⠄⠝⠕⠜⠄


### PR DESCRIPTION
The purpose of this update is mainly to fix some problems caused by an update
in April 2015, that led to misbehavior when used with devices that don't
understand unicode bbraille. Some characters are moved to get higher
priority to output from liblouis.

In addition, I've added/fixed braille representation for some capital
accented letters that previously was wrong. These chars are added to the test file
no_harness.yaml as well.

Still there are one issue that I hope someone else can look into: the
begcomp/endcomp construct. I've added a test case, with status xfail, in the
file no_backward.yaml, to demonstrate the problem. The problem is not
introduced with this update.