### PR TITLE
Fix UEB contracted back-translation of "first" and "it's"

### DIFF
--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -139,8 +139,8 @@ nofor word very  1236
 nofor word will  2456
 nofor word you  13456
 
-nofor word it's 1345-3-234
-nofor word it’s 1345-3-234
+nofor word it's 1346-3-234
+nofor word it’s 1346-3-234
 nofor word people's 1234-3-234
 nofor word people’s 1234-3-234
 nofor word that's 2345-3-234
@@ -1418,7 +1418,7 @@ nofor word deceiving's  145-14-1236-1245-3-234
 nofor word declare's  145-14-123-3-234
 nofor word declaring's  145-14-123-1245-3-234
 nofor word either's  15-24-3-234
-nofor word first's  124-34   10.9.3-3-234
+nofor word first's  124-34-3-234   10.9.3
 nofor word friend's  124-1235-3-234   appendix 1.4
 nofor word good's  1245-145-3-234   10.9.3
 nofor word great's  1245-1235-2345-3-234   10.9.3

--- a/tests/braille-specs/en-ueb-g2_backward.yaml
+++ b/tests/braille-specs/en-ueb-g2_backward.yaml
@@ -76,6 +76,13 @@ tests:
   - [⠎⠰⠛, song]
   - [⠹⠬, thing]
 
+  # Issue #572: "⠋⠌" erroneously back-translating as "first's"
+  - [⠋⠌, first]
+
+  # Issue #572: "⠭⠄⠎" erroneously back-translating as "x's"
+  - [⠭⠄⠎, it's]
+  - [⠰⠭⠄⠎, x’s]
+
 # According to issue #434 ':)' should be translated as ⠒⠐⠜ (which
 # works) and backtranslation should translate it back to ':)' (which
 # doesn't work). See https://github.com/liblouis/liblouis/issues/434


### PR DESCRIPTION
Partial resolution to issue #572 regarding the UEB issues only.

Fixed "⠋⠌" erroneously back-translating as "first's" rather than "first". When the table was edited ao annotate this as flowing from UEB Rule 10.9.3, the rule was inadvertently inserted into the midst of the rule breaking it.

Fixed "⠭⠄⠎" erroneously back-translating as "x's" rather than "it's".  The dot pattern for "x" was misspecified in the table as 1-3-4-5 (N) rather than 1-3-4-6 (X).

Adds YAML tests for verification.

The UK English grade 2 "double L" issue also raised in #572 is not addressed by this pull request.