### PR TITLE
Fix UEB contracted back-translation of 'qk' and add YAML verification test

### DIFF
--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -1365,7 +1365,7 @@ nofor word paids  1234-145-234
 nofor word perceives  1234-12456-14-1236-234
 nofor word perceivings  1234-12456-14-1236-1245-234
 nofor word perhapss  1234-12456-125-234
-nofor word quicks  12345-13   10.9.3-234
+nofor word quicks  12345-13-234   10.9.3
 nofor word receives  1235-14-1236-234
 nofor word receivings  1235-14-1236-1245-234
 nofor word rejoices  1235-245-14-234
@@ -1441,7 +1441,7 @@ nofor word paid's  1234-145-3-234
 nofor word perceive's  1234-12456-14-1236-3-234
 nofor word perceiving's  1234-12456-14-1236-1245-3-234
 nofor word perhaps's  1234-12456-125-3-234
-nofor word quick's  12345-13   10.9.3-3-234
+nofor word quick's  12345-13-3-234   10.9.3
 nofor word receive's  1235-14-1236-3-234
 nofor word receiving's  1235-14-1236-1245-3-234
 nofor word rejoice's  1235-245-14-3-234

--- a/tests/braille-specs/en-ueb-g2_backward.yaml
+++ b/tests/braille-specs/en-ueb-g2_backward.yaml
@@ -76,6 +76,9 @@ tests:
   - [⠎⠰⠛, song]
   - [⠹⠬, thing]
 
+  # Issue #562 - "⠟⠅" erroneously back-translating as "quick's"
+  - [⠟⠅, quick]
+
 # According to issue #434 ':)' should be translated as ⠒⠐⠜ (which
 # works) and backtranslation should translate it back to ':)' (which
 # doesn't work). See https://github.com/liblouis/liblouis/issues/434


### PR DESCRIPTION
Resolution for issue #562 (where 'qk' was back-translating as "quick's").  

It appears that when someone added an annotation to UEB Rule 10.9.3, that annotation was inadvertently inserted into the middle of the relevant rule rather than at the end.