### PR TITLE
Upgrade clang-format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@
 # require Trusty so we have a modern version of texinfo (> 5.0) and
 # automake (> 1.14)
 sudo: required
-dist: trusty
-
-# the check-format test seems to fail with clang-format 5.0, so for
-# now stay with the older version of clang and hence the whole trusty
-# image
-group: deprecated-2017Q4
+dist: xenial
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       env: MODE=build-gcc
     - compiler: gcc
       env: MODE=build-gcc ENABLE_UCS4=--enable-ucs4
-    - compiler: i586-mingw32msvc-gcc
+    - compiler: i686-w64-mingw32-gcc
       env: MODE=build-mingw ENABLE_UCS4=--enable-ucs4 ARCH=32
     - compiler: x86_64-w64-mingw32-gcc
       env: MODE=build-mingw ENABLE_UCS4=--enable-ucs4 ARCH=64

--- a/.travis/before_install/mingw.sh
+++ b/.travis/before_install/mingw.sh
@@ -1,4 +1,4 @@
-sudo apt-get install -y $(test $ARCH == 32 && echo mingw32 libc6-dev-i386 || echo mingw-w64) jq texinfo
+sudo apt-get install -y $(test $ARCH == 32 && echo libc6-dev-i386 || echo mingw-w64) jq texinfo
 mkdir -p $HOME/src &&
 cd $_ &&
 curl -L https://github.com/yaml/libyaml/tarball/0.1.4 | tar zx &&
@@ -6,6 +6,6 @@ mv yaml-libyaml-4dce9c1 libyaml &&
 cd libyaml &&
 patch -p1 <$TRAVIS_BUILD_DIR/libyaml_mingw.patch &&
 ./bootstrap &&
