### PR TITLE
Issue in Dutch with numbers inside all-caps phrases

### DIFF
--- a/tables/nl-g0.uti
+++ b/tables/nl-g0.uti
@@ -128,13 +128,21 @@ replace  \\_
 
 # For numbers that are immediately followed by a letter a-j, a sign must be
 # inserted for terminating the number.
-class       digitletter            abcdefghij    # 1st class = $w
+
+# Using these rules instead of the multipass rules makes a lot of tests fail:
+# nocontractsign 6
+# numericnocontchars abcdefghij
+
+class digitletter abcdefghijABCDEFGHIJ    # 1st class = $w
 noback context     $d[]%digitletter       @6
 noback context     $d","[]%digitletter    @6
 noback context     $d"."[]%digitletter    @6
 noback context     $d":"[]%digitletter    @6
 # Multiple dots 6 are collapsed into a single dot 6.
 noback pass2       [@6]@6                 ?
+# A dot 6 is not needed when the number is already cancelled by a capital or emphasis sign
+noback pass3       $d[@6]@45              ?
+noback pass3       $d[@6]@46              ?
 noback pass3       $d[@6]@456             ?
 
 # §2.20 Sleutelteken tweede betekenis [1]

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -5,6 +5,7 @@
 # Copyright © 2010-2011 by DocArch <http://www.docarch.be>
 # Copyright © 2014-2015, 2019 by Bert Frees
 # Copyright © 2015-2016, 2018 by Dedicon <http://www.dedicon.nl>
+# Copyright © 2019 by Transkript <http://www.transkript.be>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -161,9 +162,6 @@ tests:
   - [Jozef II-straat, ⠨⠚⠕⠵⠑⠋ ⠘⠊⠊⠤⠎⠞⠗⠁⠁⠞]
   - [WO II, ⠘⠺⠕ ⠘⠊⠊]
   - [E.T.A., ⠘⠑⠲⠞⠲⠁⠲]
-  - - Complex numbers mixed with letters
-    - Zie refertes D-NE004W, D-NB007B en D-NB007BDK.
-    - ⠨⠵⠊⠑ ⠗⠑⠋⠑⠗⠞⠑⠎ ⠨⠙⠤⠘⠝⠑⠼⠚⠚⠙⠨⠺⠂ ⠨⠙⠤⠘⠝⠃⠼⠚⠚⠛⠨⠃ ⠑⠝ ⠨⠙⠤⠘⠝⠃⠼⠚⠚⠛⠘⠃⠙⠅⠲
   - [EEN woord in hoofdletters, ⠘⠑⠑⠝ ⠺⠕⠕⠗⠙ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
   - [TWEE WOORDEN in hoofdletters, ⠘⠞⠺⠑⠑ ⠘⠺⠕⠕⠗⠙⠑⠝ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
   - [DRIE WOORDEN IN hoofdletters, ⠘⠙⠗⠊⠑ ⠘⠺⠕⠕⠗⠙⠑⠝ ⠘⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎]
@@ -188,6 +186,14 @@ tests:
     # However, there is nothing in the braille standard
     # to suggest that this replacement (E to É) should occur.
   - [É-U, ⠨⠿⠤⠨⠥]
+  # combinaties hoofdletters en cijfers
+  - [1e, ⠼⠁⠠⠑]
+  - [1E, ⠼⠁⠨⠑]
+  - [2DE, ⠼⠃⠘⠙⠑]
+  - - BIJ MEER DAN DRIE WOORDEN IN HOOFDLETTERS WORDT 2DE NIET CORRECT OMGEZET
+    - ⠘⠘⠃⠊⠚ ⠍⠑⠑⠗ ⠙⠁⠝ ⠙⠗⠊⠑ ⠺⠕⠕⠗⠙⠑⠝ ⠊⠝ ⠓⠕⠕⠋⠙⠇⠑⠞⠞⠑⠗⠎ ⠺⠕⠗⠙⠞ ⠼⠃⠠⠙⠑ ⠝⠊⠑⠞ ⠉⠕⠗⠗⠑⠉⠞ ⠘⠕⠍⠛⠑⠵⠑⠞
+  - - Zie refertes D-NE004W, D-NB007B en D-NB007BDK.
+    - ⠨⠵⠊⠑ ⠗⠑⠋⠑⠗⠞⠑⠎ ⠨⠙⠤⠘⠝⠑⠼⠚⠚⠙⠨⠺⠂ ⠨⠙⠤⠘⠝⠃⠼⠚⠚⠛⠨⠃ ⠑⠝ ⠨⠙⠤⠘⠝⠃⠼⠚⠚⠛⠘⠃⠙⠅⠲
   # §2.13 Internettekens
   - [lisa_dirk@yahoo.com, ⠇⠊⠎⠁⠸⠙⠊⠗⠅⠜⠽⠁⠓⠕⠕⠲⠉⠕⠍]
   - ['http://www.avh.asso.fr/', ⠓⠞⠞⠏⠒⠌⠌⠺⠺⠺⠲⠁⠧⠓⠲⠁⠎⠎⠕⠲⠋⠗⠌]


### PR DESCRIPTION
For example, when "2DE" happens inside a phrase in all-caps, it appears as the number "245".

@dkager Can you confirm that the new test is correct?