### PR TITLE
Some improvements to lou_checkyaml test reporting

### DIFF
--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -294,14 +294,6 @@ check_base(const char *tableList, const char *input, const char *expected,
 						actualInlen);
 			}
 		}
-		// on error print the table name, as it isn't always
-		// clear which table we are testing. In checkyaml for
-		// example you can define a test for multiple tables.
-		if (retval != 0 && in.diagnostics) {
-			fprintf(stderr, "Table: %s\n", tableList);
-			// add an empty line after each error
-			fprintf(stderr, "\n");
-		}
 
 	fail:
 		free(inbuf);

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -836,17 +836,24 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 					.max_outlen = maxOutputLen, .real_inlen = realInputLen,
 					.direction = direction, .diagnostics = !xfail);
 		}
-		if (xfail != r) errors++;
-		if ((xfail || r != 0) && !(verbose == 0 && xfail && r != 0)) {
+		if (xfail != r) {
+			// FAIL or XPASS
 			if (description) fprintf(stderr, "%s\n", description);
 			error_at_line(0, 0, file_name, event.start_mark.line + 1,
-					(xfail ? (r == 0 ? "Unexpected Pass" : "Expected Failure")
-						   : "Failure"));
+					(xfail ? "Unexpected Pass" : "Failure"));
+			errors++;
 			// on error print the table name, as it isn't always clear
 			// which table we are testing. You can can define a test
 			// for multiple tables.
 			fprintf(stderr, "Table: %s\n", *table);
 			// add an empty line after each error
+			fprintf(stderr, "\n");
+		} else if (xfail && r && verbose) {
+			// XFAIL
+			// in verbose mode print expected failures
+			if (description) fprintf(stderr, "%s\n", description);
+			error_at_line(0, 0, file_name, event.start_mark.line + 1, "Expected Failure");
+			fprintf(stderr, "Table: %s\n", *table);
 			fprintf(stderr, "\n");
 		}
 		result |= r;

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -32,9 +32,11 @@
 #include "version-etc.h"
 #include "brl_checks.h"
 
+static int verbose = 0;
 static const struct option longopts[] = {
 	{ "help", no_argument, NULL, 'h' },
 	{ "version", no_argument, NULL, 'v' },
+	{ "verbose", no_argument, &verbose, 1 },
 	{ NULL, 0, NULL, 0 },
 };
 
@@ -68,7 +70,8 @@ to stderr.\n\n",
 
 	fputs("\
   -h, --help          display this help and exit\n\
-  -v, --version       display version information and exit\n",
+  -v, --version       display version information and exit\n\
+      --verbose       report expected failures\n",
 			stdout);
 
 	printf("\n");
@@ -834,7 +837,7 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 					.direction = direction, .diagnostics = !xfail);
 		}
 		if (xfail != r) errors++;
-		if (xfail || r != 0) {
+		if ((xfail || r != 0) && !(verbose == 0 && xfail && r != 0)) {
 			if (description) fprintf(stderr, "%s\n", description);
 			error_at_line(0, 0, file_name, event.start_mark.line + 1,
 					(xfail ? (r == 0 ? "Unexpected Pass" : "Expected Failure")

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -840,8 +840,8 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 					(xfail ? (r == 0 ? "Unexpected Pass" : "Expected Failure")
 						   : "Failure"));
 			// on error print the table name, as it isn't always clear
-			// which table we are testing. In checkyaml for example you
-			// can define a test for multiple tables.
+			// which table we are testing. You can can define a test
+			// for multiple tables.
 			fprintf(stderr, "Table: %s\n", *table);
 			// add an empty line after each error
 			fprintf(stderr, "\n");


### PR DESCRIPTION
- Report expected failures
- Print the table under test also in hyphenation mode
- Print the table under test also for expected failures
- Make a test fail if it resulted in a expected pass for one of the tables under test
- Count every test once for every table under test in the total number of tests