-./configure --host $(test $ARCH == 32 && echo i586-mingw32msvc || echo x86_64-w64-mingw32) --prefix=$HOME/build/win$ARCH/libyaml &&
+./configure --host $(test $ARCH == 32 && echo i686-w64-mingw32 || echo x86_64-w64-mingw32) --prefix=$HOME/build/win$ARCH/libyaml &&
 make &&
 make install

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -102,8 +102,16 @@ typedef struct ChainEntry {
 static ChainEntry *tableChain = NULL;
 
 static const char *characterClassNames[] = {
-	"space", "letter", "digit", "punctuation", "uppercase", "lowercase", "math", "sign",
-	"litdigit", NULL,
+	"space",
+	"letter",
+	"digit",
+	"punctuation",
+	"uppercase",
+	"lowercase",
+	"math",
+	"sign",
+	"litdigit",
+	NULL,
 };
 
 typedef struct CharacterClass {
@@ -118,27 +126,121 @@ static CharacterClass *gCharacterClasses;
 static TranslationTableCharacterAttributes gCharacterClassAttribute;
 
 static const char *opcodeNames[CTO_None] = {
-	"include", "locale", "undefined", "capsletter", "begcapsword", "endcapsword",
-	"begcaps", "endcaps", "begcapsphrase", "endcapsphrase", "lencapsphrase", "letsign",
-	"noletsignbefore", "noletsign", "noletsignafter", "numsign", "numericmodechars",
-	"midendnumericmodechars", "numericnocontchars", "seqdelimiter", "seqbeforechars",
-	"seqafterchars", "seqafterpattern", "seqafterexpression", "emphclass", "emphletter",
-	"begemphword", "endemphword", "begemph", "endemph", "begemphphrase", "endemphphrase",
-	"lenemphphrase", "capsmodechars", "emphmodechars", "begcomp", "compbegemph1",
-	"compendemph1", "compbegemph2", "compendemph2", "compbegemph3", "compendemph3",
-	"compcapsign", "compbegcaps", "compendcaps", "endcomp", "nocontractsign", "multind",
-	"compdots", "comp6", "class", "after", "before", "noback", "nofor", "empmatchbefore",
-	"empmatchafter", "swapcc", "swapcd", "swapdd", "space", "digit", "punctuation",
-	"math", "sign", "letter", "uppercase", "lowercase", "grouping", "uplow", "litdigit",
-	"display", "replace", "context", "correct", "pass2", "pass3", "pass4", "repeated",
-	"repword", "capsnocont", "always", "exactdots", "nocross", "syllable", "nocont",
-	"compbrl", "literal", "largesign", "word", "partword", "joinnum", "joinword",
-	"lowword", "contraction", "sufword", "prfword", "begword", "begmidword", "midword",
-	"midendword", "endword", "prepunc", "postpunc", "begnum", "midnum", "endnum",
-	"decpoint", "hyphen",
+	"include",
+	"locale",
+	"undefined",
+	"capsletter",
+	"begcapsword",
+	"endcapsword",
+	"begcaps",
+	"endcaps",
+	"begcapsphrase",
+	"endcapsphrase",
+	"lencapsphrase",
+	"letsign",
+	"noletsignbefore",
+	"noletsign",
+	"noletsignafter",
+	"numsign",
+	"numericmodechars",
+	"midendnumericmodechars",
+	"numericnocontchars",
+	"seqdelimiter",
+	"seqbeforechars",
+	"seqafterchars",
+	"seqafterpattern",
+	"seqafterexpression",
+	"emphclass",
+	"emphletter",
+	"begemphword",
+	"endemphword",
+	"begemph",
+	"endemph",
+	"begemphphrase",
+	"endemphphrase",
+	"lenemphphrase",
+	"capsmodechars",
+	"emphmodechars",
+	"begcomp",
+	"compbegemph1",
+	"compendemph1",
+	"compbegemph2",
+	"compendemph2",
+	"compbegemph3",
+	"compendemph3",
+	"compcapsign",
+	"compbegcaps",
+	"compendcaps",
+	"endcomp",
+	"nocontractsign",
+	"multind",
+	"compdots",
+	"comp6",
+	"class",
+	"after",
+	"before",
+	"noback",
+	"nofor",
+	"empmatchbefore",
+	"empmatchafter",
+	"swapcc",
+	"swapcd",
+	"swapdd",
+	"space",
+	"digit",
+	"punctuation",
+	"math",
+	"sign",
+	"letter",
+	"uppercase",
+	"lowercase",
+	"grouping",
+	"uplow",
+	"litdigit",
+	"display",
+	"replace",
+	"context",
+	"correct",
+	"pass2",
+	"pass3",
+	"pass4",
+	"repeated",
+	"repword",
+	"capsnocont",
+	"always",
+	"exactdots",
+	"nocross",
+	"syllable",
+	"nocont",
+	"compbrl",
+	"literal",
+	"largesign",
+	"word",
+	"partword",
+	"joinnum",
+	"joinword",
+	"lowword",
+	"contraction",
+	"sufword",
+	"prfword",
+	"begword",
+	"begmidword",
+	"midword",
+	"midendword",
+	"endword",
+	"prepunc",
+	"postpunc",
+	"begnum",
+	"midnum",
+	"endnum",
+	"decpoint",
+	"hyphen",
 	// "apostrophe",
 	// "initial",
-	"nobreak", "match", "backmatch", "attribute",
+	"nobreak",
+	"match",
+	"backmatch",
+	"attribute",
 };
 
 static short gOpcodeLengths[CTO_None] = { 0 };
@@ -551,7 +653,7 @@ passFindCharacters(FileInfo *nested, widechar *instructions, int end,
 
 		case pass_swap:
 			IC += 2;
-		/* fall through */
+			/* fall through */
 
 		case pass_groupstart:
 		case pass_groupend:
@@ -1790,8 +1892,9 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode,
 			ruleOffset = findRuleName(&passHoldString, ruleNames);
 			if (ruleOffset)
 				rule = (TranslationTableRule *)&(*table)->ruleArea[ruleOffset];
-			if (rule && (rule->opcode == CTO_SwapCc || rule->opcode == CTO_SwapCd ||
-								rule->opcode == CTO_SwapDd)) {
+			if (rule &&
+					(rule->opcode == CTO_SwapCc || rule->opcode == CTO_SwapCd ||
+							rule->opcode == CTO_SwapDd)) {
 				passInstructions[passIC++] = pass_swap;
 				passInstructions[passIC++] = ruleOffset >> 16;
 				passInstructions[passIC++] = ruleOffset & 0xffff;
@@ -1906,8 +2009,9 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode,
 			ruleOffset = findRuleName(&passHoldString, ruleNames);
 			if (ruleOffset)
 				rule = (TranslationTableRule *)&(*table)->ruleArea[ruleOffset];
-			if (rule && (rule->opcode == CTO_SwapCc || rule->opcode == CTO_SwapCd ||
-								rule->opcode == CTO_SwapDd)) {
+			if (rule &&
+					(rule->opcode == CTO_SwapCc || rule->opcode == CTO_SwapCd ||
+							rule->opcode == CTO_SwapDd)) {
 				passInstructions[passIC++] = pass_swap;
 				passInstructions[passIC++] = ruleOffset >> 16;
 				passInstructions[passIC++] = ruleOffset & 0xffff;
@@ -2146,7 +2250,9 @@ typedef struct HyphenHashEntry {
 	int val;
 } HyphenHashEntry;
 
-typedef struct HyphenHashTab { HyphenHashEntry *entries[HYPHENHASHSIZE]; } HyphenHashTab;
+typedef struct HyphenHashTab {
+	HyphenHashEntry *entries[HYPHENHASHSIZE];
+} HyphenHashTab;
 
 /* a hash function from ASU - adapted from Gtk+ */
 static unsigned int
@@ -3376,8 +3482,8 @@ doOpcode:
 						character->attributes |= class->attribute;
 						// also add the attribute to the associated dots (if any)
 						if (character->definitionRule) {
-							defRule = (TranslationTableRule *)&(
-									*table)->ruleArea[character->definitionRule];
+							defRule = (TranslationTableRule *)&(*table)
+											  ->ruleArea[character->definitionRule];
 							if (defRule->dotslen == 1) {
 								character = compile_findCharOrDots(
 										defRule->charsdots[defRule->charslen], 1, *table);

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -67,10 +67,22 @@ typedef struct intCharTupple {
  * Mapping between braille dot and textual representation as used in dots operands
  */
 static const intCharTupple dotMapping[] = {
-	{ LOU_DOT_1, '1' }, { LOU_DOT_2, '2' }, { LOU_DOT_3, '3' }, { LOU_DOT_4, '4' },
-	{ LOU_DOT_5, '5' }, { LOU_DOT_6, '6' }, { LOU_DOT_7, '7' }, { LOU_DOT_8, '8' },
-	{ LOU_DOT_9, '9' }, { LOU_DOT_10, 'A' }, { LOU_DOT_11, 'B' }, { LOU_DOT_12, 'C' },
-	{ LOU_DOT_13, 'D' }, { LOU_DOT_14, 'E' }, { LOU_DOT_15, 'F' }, { 0, 0 },
+	{ LOU_DOT_1, '1' },
+	{ LOU_DOT_2, '2' },
+	{ LOU_DOT_3, '3' },
+	{ LOU_DOT_4, '4' },
+	{ LOU_DOT_5, '5' },
+	{ LOU_DOT_6, '6' },
+	{ LOU_DOT_7, '7' },
+	{ LOU_DOT_8, '8' },
+	{ LOU_DOT_9, '9' },
+	{ LOU_DOT_10, 'A' },
+	{ LOU_DOT_11, 'B' },
+	{ LOU_DOT_12, 'C' },
+	{ LOU_DOT_13, 'D' },
+	{ LOU_DOT_14, 'E' },
+	{ LOU_DOT_15, 'F' },
+	{ 0, 0 },
 };
 
 /* HASHNUM must be prime */

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -196,10 +196,10 @@ _lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int 
 			else
 				passbuf1[k] = _lou_getDotsForChar(inbuf[k]);
 		passbuf1[srcmax] = _lou_getDotsForChar(' ');
-		input = (InString){.chars = passbuf1, .length = srcmax, .bufferIndex = idx };
+		input = (InString){ .chars = passbuf1, .length = srcmax, .bufferIndex = idx };
 	}
 	idx = getStringBuffer(*outlen);
-	output = (OutString){.chars = stringBufferPool->buffers[idx],
+	output = (OutString){ .chars = stringBufferPool->buffers[idx],
 		.maxlength = *outlen,
 		.length = 0,
 		.bufferIndex = idx };
@@ -274,11 +274,11 @@ _lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int 
 		currentPass--;
 		if (currentPass >= lastPass && goodTrans) {
 			releaseStringBuffer(input.bufferIndex);
-			input = (InString){.chars = output.chars,
+			input = (InString){ .chars = output.chars,
 				.length = output.length,
 				.bufferIndex = output.bufferIndex };
 			idx = getStringBuffer(*outlen);
-			output = (OutString){.chars = stringBufferPool->buffers[idx],
+			output = (OutString){ .chars = stringBufferPool->buffers[idx],
 				.maxlength = *outlen,
 				.length = 0,
 				.bufferIndex = idx };
@@ -1027,10 +1027,11 @@ makeCorrections(const TranslationTableHeader *table, int mode, int currentPass,
 					currentRule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
 					currentOpcode = currentRule->opcode;
 					int currentCharslen = currentRule->charslen;
-					if (tryThis == 1 || (currentCharslen <= length &&
-												compareChars(&currentRule->charsdots[0],
-														&input->chars[pos],
-														currentCharslen, 0, table))) {
+					if (tryThis == 1 ||
+							(currentCharslen <= length &&
+									compareChars(&currentRule->charsdots[0],
+											&input->chars[pos], currentCharslen, 0,
+											table))) {
 						if (currentOpcode == CTO_Correct &&
 								back_passDoTest(table, pos, input, currentOpcode,
 										currentRule, &passInstructions, &passIC,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -269,10 +269,11 @@ makeCorrections(const TranslationTableHeader *table, const InString *input,
 					transRule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
 					transOpcode = transRule->opcode;
 					transCharslen = transRule->charslen;
-					if (tryThis == 1 || (transCharslen <= length &&
-												compareChars(&transRule->charsdots[0],
-														&input->chars[pos], transCharslen,
-														0, table))) {
+					if (tryThis == 1 ||
+							(transCharslen <= length &&
+									compareChars(&transRule->charsdots[0],
+											&input->chars[pos], transCharslen, 0,
+											table))) {
 						if (*posIncremented && transOpcode == CTO_Correct &&
 								passDoTest(table, pos, input, transOpcode, transRule,
 										&passCharDots, &passInstructions, &passIC,
@@ -538,7 +539,7 @@ removeGrouping(const InString **input, OutString *output, int passCharDots,
 				chars[len++] = (*input)->chars[k];
 			}
 			static InString stringStore;
-			stringStore = (InString){.chars = chars, .length = len, .bufferIndex = idx };
+			stringStore = (InString){ .chars = chars, .length = len, .bufferIndex = idx };
 			*input = &stringStore;
 		}
 	} else {
@@ -612,8 +613,8 @@ doPassSearch(const TranslationTableHeader *table, const InString *input,
 						itsTrue = 0;
 					else {
 						itsTrue = ((findCharOrDots(input->chars[(*searchPos)++],
-											passCharDots,
-											table)->attributes &
+											passCharDots, table)
+												   ->attributes &
 										   attributes)
 										? 1
 										: 0);
@@ -628,8 +629,9 @@ doPassSearch(const TranslationTableHeader *table, const InString *input,
 							itsTrue = 0;
 							break;
 						}
-						if (!(findCharOrDots(input->chars[*searchPos], passCharDots,
-									  table)->attributes &
+						if (!(findCharOrDots(
+									  input->chars[*searchPos], passCharDots, table)
+											->attributes &
 									attributes)) {
 							if (!not) break;
 						} else if (not)
@@ -761,8 +763,8 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 					itsTrue = 0;
 					break;
 				}
-				if (!(findCharOrDots(input->chars[pos], *passCharDots,
-							  table)->attributes &
+				if (!(findCharOrDots(input->chars[pos], *passCharDots, table)
+									->attributes &
 							attributes)) {
 					if (!not) {
 						itsTrue = 0;
@@ -782,8 +784,8 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 						itsTrue = 0;
 						break;
 					}
-					if (!(findCharOrDots(input->chars[pos], *passCharDots,
-								  table)->attributes &
+					if (!(findCharOrDots(input->chars[pos], *passCharDots, table)
+										->attributes &
 								attributes)) {
 						if (!not) break;
 					} else if (not)
@@ -833,7 +835,7 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 				startReplace = startMatch;
 				endReplace = endMatch;
 			}
-			*match = (PassRuleMatch){.startMatch = startMatch,
+			*match = (PassRuleMatch){ .startMatch = startMatch,
 				.startReplace = startReplace,
 				.endReplace = endReplace,
 				.endMatch = endMatch };
@@ -1123,7 +1125,7 @@ _lou_translateWithTracing(const char *tableList, const widechar *inbufx, int *in
 	if (table == NULL || *inlen < 0 || *outlen < 0) return 0;
 	k = 0;
 	while (k < *inlen && inbufx[k]) k++;
-	input = (InString){.chars = inbufx, .length = k, .bufferIndex = -1 };
+	input = (InString){ .chars = inbufx, .length = k, .bufferIndex = -1 };
 	haveEmphasis = 0;
 	if (!(typebuf = _lou_allocMem(alloc_typebuf, 0, input.length, *outlen))) return 0;
 	if (typeform != NULL) {
@@ -1200,7 +1202,7 @@ _lou_translateWithTracing(const char *tableList, const widechar *inbufx, int *in
 		if (!stringBufferPool) initStringBufferPool();
 		for (idx = 0; idx < stringBufferPool->size; idx++) releaseStringBuffer(idx);
 		idx = getStringBuffer(*outlen);
-		output = (OutString){.chars = stringBufferPool->buffers[idx],
+		output = (OutString){ .chars = stringBufferPool->buffers[idx],
 			.maxlength = *outlen,
 			.length = 0,
 			.bufferIndex = idx };
@@ -1244,11 +1246,11 @@ _lou_translateWithTracing(const char *tableList, const widechar *inbufx, int *in
 		if (currentPass <= table->numPasses && goodTrans) {
 			int idx;
 			releaseStringBuffer(input.bufferIndex);
-			input = (InString){.chars = output.chars,
+			input = (InString){ .chars = output.chars,
 				.length = output.length,
 				.bufferIndex = output.bufferIndex };
 			idx = getStringBuffer(*outlen);
-			output = (OutString){.chars = stringBufferPool->buffers[idx],
+			output = (OutString){ .chars = stringBufferPool->buffers[idx],
 				.maxlength = *outlen,
 				.length = 0,
 				.bufferIndex = idx };
@@ -1930,8 +1932,9 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output, i
 			*transOpcode = (*transRule)->opcode;
 			*transCharslen = (*transRule)->charslen;
 			if (tryThis == 1 ||
-					((*transCharslen <= length) && validMatch(table, pos, input, typebuf,
-														   *transRule, *transCharslen))) {
+					((*transCharslen <= length) &&
+							validMatch(table, pos, input, typebuf, *transRule,
+									*transCharslen))) {
 				TranslationTableCharacterAttributes afterAttributes;
 				/* check before emphasis match */
 				if ((*transRule)->before & CTC_EmpMatch) {
@@ -2135,8 +2138,9 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output, i
 						return;
 					case CTO_PrePunc:
 						if (!checkAttr(input->chars[pos], CTC_Punctuation, 0, table) ||
-								(pos > 0 && checkAttr(input->chars[pos - 1], CTC_Letter,
-													0, table)))
+								(pos > 0 &&
+										checkAttr(input->chars[pos - 1], CTC_Letter, 0,
+												table)))
 							break;
 						for (k = pos + *transCharslen; k < input->length; k++) {
 							if (checkAttr(input->chars[k], (CTC_Letter | CTC_Digit), 0,
@@ -3407,8 +3411,9 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		case CTO_LargeSign:
 			if (prevTransOpcode == CTO_LargeSign) {
 				int hasEndSegment = 0;
-				while (output->length > 0 && checkAttr(output->chars[output->length - 1],
-													 CTC_Space, 1, table)) {
+				while (output->length > 0 &&
+						checkAttr(
+								output->chars[output->length - 1], CTC_Space, 1, table)) {
 					if (output->chars[output->length - 1] == LOU_ENDSEGMENT) {
 						hasEndSegment = 1;
 					}
@@ -3467,12 +3472,12 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 				pos++;
 				break;
 			}
-		//		case CTO_Contraction:
-		//
-		//			if(brailleIndicatorDefined(table->noContractSign))
-		//			if(!for_updatePositions(
-		//				&indicRule->charsdots[0], 0, indicRule->dotslen, 0))
-		//				goto failure;
+			//		case CTO_Contraction:
+			//
+			//			if(brailleIndicatorDefined(table->noContractSign))
+			//			if(!for_updatePositions(
+			//				&indicRule->charsdots[0], 0, indicRule->dotslen, 0))
+			//				goto failure;
 
 		default:
 			if (transRule->dotslen) {
@@ -3525,8 +3530,9 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 			if (mode & (compbrlAtCursor | compbrlLeftCursor) && compbrlStart < srclim)
 				/* Don't skip characters from compbrlStart onwards. */
 				srclim = compbrlStart - 1;
-			while ((pos <= srclim) && compareChars(repwordStart, &input->chars[pos],
-											  repwordLength, 0, table)) {
+			while ((pos <= srclim) &&
+					compareChars(
+							repwordStart, &input->chars[pos], repwordLength, 0, table)) {
 				/* Map skipped input positions to the previous output position. */
 				/* if (posMapping.outputPositions != NULL) { */
 				/* 	int tcc; */

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -217,10 +217,20 @@ _lou_showDots(widechar const *dots, int length) {
  * Mapping between character attribute and textual representation
  */
 static const intCharTupple attributeMapping[] = {
-	{ CTC_Space, 's' }, { CTC_Letter, 'l' }, { CTC_Digit, 'd' }, { CTC_Punctuation, 'p' },
-	{ CTC_UpperCase, 'U' }, { CTC_LowerCase, 'u' }, { CTC_Math, 'm' }, { CTC_Sign, 'S' },
-	{ CTC_LitDigit, 'D' }, { CTC_Class1, 'w' }, { CTC_Class2, 'x' }, { CTC_Class3, 'y' },
-	{ CTC_Class4, 'z' }, { 0, 0 },
+	{ CTC_Space, 's' },
+	{ CTC_Letter, 'l' },
+	{ CTC_Digit, 'd' },
+	{ CTC_Punctuation, 'p' },
+	{ CTC_UpperCase, 'U' },
+	{ CTC_LowerCase, 'u' },
+	{ CTC_Math, 'm' },
+	{ CTC_Sign, 'S' },
+	{ CTC_LitDigit, 'D' },
+	{ CTC_Class1, 'w' },
+	{ CTC_Class2, 'x' },
+	{ CTC_Class3, 'y' },
+	{ CTC_Class4, 'z' },
+	{ 0, 0 },
 };
 
 /**

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -68,7 +68,7 @@ typedef struct {
  * specified, and must be smaller than or equal to the total length of the input.
  * @param direction (optional) 0 for forward translation, 1 for backwards translation,
  * 2 for both directions. If
-* not specified it defaults to 0.
+ * not specified it defaults to 0.
  * @param diagnostics (optional) Print diagnostic output on failure if diagnostics is not
  * 0. If not specified it defaults to 1.
  * @return Return 0 if the translation is as expected and 1 otherwise.
@@ -80,18 +80,19 @@ typedef struct {
  *                .cursorPos = 5);
  * ~~~~~~~~~~~~~~~~~~~~~~
  */
-#define check(tables, input, expected, ...)                                      \
-	check_base(tables, input, expected, (optional_test_params){.typeform = NULL, \
-												.cursorPos = -1,                 \
-												.expected_cursorPos = -1,        \
-												.expected_inputPos = NULL,       \
-												.expected_outputPos = NULL,      \
-												.max_outlen = -1,                \
-												.real_inlen = -1,                \
-												.mode = 0,                       \
-												.direction = 0,                  \
-												.diagnostics = 1,                \
-												__VA_ARGS__ })
+#define check(tables, input, expected, ...)           \
+	check_base(tables, input, expected,               \
+			(optional_test_params){ .typeform = NULL, \
+					.cursorPos = -1,                  \
+					.expected_cursorPos = -1,         \
+					.expected_inputPos = NULL,        \
+					.expected_outputPos = NULL,       \
+					.max_outlen = -1,                 \
+					.real_inlen = -1,                 \
+					.mode = 0,                        \
+					.direction = 0,                   \
+					.diagnostics = 1,                 \
+					__VA_ARGS__ })
 
 int
 check_base(const char *tableList, const char *input, const char *expected,

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -34,7 +34,8 @@
 #include "version-etc.h"
 
 static const struct option longopts[] = {
-	{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
+	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'v' },
 	{ NULL, 0, NULL, 0 },
 };
 

--- a/tools/lou_checkhyphens.c
+++ b/tools/lou_checkhyphens.c
@@ -32,7 +32,8 @@
 #include "version-etc.h"
 
 static const struct option longopts[] = {
-	{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
+	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'v' },
 	{ NULL, 0, NULL, 0 },
 };
 

--- a/tools/lou_checktable.c
+++ b/tools/lou_checktable.c
@@ -31,8 +31,10 @@
 #include "version-etc.h"
 
 static const struct option longopts[] = {
-	{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
-	{ "quiet", no_argument, NULL, 'q' }, { NULL, 0, NULL, 0 },
+	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'v' },
+	{ "quiet", no_argument, NULL, 'q' },
+	{ NULL, 0, NULL, 0 },
 };
 
 const char version_etc_copyright[] =

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -33,7 +33,8 @@
 #include "brl_checks.h"
 
 static const struct option longopts[] = {
-	{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
+	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'v' },
 	{ NULL, 0, NULL, 0 },
 };
 

--- a/tools/lou_debug.c
+++ b/tools/lou_debug.c
@@ -32,7 +32,8 @@
 #include "version-etc.h"
 
 static const struct option longopts[] = {
-	{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
+	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'v' },
 	{ NULL, 0, NULL, 0 },
 };
 
@@ -122,11 +123,13 @@ printRule(TranslationTableRule *thisRule, int mode) {
 	default:
 		if (mode == 0) {
 			printf("chars=%s, ", print_chars(thisRule->charsdots, thisRule->charslen));
-			printf("dots=%s, ", _lou_showDots(&thisRule->charsdots[thisRule->charslen],
-										thisRule->dotslen));
+			printf("dots=%s, ",
+					_lou_showDots(
+							&thisRule->charsdots[thisRule->charslen], thisRule->dotslen));
 		} else {
-			printf("dots=%s, ", _lou_showDots(&thisRule->charsdots[thisRule->charslen],
-										thisRule->dotslen));
+			printf("dots=%s, ",
+					_lou_showDots(
+							&thisRule->charsdots[thisRule->charslen], thisRule->dotslen));
 			printf("chars=%s, ", print_chars(thisRule->charsdots, thisRule->charslen));
 		}
 		break;

--- a/tools/lou_tableinfo.c
+++ b/tools/lou_tableinfo.c
@@ -24,7 +24,8 @@
 #include "version-etc.h"
 
 static const struct option longopts[] = {
-	{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
+	{ "help", no_argument, NULL, 'h' },
+	{ "version", no_argument, NULL, 'v' },
 	{ NULL, 0, NULL, 0 },
 };
 

--- a/tools/lou_trace.c
+++ b/tools/lou_trace.c
@@ -287,8 +287,10 @@ main(int argc, char **argv) {
 	int partialTransMode = 0;
 
 	const struct option longopts[] = {
-		{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
-		{ "forward", no_argument, NULL, 'f' }, { "backward", no_argument, NULL, 'b' },
+		{ "help", no_argument, NULL, 'h' },
+		{ "version", no_argument, NULL, 'v' },
+		{ "forward", no_argument, NULL, 'f' },
+		{ "backward", no_argument, NULL, 'b' },
 		{ "noContractions", no_argument, &noContractionsMode, noContractions },
 		{ "dotsIO", no_argument, &dotsIOMode, dotsIO },
 		{ "ucBrl", no_argument, &ucBrlMode, ucBrl },

--- a/tools/lou_translate.c
+++ b/tools/lou_translate.c
@@ -134,8 +134,10 @@ main(int argc, char **argv) {
 	FILE *input;
 
 	const struct option longopts[] = {
-		{ "help", no_argument, NULL, 'h' }, { "version", no_argument, NULL, 'v' },
-		{ "forward", no_argument, NULL, 'f' }, { "backward", no_argument, NULL, 'b' },
+		{ "help", no_argument, NULL, 'h' },
+		{ "version", no_argument, NULL, 'v' },
+		{ "forward", no_argument, NULL, 'f' },
+		{ "backward", no_argument, NULL, 'b' },
 		{ NULL, 0, NULL, 0 },
 	};
 


### PR DESCRIPTION
Unfortunately not every version of `clang-format` produces the same output given the same config file. For that reason when upgrading `clang-format` we also have to re-format the source. Luckily the changes are pretty small.

Since I upgraded my machine I no longer have clang-format5 which we are currently using on travis. 

This PR upgrades the Travis build environment to Xenial which has Clang7. I locally have Clang8 and re-formated the source with that. They seem to produce identical output.