### PR TITLE
UK English Braille Grade 2 - Correct erroneous back-translation of 'll'

### DIFF
--- a/tables/en-GB-g2.ctb
+++ b/tables/en-GB-g2.ctb
@@ -143,6 +143,8 @@ word behring 12-15-125-1235-346
 word beh =
 word bel =
 begword beln = Belnick
+begword belittle 23-123-123
+nofor sufword belittle 23-123-24-2345-2345-123-15
 always below 23-123
 always beneath 23-1345
 always beside 23-234
@@ -405,7 +407,7 @@ always letter 123-1235
 contraction lr
 word like 123
 word doolittle =
-always little 123-123
+sufword little 123-123
 contraction ll
 sufword lone 123-5-135 lonely
 always lord 5-123

--- a/tests/braille-specs/en-GB-g2_backward.yaml
+++ b/tests/braille-specs/en-GB-g2_backward.yaml
@@ -16,3 +16,18 @@ tests:
     - you went to
     - mode: [compbrlAtCursor]
       cursorPos: [2,4]
+
+  # Issue 572: "ll" erroneously treated as "little" contraction in all words
+  # Tests based on UKAAF Standards Rule 8.10.6 and Appendix III
+flags: {testmode: bothDirections}
+tests:
+  - [ball, ⠃⠁⠇⠇]
+  - [little, ⠇⠇]
+  - [littler, ⠇⠇⠗]
+  - [belittle, ⠆⠇⠊⠞⠞⠇⠑]
+  - [belittled, ⠆⠇⠇⠙]
+  - [littlewood, ⠇⠇⠺⠕⠕⠙]
+  - [Dolittle, ⠠⠙⠕⠇⠊⠞⠞⠇⠑]
+  - [Doolittle, ⠠⠙⠕⠕⠇⠊⠞⠞⠇⠑]
+  - [Littlejohn, ⠠⠇⠇⠚⠕⠓⠝]
+  - [Littleover, ⠠⠇⠇⠕⠧⠻]


### PR DESCRIPTION
Resolution to remaining problems reported at issue #572 relating to the UK grade 2 table.

Resolves numerous problems surrounding the (ll)=(little) and (bel)=(below) contractions.

On back-translation, the letters "ll" were being back-translated as 'little' regardless of where they appeared in the word (resulting in e.g. ball => balittle).  

On back-translation, "(be)little" was erroneously back-translated as "belowittle".

On back-translation, "(be)(ll)d" was erroneously back-translated as "belowld".

On forward-translation, "belittle" was being abbreviated to "(be)ll" creating ambiguity between belittle and bell.

This patch corrects the above issues and adds YAML verification tests based on examples in UKAAF standards.