### PR TITLE
Revert "Python binding: allows translate if tables are located in path with non-ASCII characters"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,9 +11,6 @@ issues]].
 ** Bug fixes
 - Fix a problem in the callback registration in the Python bindings
   thanks to Leonard de Ruijter
-- Fix a problem in the Python bindings when translating using tables
-  located in path with Non-ASCII characters. Thanks to André-Abush
-  Clause.
 - Fixed memory leaks created by block scope compound literals thanks
   to Martin Gieseking
 

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -44,16 +44,7 @@ import sys
 # Some general utility functions
 def _createTablesString(tablesList):
     """Creates a tables string for liblouis calls"""
-    if sys.version_info.major == 2:
-        if sys.platform == "win32":
-            return b",".join([x.decode("UTF-8") if isinstance(x, str) else bytes(x) for x in tablesList])
-        else:
-            return b",".join([x.decode("UTF-8").encode("UTF-8") if isinstance(x, str) else bytes(x) for x in tablesList])
-    else:
-        if sys.platform == "win32":
-            return b",".join([x.encode("mbcs") if isinstance(x, str) else bytes(x) for x in tablesList])
-        else:
-            return b",".join([x.encode("UTF-8") if isinstance(x, str) else bytes(x) for x in tablesList])
+    return b",".join([x.encode("ASCII") if isinstance(x, str) else bytes(x) for x in tablesList])
 
 def _createTypeformbuf(length, typeform=None):
     """Creates a typeform buffer for liblouis calls"""


### PR DESCRIPTION
Reverts liblouis/liblouis#699

Based on the discussion in #699 I'm reverting this