### PR TITLE
Add Hungarian grade1 Braille input related rules, and some modifications to the Hungarian table files

### DIFF
--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -164,6 +164,7 @@ table_files = \
 	hu-backtranslate-correction.dis \
 	hu-chardefs.cti \
 	hu-exceptionwords.cti \
+	hu-hu-g1_braille_input.cti \
 	hu-hu-comp8.ctb \
 	hu-hu-g1.ctb \
 	hu-hu-g2.ctb \

--- a/tables/hu-hu-comp8.ctb
+++ b/tables/hu-hu-comp8.ctb
@@ -46,7 +46,7 @@
 include boxes.ctb
 include digits6DotsPlusDot6.uti
 include latinLetterDef8Dots.uti
-
+include spaces.uti
 #Uppercase and lowercase accented characters
 uppercase	\x00c1	478	LATIN CAPITAL LETTER A WITH ACUTE
 uppercase	\x00c4	4578	LATIN CAPITAL LETTER A WITH DIAERESIS
@@ -104,7 +104,6 @@ punctuation	|	34	VERTICAL LINE
 punctuation	}	23456	RIGHT CURLY BRACKET
 punctuation	~	2346	TILDE
 letter	\x007f	456	DELETE
-space	\s	0	SPACE
 punctuation	\x00a0	0	NO-BREAK SPACE
 punctuation	\x2580	1245	UPPER HALF BLOCK
 punctuation	\x2582	78	LOWER ONE QUARTER BLOCK
@@ -116,5 +115,9 @@ punctuation – 36
 punctuation … 3-3-3
 sign € 457
 sign • 6-35
+nofor pass2 @67 @6-35
+noback pass2 @67 @6-35
+space	\s	0	SPACE
 include braille-patterns.cti
+
 undefined 26

--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -23,7 +23,7 @@
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin
-
+include spaces.uti
 include hu-backtranslate-correction.dis
 include hu-chardefs.cti
 include hu-exceptionwords.cti
@@ -71,6 +71,7 @@ always ! 235
 endnum . 3
 always • 6-35
 endnum % 3456-245-356
+endnum / 5-2
 # literary forms of the decimal digits
 include litdigits6Dots.uti
 midendnumericmodechars ,:.-
@@ -107,7 +108,7 @@ always " 236	Need this rule to present one left quotation mark if the user first
 prepunc ( 2346	Opening left parenthese
 postpunc ) 1356	Closing right parenthese
 always ( 2346	Need this rule to the user always see 2346 dot combination if type first ( character a text
-always ) 1356	Need this rule to the user always see 2346 dot combination if type first ) character a text
+always ) 1356	Need this rule to the user always see 1356 dot combination if type first ) character a text
 prepunc « 236
 postpunc » 356
 prepunc ‘ 236
