### PR TITLE
Python wrapper: createEncodedByeString > createEncodedByteString and allow surrogates on Python 3

### DIFF
--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -50,11 +50,11 @@ def _createTypeformbuf(length, typeform=None):
     """Creates a typeform buffer for liblouis calls"""
     return (c_ushort*length)(*typeform) if typeform else (c_ushort*length)()
 
-createEncodedByeString = None
+createEncodedByteString = None
 if sys.version_info.major == 2:
-    createEncodedByeString = lambda x: unicode(x).encode(conversionEncoding)
+    createEncodedByteString = lambda x: unicode(x).encode(conversionEncoding)
 else: # sys.version_info[0] == 3
-    createEncodedByeString = lambda x: str(x).encode(conversionEncoding)
+    createEncodedByteString = lambda x: str(x).encode(conversionEncoding)
 
 try:
     # Native win32
@@ -168,7 +168,7 @@ def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     @see: lou_translate in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value*outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
@@ -203,7 +203,7 @@ def translateString(tableList, inbuf, typeform=None, mode=0):
     @see: lou_translateString in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value*outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
@@ -239,7 +239,7 @@ def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     @see: lou_backTranslate in the liblouis documentation.
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value * outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
@@ -274,7 +274,7 @@ def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     @see: lou_backTranslateString in the liblouis documentation.
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
     outlen = c_int(inlen.value * outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
@@ -307,7 +307,7 @@ def hyphenate(tableList, inbuf, mode=0):
     @see: lou_hyphenate in the liblouis documentation.
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
     hyphen_string = create_string_buffer(inlen.value + 1) 
     if not liblouis.lou_hyphenate(tablesString, inbuf, inlen, hyphen_string, mode):
@@ -363,7 +363,7 @@ def dotsToChar(tableList, inbuf):
     @see: lou_dotsToChar in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     length = c_int(len(inbuf) // wideCharBytes)
     outbuf = create_string_buffer(length.value * wideCharBytes)
     if not liblouis.lou_dotsToChar(tablesString, inbuf, outbuf, length, 0):
@@ -382,7 +382,7 @@ def charToDots(tableList, inbuf, mode=0):
     @see: lou_charToDOts in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
-    inbuf = createEncodedByeString(inbuf)
+    inbuf = createEncodedByteString(inbuf)
     length = c_int(len(inbuf) // wideCharBytes)
     outbuf = create_string_buffer(length.value * wideCharBytes)
     if not liblouis.lou_charToDots(tablesString, inbuf, outbuf, length, mode):

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -50,11 +50,14 @@ def _createTypeformbuf(length, typeform=None):
     """Creates a typeform buffer for liblouis calls"""
     return (c_ushort*length)(*typeform) if typeform else (c_ushort*length)()
 
+ENCODING_ERROR_HANDLER = None
 createEncodedByteString = None
 if sys.version_info.major == 2:
-    createEncodedByteString = lambda x: unicode(x).encode(conversionEncoding)
+    ENCODING_ERROR_HANDLER = "strict"
+    createEncodedByteString = lambda x: unicode(x).encode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
 else: # sys.version_info[0] == 3
-    createEncodedByteString = lambda x: str(x).encode(conversionEncoding)
+    ENCODING_ERROR_HANDLER = "surrogatepass"
+    createEncodedByteString = lambda x: str(x).encode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
 
 try:
     # Native win32
@@ -184,7 +187,7 @@ def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
         raise RuntimeError("Can't translate: tables %s, inbuf %s, typeform %s, cursorPos %s, mode %s"%(tableList, inbuf, typeform, cursorPos, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
 
 def translateString(tableList, inbuf, typeform=None, mode=0):
     """Translate a string of characters.
@@ -216,7 +219,7 @@ def translateString(tableList, inbuf, typeform=None, mode=0):
         raise RuntimeError("Can't translate: tables %s, inbuf %s, typeform %s, mode %s"%(tableList, inbuf, typeform, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding)
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
 
 def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     """Back translates a string of characters, providing position information.
@@ -255,7 +258,7 @@ def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
         raise RuntimeError("Can't back translate: tables %s, inbuf %s, typeform %s, cursorPos %d, mode %d"%(tableList, inbuf, typeform, cursorPos, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
 
 def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     """Back translate from Braille.
@@ -286,7 +289,7 @@ def backTranslateString(tableList, inbuf, typeform=None, mode=0):
         raise RuntimeError("Can't back translate: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding)
+    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
 
 def hyphenate(tableList, inbuf, mode=0):
     """Get information for hyphenation.
@@ -368,7 +371,7 @@ def dotsToChar(tableList, inbuf):
     outbuf = create_string_buffer(length.value * wideCharBytes)
     if not liblouis.lou_dotsToChar(tablesString, inbuf, outbuf, length, 0):
         raise RuntimeError("Can't convert dots to char: tables %s, inbuf %s"%(tableList, inbuf))
-    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding)
+    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
 
 def charToDots(tableList, inbuf, mode=0):
     """"Convert a string of characterss to a string of dot patterns according to the specifications in tableList.
@@ -387,7 +390,7 @@ def charToDots(tableList, inbuf, mode=0):
     outbuf = create_string_buffer(length.value * wideCharBytes)
     if not liblouis.lou_charToDots(tablesString, inbuf, outbuf, length, mode):
         raise RuntimeError("Can't convert char to dots: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
-    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding)
+    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
 
 def registerLogCallback(logCallback):
     """Register logging callbacks.


### PR DESCRIPTION
1. FIxed a typo: createEncodedByeString > createEncodedByteString. This typo was probably introduced due to a bad search/replace.
2. On Python 3, an UnicodeEncodeError was raised when trying to translate utf-16 surrogate characters. NVDA suffers from this issue in command consoles, where surrogate characters seem to be allowed. Using the surrogatepass error handler ensures that behavior is similar to the behavior on Python 2.