### PR TITLE
Remove the _lou_getLastTableList function

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4085,15 +4085,6 @@ cleanup:
 }
 
 static ChainEntry *lastTrans = NULL;
-char *EXPORT_CALL
-_lou_getLastTableList(void) {
-	static char scratchBuf[MAXSTRING];
-	if (lastTrans == NULL) return NULL;
-	strncpy(scratchBuf, lastTrans->tableList, lastTrans->tableListLength);
-	scratchBuf[lastTrans->tableListLength] = 0;
-	return scratchBuf;
-}
-
 /* Return the emphasis classes declared in tableList. */
 char const **EXPORT_CALL
 lou_getEmphClasses(const char *tableList) {

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -633,9 +633,6 @@ _lou_resolveTable(const char *tableList, const char *base);
 char **EXPORT_CALL
 _lou_defaultTableResolver(const char *tableList, const char *base);
 
-char *EXPORT_CALL
-_lou_getLastTableList(void);
-
 /**
  * Return single-cell dot pattern corresponding to a character.
  * TODO: move to commonTranslationFunctions.c


### PR DESCRIPTION
It was only used in liblouisutdml and since the internal API is no longer exported it makes no sense to have this call in the API.