@@ -143,9 +144,14 @@ always ` 4
 always Æ 1
 always lyú 456-346
 always lysz 456-156
+space \x000c 0
+space \x001b 1b
+space \e 1b
+space \f 0
 always ä 5-1
 noback context $l$p["–"] @36-36
 noback context $l["–"] @36-36
 noback always \\_ 6 letter sign before Roman page numbers
 noback pass2 @3456-356 @356-3456
+include hu-hu-g1_braille_input.cti
 undefined 26

--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -23,7 +23,7 @@
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin
-include spaces.uti
+
 include hu-backtranslate-correction.dis
 include hu-chardefs.cti
 include hu-exceptionwords.cti

--- a/tables/hu-hu-g1_braille_input.cti
+++ b/tables/hu-hu-g1_braille_input.cti
@@ -1,0 +1,104 @@
+# liblouis: Hungarian Grade 1 Braille input subtable
+#
+#  Copyright (C) 2018-2019 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+#  Maintained by Attila Hammer  hammer.attila@infoalap.hu
+#
+# If you found bugs with hungarian grade1 table, report it with following address:
+# Attila Hammer <hammer.attila@infoalap.hu
+#If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin
+
+#Hungarian Braille input related rules
+#Exceptions for two simple equals special letter rules related (for example two literary cscs letter, two literary gygy letter, etc)
+#cscs letter related input rules
+nofor always cscs 146-5-146
+noback always cscs 146-5-146
+noback pass2 @146-5-146 @146-146
+
+#gygy letter related input rules
+nofor always gygy 1456-5-1456
+noback always gygy 1456-5-1456
+noback pass2 @1456-5-1456 @1456-1456
+
+#nyny related input rules
+nofor always nyny 1246-5-1246
+noback always nyny 1246-5-1246
+noback pass2 @1246-5-1246 @1246-1246
+
+#Exceptions for lyly letter related input rules
+nofor always lyly 456-5-456
+noback always lyly 456-5-456
+noback pass2 @456-5-456 @456-456
+
+#Exceptions for tyty lrelated rules
+nofor always tyty 1256-5-1256
+noback always tyty 1256-5-1256
+noback pass2 @1256-5-1256 @1256-1256
+
+#Exception  for szsz related input
+nofor always szsz 156-5-156
+noback always szsz 156-5-156
+noback pass2 @156-5-156 @156-156
+
+#Exception rules for zszs input related
+nofor always zszs 345-5-345
+noback always zszs 345-5-345
+noback pass2 @345-5-345 @345-345
+
+#punctuation related exceptions
+nofor always – 5-36
+nofor context @8 "\n"
+nofor context @235-8 "!\n"
+nofor context @235-0 "! "
+
+#for plus sign related rule
+nofor context @5-235 "+"
+noback context $a["+"] @5-235
+noback pass2 @5-235 @235
+
+#for [ and ] character input related old dot combinations related rules, need keeping this rules with compatibility purposes
+nofor always [ 5-12356
+noback always [ 5-12356
+noback pass2 @5-12356 @46-2346
+nofor always ] 5-23456
+noback always ] 5-23456
+noback pass2 @5-23456 @46-1356
+
+#\ character related rule related exception
+nofor always \\ 5-16
+noback always \\ 5-16
+noback pass2 @5-16 @16
+
+#for ` related exception rules
+nofor always ` 5-4
+noback always ` 5-4
+noback pass2 @5-4 @4
+
+#for { and } related old rules, need keeping this rules with compatibility purposes:
+nofor always { 5-12345
+noback always { 5-12345
+noback pass2 @5-12345 @5-2345
+nofor always } 5-12456
+noback always } 5-12456
+noback pass2 @5-12456 @5-1356
+
+#For | punctuation character related input rule related exception
+nofor always | 5-45
+noback always | 5-45
+noback pass2 @5-45 @45

--- a/tables/hu-hu-g2.ctb
+++ b/tables/hu-hu-g2.ctb
@@ -42,6 +42,7 @@
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin
+include spaces.uti
 include hu-backtranslate-correction.dis
 include hu-chardefs.cti
 include hu-exceptionwords.cti
@@ -89,6 +90,7 @@ always ! 235
 endnum . 3
 always • 6-35
 endnum % 3456-245-356
+endnum / 5-2
 # literary forms of the decimal digits
 include litdigits6Dots.uti
 midendnumericmodechars ,:.-

--- a/tables/hu-hu-g2.ctb
+++ b/tables/hu-hu-g2.ctb
@@ -42,7 +42,7 @@
 # If you found bugs with hungarian grade1 table, report it with following address:
 # Attila Hammer <hammer.attila@infoalap.hu
 #If you have a Launchpad account, report table related requests with following bug tracker address: https://bugs.launchpad.net/belin
-include spaces.uti
+
 include hu-backtranslate-correction.dis
 include hu-chardefs.cti
 include hu-exceptionwords.cti


### PR DESCRIPTION
Hy Chris,

I doed first release with hungarian grade1 Braille input related.
If this is possible, please merge this pull request with the Liblouis master branch before Liblouis 3.10.0 release coming out.

I doed few small modifications with hu-hu-comp8.ctb, hu-hu-g1.ctb, hu-hu-g1.ctb, hu-hu-g2.ctb tables related. I merge these changes with one commit.

Attila