### PR TITLE
Internally separate display from translation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -47,6 +47,10 @@ None
 ** Backwards incompatible changes
 None
 
+** Invisible changes
+   - Internally separate more clearly the display and translation
+     phases.
+
 ** New, renamed or removed tables
 *** New
 - grc-international-common.uti

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -430,11 +430,6 @@ allocateSpaceInTable(FileInfo *nested, TranslationTableOffset *offset, int count
 }
 
 static int
-reserveSpaceInTable(FileInfo *nested, int count, TranslationTableHeader **table) {
-	return (allocateSpaceInTable(nested, NULL, count, table));
-}
-
-static int
 allocateHeader(FileInfo *nested, TranslationTableHeader **table) {
 	/* Allocate memory for the table header and a guess on the number of
 	 * rules */
@@ -2374,7 +2369,7 @@ compileHyphenation(FileInfo *nested, CharsString *encoding, int *lastToken,
 	TranslationTableOffset holdOffset;
 	/* Set aside enough space for hyphenation states and transitions in
 	 * translation table. Must be done before anything else */
-	reserveSpaceInTable(nested, 250000, table);
+	allocateSpaceInTable(nested, NULL, 250000, table);
 	hashTab = hyphenHashNew();
 	dict.numStates = 1;
 	dict.states = malloc(sizeof(HyphenationState));

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -87,16 +87,25 @@ typedef struct CharsString {
 static int errorCount;
 static int warningCount;
 
-static TranslationTableHeader *gTable;
+static DisplayTableHeader *currentDisplayTable;
 
-typedef struct ChainEntry {
-	struct ChainEntry *next;
+typedef struct TranslationTableChainEntry {
+	struct TranslationTableChainEntry *next;
 	TranslationTableHeader *table;
 	int tableListLength;
 	char tableList[1];
-} ChainEntry;
+} TranslationTableChainEntry;
 
-static ChainEntry *tableChain = NULL;
+static TranslationTableChainEntry *translationTableChain = NULL;
+
+typedef struct DisplayTableChainEntry {
+	struct DisplayTableChainEntry *next;
+	DisplayTableHeader *table;
+	int tableListLength;
+	char tableList[1];
+} DisplayTableChainEntry;
+
+static DisplayTableChainEntry *displayTableChain = NULL;
 
 static const char *characterClassNames[] = {
 	"space",
@@ -396,10 +405,9 @@ compileWarning(FileInfo *nested, const char *format, ...) {
 }
 
 static int
-allocateSpaceInTable(FileInfo *nested, TranslationTableOffset *offset, int count,
-		TranslationTableHeader **table) {
-	/* allocate memory for translation table and expand previously allocated
-	 * memory if necessary */
+allocateSpaceInTranslationTable(FileInfo *nested, TranslationTableOffset *offset,
+		int count, TranslationTableHeader **table) {
+	/* allocate memory for table and expand previously allocated memory if necessary */
 	int spaceNeeded = ((count + OFFSETSIZE - 1) / OFFSETSIZE) * OFFSETSIZE;
 	TranslationTableOffset newSize = (*table)->bytesUsed + spaceNeeded;
 	TranslationTableOffset size = (*table)->tableSize;
@@ -414,8 +422,8 @@ allocateSpaceInTable(FileInfo *nested, TranslationTableOffset *offset, int count
 		memset(((unsigned char *)newTable) + size, 0, newSize - size);
 		/* update references to the old table */
 		{
-			ChainEntry *entry;
-			for (entry = tableChain; entry != NULL; entry = entry->next)
+			TranslationTableChainEntry *entry;
+			for (entry = translationTableChain; entry != NULL; entry = entry->next)
 				if (entry->table == *table)
 					entry->table = (TranslationTableHeader *)newTable;
 		}
@@ -430,12 +438,63 @@ allocateSpaceInTable(FileInfo *nested, TranslationTableOffset *offset, int count
 }
 
 static int
-allocateHeader(FileInfo *nested, TranslationTableHeader **table) {
-	/* Allocate memory for the table header and a guess on the number of
-	 * rules */
+allocateSpaceInDisplayTable(FileInfo *nested, TranslationTableOffset *offset, int count,
+		DisplayTableHeader **table) {
+	/* allocate memory for table and expand previously allocated memory if necessary */
+	int spaceNeeded = ((count + OFFSETSIZE - 1) / OFFSETSIZE) * OFFSETSIZE;
+	TranslationTableOffset newSize = (*table)->bytesUsed + spaceNeeded;
+	TranslationTableOffset size = (*table)->tableSize;
+	if (newSize > size) {
+		DisplayTableHeader *newTable;
+		newSize += (newSize / OFFSETSIZE);
+		newTable = realloc(*table, newSize);
+		if (!newTable) {
+			compileError(nested, "Not enough memory for display table.");
+			_lou_outOfMemory();
+		}
+		memset(((unsigned char *)newTable) + size, 0, newSize - size);
+		/* update references to the old table */
+		{
+			DisplayTableChainEntry *entry;
+			for (entry = displayTableChain; entry != NULL; entry = entry->next)
+				if (entry->table == *table) entry->table = (DisplayTableHeader *)newTable;
+		}
+		*table = (DisplayTableHeader *)newTable;
+		(*table)->tableSize = newSize;
+	}
+	if (offset != NULL) {
+		*offset = ((*table)->bytesUsed - sizeof(**table)) / OFFSETSIZE;
+		(*table)->bytesUsed += spaceNeeded;
+	}
+	return 1;
+}
+
+static int
+allocateTranslationTable(FileInfo *nested, TranslationTableHeader **table) {
+	/* Allocate memory for the table and a guess on the number of rules */
 	const TranslationTableOffset startSize = 2 * sizeof(**table);
 	if (*table) return 1;
-	TranslationTableOffset bytesUsed = sizeof(**table) + OFFSETSIZE; /* So no offset is ever zero */
+	TranslationTableOffset bytesUsed =
+			sizeof(**table) + OFFSETSIZE; /* So no offset is ever zero */
+	if (!(*table = malloc(startSize))) {
+		compileError(nested, "Not enough memory");
+		if (*table != NULL) free(*table);
+		*table = NULL;
+		_lou_outOfMemory();
+	}
+	memset(*table, 0, startSize);
+	(*table)->tableSize = startSize;
+	(*table)->bytesUsed = bytesUsed;
+	return 1;
+}
+
+static int
+allocateDisplayTable(FileInfo *nested, DisplayTableHeader **table) {
+	/* Allocate memory for the table and a guess on the number of rules */
+	const TranslationTableOffset startSize = 2 * sizeof(**table);
+	if (*table) return 1;
+	TranslationTableOffset bytesUsed =
+			sizeof(**table) + OFFSETSIZE; /* So no offset is ever zero */
 	if (!(*table = malloc(startSize))) {
 		compileError(nested, "Not enough memory");
 		if (*table != NULL) free(*table);
@@ -483,7 +542,8 @@ addCharOrDots(FileInfo *nested, widechar c, int m, TranslationTableHeader **tabl
 	TranslationTableOffset offset;
 	unsigned long int makeHash;
 	if ((character = compile_findCharOrDots(c, m, *table))) return character;
-	if (!allocateSpaceInTable(nested, &offset, sizeof(*character), table)) return NULL;
+	if (!allocateSpaceInTranslationTable(nested, &offset, sizeof(*character), table))
+		return NULL;
 	character = (TranslationTableCharacter *)&(*table)->ruleArea[offset];
 	memset(character, 0, sizeof(*character));
 	character->realchar = c;
@@ -507,7 +567,7 @@ addCharOrDots(FileInfo *nested, widechar c, int m, TranslationTableHeader **tabl
 }
 
 static CharOrDots *
-getCharOrDots(widechar c, int m, TranslationTableHeader *table) {
+getCharOrDots(widechar c, int m, DisplayTableHeader *table) {
 	CharOrDots *cdPtr;
 	TranslationTableOffset bucket;
 	unsigned long int makeHash = _lou_charHash(c);
@@ -525,27 +585,28 @@ getCharOrDots(widechar c, int m, TranslationTableHeader *table) {
 
 widechar EXPORT_CALL
 _lou_getDotsForChar(widechar c) {
-	CharOrDots *cdPtr = getCharOrDots(c, 0, gTable);
+	CharOrDots *cdPtr = getCharOrDots(c, 0, currentDisplayTable);
 	if (cdPtr) return cdPtr->found;
 	return LOU_DOTS;
 }
 
 widechar EXPORT_CALL
 _lou_getCharFromDots(widechar d) {
-	CharOrDots *cdPtr = getCharOrDots(d, 1, gTable);
+	CharOrDots *cdPtr = getCharOrDots(d, 1, currentDisplayTable);
 	if (cdPtr) return cdPtr->found;
 	return ' ';
 }
 
 static int
-putCharAndDots(FileInfo *nested, widechar c, widechar d, TranslationTableHeader **table) {
+putCharAndDots(FileInfo *nested, widechar c, widechar d, DisplayTableHeader **table) {
 	TranslationTableOffset bucket;
 	CharOrDots *cdPtr;
 	CharOrDots *oldcdPtr = NULL;
 	TranslationTableOffset offset;
 	unsigned long int makeHash;
 	if (!(cdPtr = getCharOrDots(c, 0, *table))) {
-		if (!allocateSpaceInTable(nested, &offset, sizeof(*cdPtr), table)) return 0;
+		if (!allocateSpaceInDisplayTable(nested, &offset, sizeof(*cdPtr), table))
+			return 0;
 		cdPtr = (CharOrDots *)&(*table)->ruleArea[offset];
 		cdPtr->next = 0;
 		cdPtr->lookFor = c;
@@ -562,7 +623,8 @@ putCharAndDots(FileInfo *nested, widechar c, widechar d, TranslationTableHeader 
 		}
 	}
 	if (!(cdPtr = getCharOrDots(d, 1, *table))) {
-		if (!allocateSpaceInTable(nested, &offset, sizeof(*cdPtr), table)) return 0;
+		if (!allocateSpaceInDisplayTable(nested, &offset, sizeof(*cdPtr), table))
+			return 0;
 		cdPtr = (CharOrDots *)&(*table)->ruleArea[offset];
 		cdPtr->next = 0;
 		cdPtr->lookFor = d;
@@ -890,7 +952,8 @@ addRule(FileInfo *nested, TranslationTableOpcode opcode, CharsString *ruleChars,
 	int ruleSize = sizeof(TranslationTableRule) - (DEFAULTRULESIZE * CHARSIZE);
 	if (ruleChars) ruleSize += CHARSIZE * ruleChars->length;
 	if (ruleDots) ruleSize += CHARSIZE * ruleDots->length;
-	if (!allocateSpaceInTable(nested, newRuleOffset, ruleSize, table)) return 0;
+	if (!allocateSpaceInTranslationTable(nested, newRuleOffset, ruleSize, table))
+		return 0;
 	TranslationTableRule *rule =
 			(TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
 	*newRule = rule;
@@ -1414,7 +1477,7 @@ includeFile(FileInfo *nested, CharsString *includedFile,
 		TranslationTableCharacterAttributes *characterClassAttribute,
 		short opcodeLengths[], TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, RuleName **ruleNames,
-		TranslationTableHeader **table);
+		TranslationTableHeader **table, DisplayTableHeader **displayTable);
 
 static struct RuleName *gRuleNames = NULL;
 
@@ -2083,15 +2146,12 @@ compileNumber(FileInfo *nested, int *lastToken) {
 static int
 compileGrouping(FileInfo *nested, int *lastToken, TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, int noback, int nofor, RuleName **ruleNames,
-		TranslationTableHeader **table) {
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	int k;
 	CharsString name;
 	CharsString groupChars;
 	CharsString groupDots;
 	CharsString dotsParsed;
-	TranslationTableCharacter *charsDotsPtr;
-	widechar endChar;
-	widechar endDots;
 	if (!getToken(nested, &name, "name operand", lastToken)) return 0;
 	if (!getRuleCharsText(nested, &groupChars, lastToken)) return 0;
 	if (!getToken(nested, &groupDots, "dots operand", lastToken)) return 0;
@@ -2109,46 +2169,55 @@ compileGrouping(FileInfo *nested, int *lastToken, TranslationTableOffset *newRul
 				"two Unicode characters and two cells separated by a comma are needed.");
 		return 0;
 	}
-	charsDotsPtr = addCharOrDots(nested, groupChars.chars[0], 0, table);
-	charsDotsPtr->attributes |= CTC_Math;
-	charsDotsPtr->uppercase = charsDotsPtr->realchar;
-	charsDotsPtr->lowercase = charsDotsPtr->realchar;
-	charsDotsPtr = addCharOrDots(nested, groupChars.chars[1], 0, table);
-	charsDotsPtr->attributes |= CTC_Math;
-	charsDotsPtr->uppercase = charsDotsPtr->realchar;
-	charsDotsPtr->lowercase = charsDotsPtr->realchar;
-	charsDotsPtr = addCharOrDots(nested, dotsParsed.chars[0], 1, table);
-	charsDotsPtr->attributes |= CTC_Math;
-	charsDotsPtr->uppercase = charsDotsPtr->realchar;
-	charsDotsPtr->lowercase = charsDotsPtr->realchar;
-	charsDotsPtr = addCharOrDots(nested, dotsParsed.chars[1], 1, table);
-	charsDotsPtr->attributes |= CTC_Math;
-	charsDotsPtr->uppercase = charsDotsPtr->realchar;
-	charsDotsPtr->lowercase = charsDotsPtr->realchar;
-	if (!addRule(nested, CTO_Grouping, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
-				newRule, noback, nofor, table))
-		return 0;
-	if (!addRuleName(nested, &name, newRuleOffset, ruleNames)) return 0;
-	putCharAndDots(nested, groupChars.chars[0], dotsParsed.chars[0], table);
-	putCharAndDots(nested, groupChars.chars[1], dotsParsed.chars[1], table);
-	endChar = groupChars.chars[1];
-	endDots = dotsParsed.chars[1];
-	groupChars.length = dotsParsed.length = 1;
-	if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, newRuleOffset, newRule,
-				noback, nofor, table))
-		return 0;
-	groupChars.chars[0] = endChar;
-	dotsParsed.chars[0] = endDots;
-	if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, newRuleOffset, newRule,
-				noback, nofor, table))
-		return 0;
+	if (table) {
+		TranslationTableCharacter *charsDotsPtr;
+		charsDotsPtr = addCharOrDots(nested, groupChars.chars[0], 0, table);
+		charsDotsPtr->attributes |= CTC_Math;
+		charsDotsPtr->uppercase = charsDotsPtr->realchar;
+		charsDotsPtr->lowercase = charsDotsPtr->realchar;
+		charsDotsPtr = addCharOrDots(nested, groupChars.chars[1], 0, table);
+		charsDotsPtr->attributes |= CTC_Math;
+		charsDotsPtr->uppercase = charsDotsPtr->realchar;
+		charsDotsPtr->lowercase = charsDotsPtr->realchar;
+		charsDotsPtr = addCharOrDots(nested, dotsParsed.chars[0], 1, table);
+		charsDotsPtr->attributes |= CTC_Math;
+		charsDotsPtr->uppercase = charsDotsPtr->realchar;
+		charsDotsPtr->lowercase = charsDotsPtr->realchar;
+		charsDotsPtr = addCharOrDots(nested, dotsParsed.chars[1], 1, table);
+		charsDotsPtr->attributes |= CTC_Math;
+		charsDotsPtr->uppercase = charsDotsPtr->realchar;
+		charsDotsPtr->lowercase = charsDotsPtr->realchar;
+		if (!addRule(nested, CTO_Grouping, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
+					newRule, noback, nofor, table))
+			return 0;
+		if (!addRuleName(nested, &name, newRuleOffset, ruleNames)) return 0;
+	}
+	if (displayTable) {
+		putCharAndDots(nested, groupChars.chars[0], dotsParsed.chars[0], displayTable);
+		putCharAndDots(nested, groupChars.chars[1], dotsParsed.chars[1], displayTable);
+	}
+	if (table) {
+		widechar endChar;
+		widechar endDots;
+		endChar = groupChars.chars[1];
+		endDots = dotsParsed.chars[1];
+		groupChars.length = dotsParsed.length = 1;
+		if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
+					newRule, noback, nofor, table))
+			return 0;
+		groupChars.chars[0] = endChar;
+		dotsParsed.chars[0] = endDots;
+		if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
+					newRule, noback, nofor, table))
+			return 0;
+	}
 	return 1;
 }
 
 static int
 compileUplow(FileInfo *nested, int *lastToken, TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, int noback, int nofor,
-		TranslationTableHeader **table) {
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	int k;
 	TranslationTableCharacter *upperChar;
 	TranslationTableCharacter *lowerChar;
@@ -2188,48 +2257,54 @@ compileUplow(FileInfo *nested, int *lastToken, TranslationTableOffset *newRuleOf
 		compileError(nested, "at least one cell is required after the comma.");
 		return 0;
 	}
-	upperChar = addCharOrDots(nested, ruleChars.chars[0], 0, table);
-	upperChar->attributes |= CTC_Letter | CTC_UpperCase;
-	upperChar->uppercase = ruleChars.chars[0];
-	upperChar->lowercase = ruleChars.chars[1];
-	lowerChar = addCharOrDots(nested, ruleChars.chars[1], 0, table);
-	lowerChar->attributes |= CTC_Letter | CTC_LowerCase;
-	lowerChar->uppercase = ruleChars.chars[0];
-	lowerChar->lowercase = ruleChars.chars[1];
-	for (k = 0; k < upperDots.length; k++)
-		if (!compile_findCharOrDots(upperDots.chars[k], 1, *table)) {
-			attr = CTC_Letter | CTC_UpperCase;
-			upperCell = addCharOrDots(nested, upperDots.chars[k], 1, table);
-			upperCell->attributes |= attr;
-			upperCell->uppercase = upperCell->realchar;
-		}
-	if (haveLowerDots) {
-		for (k = 0; k < lowerDots.length; k++)
-			if (!compile_findCharOrDots(lowerDots.chars[k], 1, *table)) {
-				attr = CTC_Letter | CTC_LowerCase;
-				lowerCell = addCharOrDots(nested, lowerDots.chars[k], 1, table);
-				if (lowerDots.length != 1) attr = CTC_Space;
-				lowerCell->attributes |= attr;
-				lowerCell->lowercase = lowerCell->realchar;
+	if (table) {
+		upperChar = addCharOrDots(nested, ruleChars.chars[0], 0, table);
+		upperChar->attributes |= CTC_Letter | CTC_UpperCase;
+		upperChar->uppercase = ruleChars.chars[0];
+		upperChar->lowercase = ruleChars.chars[1];
+		lowerChar = addCharOrDots(nested, ruleChars.chars[1], 0, table);
+		lowerChar->attributes |= CTC_Letter | CTC_LowerCase;
+		lowerChar->uppercase = ruleChars.chars[0];
+		lowerChar->lowercase = ruleChars.chars[1];
+		for (k = 0; k < upperDots.length; k++)
+			if (!compile_findCharOrDots(upperDots.chars[k], 1, *table)) {
+				attr = CTC_Letter | CTC_UpperCase;
+				upperCell = addCharOrDots(nested, upperDots.chars[k], 1, table);
+				upperCell->attributes |= attr;
+				upperCell->uppercase = upperCell->realchar;
 			}
-	} else if (upperCell != NULL && upperDots.length == 1)
-		upperCell->attributes |= CTC_LowerCase;
-	if (lowerDots.length == 1)
-		putCharAndDots(nested, ruleChars.chars[1], lowerDots.chars[0], table);
-	if (upperCell != NULL) upperCell->lowercase = lowerDots.chars[0];
-	if (lowerCell != NULL) lowerCell->uppercase = upperDots.chars[0];
-	if (upperDots.length == 1)
-		putCharAndDots(nested, ruleChars.chars[0], upperDots.chars[0], table);
-	ruleChars.length = 1;
-	ruleChars.chars[2] = ruleChars.chars[0];
-	ruleChars.chars[0] = ruleChars.chars[1];
-	if (!addRule(nested, CTO_LowerCase, &ruleChars, &lowerDots, 0, 0, newRuleOffset,
-				newRule, noback, nofor, table))
-		return 0;
-	ruleChars.chars[0] = ruleChars.chars[2];
-	if (!addRule(nested, CTO_UpperCase, &ruleChars, &upperDots, 0, 0, newRuleOffset,
-				newRule, noback, nofor, table))
-		return 0;
+		if (haveLowerDots) {
+			for (k = 0; k < lowerDots.length; k++)
+				if (!compile_findCharOrDots(lowerDots.chars[k], 1, *table)) {
+					attr = CTC_Letter | CTC_LowerCase;
+					lowerCell = addCharOrDots(nested, lowerDots.chars[k], 1, table);
+					if (lowerDots.length != 1) attr = CTC_Space;
+					lowerCell->attributes |= attr;
+					lowerCell->lowercase = lowerCell->realchar;
+				}
+		} else if (upperCell != NULL && upperDots.length == 1)
+			upperCell->attributes |= CTC_LowerCase;
+		if (upperCell != NULL) upperCell->lowercase = lowerDots.chars[0];
+		if (lowerCell != NULL) lowerCell->uppercase = upperDots.chars[0];
+	}
+	if (displayTable) {
+		if (lowerDots.length == 1)
+			putCharAndDots(nested, ruleChars.chars[1], lowerDots.chars[0], displayTable);
+		if (upperDots.length == 1)
+			putCharAndDots(nested, ruleChars.chars[0], upperDots.chars[0], displayTable);
+	}
+	if (table) {
+		ruleChars.length = 1;
+		ruleChars.chars[2] = ruleChars.chars[0];
+		ruleChars.chars[0] = ruleChars.chars[1];
+		if (!addRule(nested, CTO_LowerCase, &ruleChars, &lowerDots, 0, 0, newRuleOffset,
+					newRule, noback, nofor, table))
+			return 0;
+		ruleChars.chars[0] = ruleChars.chars[2];
+		if (!addRule(nested, CTO_UpperCase, &ruleChars, &upperDots, 0, 0, newRuleOffset,
+					newRule, noback, nofor, table))
+			return 0;
+	}
 	return 1;
 }
 
@@ -2369,7 +2444,7 @@ compileHyphenation(FileInfo *nested, CharsString *encoding, int *lastToken,
 	TranslationTableOffset holdOffset;
 	/* Set aside enough space for hyphenation states and transitions in
 	 * translation table. Must be done before anything else */
-	allocateSpaceInTable(nested, NULL, 250000, table);
+	allocateSpaceInTranslationTable(nested, NULL, 250000, table);
 	hashTab = hyphenHashNew();
 	dict.numStates = 1;
 	dict.states = malloc(sizeof(HyphenationState));
@@ -2411,7 +2486,8 @@ compileHyphenation(FileInfo *nested, CharsString *encoding, int *lastToken,
 			stateNum = hyphenGetNewState(&dict, hashTab, &word);
 		k = j + 2 - i;
 		if (k > 0) {
-			allocateSpaceInTable(nested, &dict.states[stateNum].hyphenPattern, k, table);
+			allocateSpaceInTranslationTable(
+					nested, &dict.states[stateNum].hyphenPattern, k, table);
 			memcpy(&(*table)->ruleArea[dict.states[stateNum].hyphenPattern], &pattern[i],
 					k);
 		}
@@ -2447,14 +2523,14 @@ compileHyphenation(FileInfo *nested, CharsString *encoding, int *lastToken,
 			dict.states[i].trans.offset = 0;
 		else {
 			holdPointer = dict.states[i].trans.pointer;
-			allocateSpaceInTable(nested, &dict.states[i].trans.offset,
+			allocateSpaceInTranslationTable(nested, &dict.states[i].trans.offset,
 					dict.states[i].numTrans * sizeof(HyphenationTrans), table);
 			memcpy(&(*table)->ruleArea[dict.states[i].trans.offset], holdPointer,
 					dict.states[i].numTrans * sizeof(HyphenationTrans));
 			free(holdPointer);
 		}
 	}
-	allocateSpaceInTable(
+	allocateSpaceInTranslationTable(
 			nested, &holdOffset, dict.numStates * sizeof(HyphenationState), table);
 	(*table)->hyphenStatesArray = holdOffset;
 	/* Prevents segmentation fault if table is reallocated */
@@ -2468,12 +2544,9 @@ static int
 compileCharDef(FileInfo *nested, TranslationTableOpcode opcode,
 		TranslationTableCharacterAttributes attributes, int *lastToken,
 		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule, int noback,
-		int nofor, TranslationTableHeader **table) {
+		int nofor, TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	CharsString ruleChars;
 	CharsString ruleDots;
-	TranslationTableCharacter *character;
-	TranslationTableCharacter *cell = NULL;
-	int k;
 	if (!getRuleCharsText(nested, &ruleChars, lastToken)) return 0;
 	if (!getRuleDotsPattern(nested, &ruleDots, lastToken)) return 0;
 	if (ruleChars.length != 1) {
@@ -2484,24 +2557,29 @@ compileCharDef(FileInfo *nested, TranslationTableOpcode opcode,
 		compileError(nested, "At least one cell is required.");
 		return 0;
 	}
-	if (attributes & (CTC_UpperCase | CTC_LowerCase)) attributes |= CTC_Letter;
-	character = addCharOrDots(nested, ruleChars.chars[0], 0, table);
-	character->attributes |= attributes;
-	character->uppercase = character->lowercase = character->realchar;
-	for (k = ruleDots.length - 1; k >= 0; k -= 1) {
-		cell = compile_findCharOrDots(ruleDots.chars[k], 1, *table);
-		if (!cell) {
-			cell = addCharOrDots(nested, ruleDots.chars[k], 1, table);
-			cell->uppercase = cell->lowercase = cell->realchar;
+	if (table) {
+		TranslationTableCharacter *character;
+		TranslationTableCharacter *cell = NULL;
+		int k;
+		if (attributes & (CTC_UpperCase | CTC_LowerCase)) attributes |= CTC_Letter;
+		character = addCharOrDots(nested, ruleChars.chars[0], 0, table);
+		character->attributes |= attributes;
+		character->uppercase = character->lowercase = character->realchar;
+		for (k = ruleDots.length - 1; k >= 0; k -= 1) {
+			cell = compile_findCharOrDots(ruleDots.chars[k], 1, *table);
+			if (!cell) {
+				cell = addCharOrDots(nested, ruleDots.chars[k], 1, table);
+				cell->uppercase = cell->lowercase = cell->realchar;
+			}
 		}
+		if (ruleDots.length == 1) cell->attributes |= attributes;
 	}
-	if (ruleDots.length == 1) {
-		cell->attributes |= attributes;
-		putCharAndDots(nested, ruleChars.chars[0], ruleDots.chars[0], table);
-	}
-	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
-				noback, nofor, table))
-		return 0;
+	if (displayTable && ruleDots.length == 1)
+		putCharAndDots(nested, ruleChars.chars[0], ruleDots.chars[0], displayTable);
+	if (table)
+		if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
+					noback, nofor, table))
+			return 0;
 	return 1;
 }
 
@@ -2523,7 +2601,7 @@ compileRule(FileInfo *nested, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
 		short opcodeLengths[], TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, RuleName **ruleNames,
-		TranslationTableHeader **table) {
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	int lastToken = 0;
 	int ok = 1;
 	CharsString token;
@@ -2547,1074 +2625,54 @@ doOpcode:
 	if (nested->lineNumber == 1 &&
 			(eqasc2uni((unsigned char *)"ISO", token.chars, 3) ||
 					eqasc2uni((unsigned char *)"UTF-8", token.chars, 5))) {
-		compileHyphenation(nested, &token, &lastToken, table);
+		if (table) compileHyphenation(nested, &token, &lastToken, table);
 		return 1;
 	}
 	opcode = getOpcode(nested, &token, opcodeLengths);
-
 	switch (opcode) { /* Carry out operations */
-	case CTO_None:
-		break;
-	case CTO_IncludeFile: {
-		CharsString includedFile;
-		if (getToken(nested, &token, "include file name", &lastToken))
-			if (parseChars(nested, &includedFile, &token))
-				if (!includeFile(nested, &includedFile, characterClasses,
-							characterClassAttribute, opcodeLengths, newRuleOffset,
-							newRule, ruleNames, table))
-					ok = 0;
-		break;
-	}
-	case CTO_Locale:
-		compileWarning(nested,
-				"The locale opcode is not implemented. Use the locale meta data "
-				"instead.");
-		break;
-	case CTO_Undefined:
-		tmp_offset = (*table)->undefined;
-		ok = compileBrailleIndicator(nested, "undefined character opcode", CTO_Undefined,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->undefined = tmp_offset;
-		break;
-
-	case CTO_Match: {
-		CharsString ptn_before, ptn_after;
-		TranslationTableOffset offset;
-		int len, mrk;
-
-		size_t patternsByteSize = sizeof(*patterns) * 27720;
-		patterns = (widechar *)malloc(patternsByteSize);
-		if (!patterns) _lou_outOfMemory();
-		memset(patterns, 0xffff, patternsByteSize);
-
-		noback = 1;
-		getCharacters(nested, &ptn_before, &lastToken);
-		getRuleCharsText(nested, &ruleChars, &lastToken);
-		getCharacters(nested, &ptn_after, &lastToken);
-		getRuleDotsPattern(nested, &ruleDots, &lastToken);
-
-		if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before, newRuleOffset,
-					newRule, noback, nofor, table))
-			ok = 0;
-
-		if (ptn_before.chars[0] == '-' && ptn_before.length == 1)
-			len = _lou_pattern_compile(
-					&ptn_before.chars[0], 0, &patterns[1], 13841, *table);
-		else
-			len = _lou_pattern_compile(
-					&ptn_before.chars[0], ptn_before.length, &patterns[1], 13841, *table);
-		if (!len) {
-			ok = 0;
-			break;
-		}
-		mrk = patterns[0] = len + 1;
-		_lou_pattern_reverse(&patterns[1]);
-
-		if (ptn_after.chars[0] == '-' && ptn_after.length == 1)
-			len = _lou_pattern_compile(
-					&ptn_after.chars[0], 0, &patterns[mrk], 13841, *table);
-		else
-			len = _lou_pattern_compile(
-					&ptn_after.chars[0], ptn_after.length, &patterns[mrk], 13841, *table);
-		if (!len) {
-			ok = 0;
-			break;
-		}
-		len += mrk;
-
-		if (!allocateSpaceInTable(nested, &offset, len * sizeof(widechar), table)) {
-			ok = 0;
-			break;
-		}
-
-		/* realloc may have moved table, so make sure newRule is still valid */
-		*newRule = (TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
-
-		memcpy(&(*table)->ruleArea[offset], patterns, len * sizeof(widechar));
-		(*newRule)->patterns = offset;
-
-		break;
-	}
-
-	case CTO_BackMatch: {
-		CharsString ptn_before, ptn_after;
-		TranslationTableOffset offset;
-		int len, mrk;
-
-		size_t patternsByteSize = sizeof(*patterns) * 27720;
-		patterns = (widechar *)malloc(patternsByteSize);
-		if (!patterns) _lou_outOfMemory();
-		memset(patterns, 0xffff, patternsByteSize);
-
-		nofor = 1;
-		getCharacters(nested, &ptn_before, &lastToken);
-		getRuleCharsText(nested, &ruleChars, &lastToken);
-		getCharacters(nested, &ptn_after, &lastToken);
-		getRuleDotsPattern(nested, &ruleDots, &lastToken);
-
-		if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
-					noback, nofor, table))
-			ok = 0;
-
-		if (ptn_before.chars[0] == '-' && ptn_before.length == 1)
-			len = _lou_pattern_compile(
-					&ptn_before.chars[0], 0, &patterns[1], 13841, *table);
-		else
-			len = _lou_pattern_compile(
-					&ptn_before.chars[0], ptn_before.length, &patterns[1], 13841, *table);
-		if (!len) {
-			ok = 0;
-			break;
-		}
-		mrk = patterns[0] = len + 1;
-		_lou_pattern_reverse(&patterns[1]);
-
-		if (ptn_after.chars[0] == '-' && ptn_after.length == 1)
-			len = _lou_pattern_compile(
-					&ptn_after.chars[0], 0, &patterns[mrk], 13841, *table);
-		else
-			len = _lou_pattern_compile(
-					&ptn_after.chars[0], ptn_after.length, &patterns[mrk], 13841, *table);
-		if (!len) {
-			ok = 0;
-			break;
-		}
-		len += mrk;
-
-		if (!allocateSpaceInTable(nested, &offset, len * sizeof(widechar), table)) {
-			ok = 0;
-			break;
-		}
-
-		/* realloc may have moved table, so make sure newRule is still valid */
-		*newRule = (TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
-
-		memcpy(&(*table)->ruleArea[offset], patterns, len * sizeof(widechar));
-		(*newRule)->patterns = offset;
-
-		break;
-	}
-
-	case CTO_BegCapsPhrase:
-		tmp_offset = (*table)->emphRules[capsRule][begPhraseOffset];
-		ok = compileBrailleIndicator(nested, "first word capital sign",
-				CTO_BegCapsPhraseRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
-		(*table)->emphRules[capsRule][begPhraseOffset] = tmp_offset;
-		break;
-	case CTO_EndCapsPhrase:
-		switch (compileBeforeAfter(nested, &lastToken)) {
-		case 1:  // before
-			if ((*table)->emphRules[capsRule][endPhraseAfterOffset]) {
-				compileError(nested, "Capital sign after last word already defined.");
-				ok = 0;
-				break;
-			}
-			tmp_offset = (*table)->emphRules[capsRule][endPhraseBeforeOffset];
-			ok = compileBrailleIndicator(nested, "capital sign before last word",
-					CTO_EndCapsPhraseBeforeRule, &tmp_offset, &lastToken, newRuleOffset,
-					newRule, noback, nofor, table);
-			(*table)->emphRules[capsRule][endPhraseBeforeOffset] = tmp_offset;
-			break;
-		case 2:  // after
-			if ((*table)->emphRules[capsRule][endPhraseBeforeOffset]) {
-				compileError(nested, "Capital sign before last word already defined.");
-				ok = 0;
-				break;
-			}
-			tmp_offset = (*table)->emphRules[capsRule][endPhraseAfterOffset];
-			ok = compileBrailleIndicator(nested, "capital sign after last word",
-					CTO_EndCapsPhraseAfterRule, &tmp_offset, &lastToken, newRuleOffset,
-					newRule, noback, nofor, table);
-			(*table)->emphRules[capsRule][endPhraseAfterOffset] = tmp_offset;
-			break;
-		default:  // error
-			compileError(nested, "Invalid lastword indicator location.");
-			ok = 0;
-			break;
-		}
-		break;
-	case CTO_BegCaps:
-		tmp_offset = (*table)->emphRules[capsRule][begOffset];
-		ok = compileBrailleIndicator(nested, "first letter capital sign", CTO_BegCapsRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->emphRules[capsRule][begOffset] = tmp_offset;
-		break;
-	case CTO_EndCaps:
-		tmp_offset = (*table)->emphRules[capsRule][endOffset];
-		ok = compileBrailleIndicator(nested, "last letter capital sign", CTO_EndCapsRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->emphRules[capsRule][endOffset] = tmp_offset;
-		break;
-	case CTO_CapsLetter:
-		tmp_offset = (*table)->emphRules[capsRule][letterOffset];
-		ok = compileBrailleIndicator(nested, "single letter capital sign",
-				CTO_CapsLetterRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
-		(*table)->emphRules[capsRule][letterOffset] = tmp_offset;
-		break;
-	case CTO_BegCapsWord:
-		tmp_offset = (*table)->emphRules[capsRule][begWordOffset];
-		ok = compileBrailleIndicator(nested, "capital word", CTO_BegCapsWordRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->emphRules[capsRule][begWordOffset] = tmp_offset;
-		break;
-	case CTO_EndCapsWord:
-		tmp_offset = (*table)->emphRules[capsRule][endWordOffset];
-		ok = compileBrailleIndicator(nested, "capital word stop", CTO_EndCapsWordRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->emphRules[capsRule][endWordOffset] = tmp_offset;
-		break;
-	case CTO_LenCapsPhrase:
-		ok = (*table)->emphRules[capsRule][lenPhraseOffset] =
-				compileNumber(nested, &lastToken);
-		break;
-
-	/* these 9 general purpose emphasis opcodes are compiled further down to more specific
-	 * internal opcodes:
-	 * - emphletter
-	 * - begemphword
-	 * - endemphword
-	 * - begemph
-	 * - endemph
-	 * - begemphphrase
-	 * - endemphphrase
-	 * - lenemphphrase
-	 */
-	case CTO_EmphClass:
-		if (getToken(nested, &token, "emphasis class", &lastToken))
-			if (parseChars(nested, &emphClass, &token)) {
-				char *s = malloc(sizeof(char) * (emphClass.length + 1));
-				for (k = 0; k < emphClass.length; k++) s[k] = (char)emphClass.chars[k];
-				s[k++] = '\0';
-				for (i = 0; (*table)->emphClasses[i]; i++)
-					if (strcmp(s, (*table)->emphClasses[i]) == 0) {
-						_lou_logMessage(LOU_LOG_WARN, "Duplicate emphasis class: %s", s);
-						warningCount++;
-						free(s);
-						return 1;
-					}
-				if (i < MAX_EMPH_CLASSES) {
-					switch (i) {
-					/* For backwards compatibility (i.e. because programs will assume the
-					 * first 3
-					 * typeform bits are `italic', `underline' and `bold') we require that
-					 * the first
-					 * 3 emphclass definitions are (in that order):
-					 *
-					 *   emphclass italic
-					 *   emphclass underline
-					 *   emphclass bold
-					 *
-					 * While it would be possible to use the emphclass opcode only for
-					 * defining
-					 * _additional_ classes (not allowing for them to be called italic,
-					 * underline or
-					 * bold), thereby reducing the amount of boilerplate, we deliberately
-					 * choose not
-					 * to do that in order to not give italic, underline and bold any
-					 * special
-					 * status. The hope is that eventually all programs will use liblouis
-					 * for
-					 * emphasis the recommended way (i.e. by looking up the supported
-					 * typeforms in
-					 * the documentation or API) so that we can drop this restriction.
-					 */
-					case 0:
-						if (strcmp(s, "italic") != 0) {
-							_lou_logMessage(LOU_LOG_ERROR,
-									"First emphasis class must be \"italic\" but got %s",
-									s);
-							errorCount++;
-							free(s);
-							return 0;
-						}
-						break;
-					case 1:
-						if (strcmp(s, "underline") != 0) {
-							_lou_logMessage(LOU_LOG_ERROR,
-									"Second emphasis class must be \"underline\" but got "
-									"%s",
-									s);
-							errorCount++;
-							free(s);
-							return 0;
-						}
-						break;
-					case 2:
-						if (strcmp(s, "bold") != 0) {
-							_lou_logMessage(LOU_LOG_ERROR,
-									"Third emphasis class must be \"bold\" but got %s",
-									s);
-							errorCount++;
-							free(s);
-							return 0;
-						}
-						break;
-					}
-					(*table)->emphClasses[i] = s;
-					(*table)->emphClasses[i + 1] = NULL;
-					ok = 1;
-					break;
-				} else {
-					_lou_logMessage(LOU_LOG_ERROR,
-							"Max number of emphasis classes (%i) reached",
-							MAX_EMPH_CLASSES);
-					errorCount++;
-					free(s);
-					ok = 0;
-					break;
-				}
-			}
-		compileError(nested, "emphclass must be followed by a valid class name.");
-		ok = 0;
-		break;
-	case CTO_EmphLetter:
-	case CTO_BegEmphWord:
-	case CTO_EndEmphWord:
-	case CTO_BegEmph:
-	case CTO_EndEmph:
-	case CTO_BegEmphPhrase:
-	case CTO_EndEmphPhrase:
-	case CTO_LenEmphPhrase:
-		ok = 0;
-		if (getToken(nested, &token, "emphasis class", &lastToken))
-			if (parseChars(nested, &emphClass, &token)) {
-				char *s = malloc(sizeof(char) * (emphClass.length + 1));
-				for (k = 0; k < emphClass.length; k++) s[k] = (char)emphClass.chars[k];
-				s[k++] = '\0';
-				for (i = 0; (*table)->emphClasses[i]; i++)
-					if (strcmp(s, (*table)->emphClasses[i]) == 0) break;
-				if (!(*table)->emphClasses[i]) {
-					_lou_logMessage(LOU_LOG_ERROR, "Emphasis class %s not declared", s);
-					errorCount++;
-					free(s);
-					break;
-				}
-				i++;  // in table->emphRules the first index is used for caps
-				if (opcode == CTO_EmphLetter) {
-					tmp_offset = (*table)->emphRules[i][letterOffset];
-					ok = compileBrailleIndicator(nested, "single letter",
-							CTO_Emph1LetterRule + letterOffset + (8 * i), &tmp_offset,
-							&lastToken, newRuleOffset, newRule, noback, nofor, table);
-					(*table)->emphRules[i][letterOffset] = tmp_offset;
-				} else if (opcode == CTO_BegEmphWord) {
-					tmp_offset = (*table)->emphRules[i][begWordOffset];
-					ok = compileBrailleIndicator(nested, "word",
-							CTO_Emph1LetterRule + begWordOffset + (8 * i), &tmp_offset,
-							&lastToken, newRuleOffset, newRule, noback, nofor, table);
-					(*table)->emphRules[i][begWordOffset] = tmp_offset;
-				} else if (opcode == CTO_EndEmphWord) {
-					tmp_offset = (*table)->emphRules[i][endWordOffset];
-					ok = compileBrailleIndicator(nested, "word stop",
-							CTO_Emph1LetterRule + endWordOffset + (8 * i), &tmp_offset,
-							&lastToken, newRuleOffset, newRule, noback, nofor, table);
-					(*table)->emphRules[i][endWordOffset] = tmp_offset;
-				} else if (opcode == CTO_BegEmph) {
-					/* fail if both begemph and any of begemphphrase or begemphword are
-					 * defined */
-					if ((*table)->emphRules[i][begWordOffset] ||
-							(*table)->emphRules[i][begPhraseOffset]) {
-						compileError(nested,
-								"Cannot define emphasis for both no context and word or "
-								"phrase context, i.e. cannot have both begemph and "
-								"begemphword or begemphphrase.");
-						ok = 0;
-						break;
-					}
-					tmp_offset = (*table)->emphRules[i][begOffset];
-					ok = compileBrailleIndicator(nested, "first letter",
-							CTO_Emph1LetterRule + begOffset + (8 * i), &tmp_offset,
-							&lastToken, newRuleOffset, newRule, noback, nofor, table);
-					(*table)->emphRules[i][begOffset] = tmp_offset;
-				} else if (opcode == CTO_EndEmph) {
-					if ((*table)->emphRules[i][endWordOffset] ||
-							(*table)->emphRules[i][endPhraseBeforeOffset] ||
-							(*table)->emphRules[i][endPhraseAfterOffset]) {
-						compileError(nested,
-								"Cannot define emphasis for both no context and word or "
-								"phrase context, i.e. cannot have both endemph and "
-								"endemphword or endemphphrase.");
-						ok = 0;
-						break;
-					}
-					tmp_offset = (*table)->emphRules[i][endOffset];
-					ok = compileBrailleIndicator(nested, "last letter",
-							CTO_Emph1LetterRule + endOffset + (8 * i), &tmp_offset,
-							&lastToken, newRuleOffset, newRule, noback, nofor, table);
-					(*table)->emphRules[i][endOffset] = tmp_offset;
-				} else if (opcode == CTO_BegEmphPhrase) {
-					tmp_offset = (*table)->emphRules[i][begPhraseOffset];
-					ok = compileBrailleIndicator(nested, "first word",
-							CTO_Emph1LetterRule + begPhraseOffset + (8 * i), &tmp_offset,
-							&lastToken, newRuleOffset, newRule, noback, nofor, table);
-					(*table)->emphRules[i][begPhraseOffset] = tmp_offset;
-				} else if (opcode == CTO_EndEmphPhrase)
-					switch (compileBeforeAfter(nested, &lastToken)) {
-					case 1:  // before
-						if ((*table)->emphRules[i][endPhraseAfterOffset]) {
-							compileError(nested, "last word after already defined.");
-							ok = 0;
-							break;
-						}
-						tmp_offset = (*table)->emphRules[i][endPhraseBeforeOffset];
-						ok = compileBrailleIndicator(nested, "last word before",
-								CTO_Emph1LetterRule + endPhraseBeforeOffset + (8 * i),
-								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
-								nofor, table);
-						(*table)->emphRules[i][endPhraseBeforeOffset] = tmp_offset;
-						break;
-					case 2:  // after
-						if ((*table)->emphRules[i][endPhraseBeforeOffset]) {
-							compileError(nested, "last word before already defined.");
-							ok = 0;
-							break;
-						}
-						tmp_offset = (*table)->emphRules[i][endPhraseAfterOffset];
-						ok = compileBrailleIndicator(nested, "last word after",
-								CTO_Emph1LetterRule + endPhraseAfterOffset + (8 * i),
-								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
-								nofor, table);
-						(*table)->emphRules[i][endPhraseAfterOffset] = tmp_offset;
-						break;
-					default:  // error
-						compileError(nested, "Invalid lastword indicator location.");
-						ok = 0;
-						break;
-					}
-				else if (opcode == CTO_LenEmphPhrase)
-					ok = (*table)->emphRules[i][lenPhraseOffset] =
-							compileNumber(nested, &lastToken);
-				free(s);
-			}
-		break;
-
-	case CTO_LetterSign:
-		tmp_offset = (*table)->letterSign;
-		ok = compileBrailleIndicator(nested, "letter sign", CTO_LetterRule, &tmp_offset,
-				&lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->letterSign = tmp_offset;
-		break;
-	case CTO_NoLetsignBefore:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			if (((*table)->noLetsignBeforeCount + ruleChars.length) > LETSIGNSIZE) {
-				compileError(nested, "More than %d characters", LETSIGNSIZE);
-				ok = 0;
-				break;
-			}
-			for (k = 0; k < ruleChars.length; k++)
-				(*table)->noLetsignBefore[(*table)->noLetsignBeforeCount++] =
-						ruleChars.chars[k];
-		}
-		break;
-	case CTO_NoLetsign:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			if (((*table)->noLetsignCount + ruleChars.length) > LETSIGNSIZE) {
-				compileError(nested, "More than %d characters", LETSIGNSIZE);
-				ok = 0;
-				break;
-			}
-			for (k = 0; k < ruleChars.length; k++)
-				(*table)->noLetsign[(*table)->noLetsignCount++] = ruleChars.chars[k];
-		}
-		break;
-	case CTO_NoLetsignAfter:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			if (((*table)->noLetsignAfterCount + ruleChars.length) > LETSIGNSIZE) {
-				compileError(nested, "More than %d characters", LETSIGNSIZE);
-				ok = 0;
-				break;
-			}
-			for (k = 0; k < ruleChars.length; k++)
-				(*table)->noLetsignAfter[(*table)->noLetsignAfterCount++] =
-						ruleChars.chars[k];
-		}
-		break;
-	case CTO_NumberSign:
-		tmp_offset = (*table)->numberSign;
-		ok = compileBrailleIndicator(nested, "number sign", CTO_NumberRule, &tmp_offset,
-				&lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->numberSign = tmp_offset;
-		break;
-
-	case CTO_Attribute:
-
-		c = NULL;
-		ok = 1;
-		if (!getToken(nested, &ruleChars, "attribute number", &lastToken)) {
-			compileError(nested, "Expected attribute number.");
-			ok = 0;
-			break;
-		}
-
-		k = -1;
-		switch (ruleChars.chars[0]) {
-		case '0':
-			k = 0;
-			break;
-		case '1':
-			k = 1;
-			break;
-		case '2':
-			k = 2;
-			break;
-		case '3':
-			k = 3;
-			break;
-		case '4':
-			k = 4;
-			break;
-		case '5':
-			k = 5;
-			break;
-		case '6':
-			k = 6;
-			break;
-		case '7':
-			k = 7;
-			break;
-		}
-		if (k == -1) {
-			compileError(nested, "Invalid attribute number.");
-			ok = 0;
-			break;
-		}
-
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (i = 0; i < ruleChars.length; i++) {
-				c = compile_findCharOrDots(ruleChars.chars[i], 0, *table);
-				if (c)
-					c->attributes |= (CTC_UserDefined0 << k);
-				else {
-					compileError(nested, "Attribute character undefined");
-					ok = 0;
-					break;
-				}
-			}
-		}
-		break;
-
-	case CTO_NumericModeChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_NumericMode;
-				else {
-					compileError(nested, "Numeric mode character undefined");
-					ok = 0;
-					break;
-				}
-			}
-			(*table)->usesNumericMode = 1;
-		}
-		break;
-
-	case CTO_MidEndNumericModeChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_MidEndNumericMode;
-				else {
-					compileError(nested, "Midendnumeric mode character undefined");
-					ok = 0;
-					break;
-				}
-			}
-			(*table)->usesNumericMode = 1;
-		}
-		break;
-
-	case CTO_NumericNoContractChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_NumericNoContract;
-				else {
-					compileError(nested, "Numeric no contraction character undefined");
-					ok = 0;
-					break;
-				}
-			}
-			(*table)->usesNumericMode = 1;
-		}
-		break;
-
-	case CTO_NoContractSign:
-
-		tmp_offset = (*table)->noContractSign;
-		ok = compileBrailleIndicator(nested, "no contractions sign", CTO_NoContractRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->noContractSign = tmp_offset;
-		break;
-
-	case CTO_SeqDelimiter:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_SeqDelimiter;
-				else {
-					compileError(nested, "Sequence delimiter character undefined");
-					ok = 0;
-					break;
-				}
-			}
-			(*table)->usesSequences = 1;
-		}
-		break;
-
-	case CTO_SeqBeforeChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_SeqBefore;
-				else {
-					compileError(nested, "Sequence before character undefined");
-					ok = 0;
-					break;
-				}
-			}
-		}
-		break;
-
-	case CTO_SeqAfterChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_SeqAfter;
-				else {
-					compileError(nested, "Sequence after character undefined");
-					ok = 0;
-					break;
-				}
-			}
-		}
-		break;
-
-	case CTO_SeqAfterPattern:
-
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			if (((*table)->seqPatternsCount + ruleChars.length + 1) > SEQPATTERNSIZE) {
-				compileError(nested, "More than %d characters", SEQPATTERNSIZE);
-				ok = 0;
-				break;
-			}
-			for (k = 0; k < ruleChars.length; k++)
-				(*table)->seqPatterns[(*table)->seqPatternsCount++] = ruleChars.chars[k];
-			(*table)->seqPatterns[(*table)->seqPatternsCount++] = 0;
-		}
-		break;
-	case CTO_SeqAfterExpression:
-
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for ((*table)->seqAfterExpressionLength = 0;
-					(*table)->seqAfterExpressionLength < ruleChars.length;
-					(*table)->seqAfterExpressionLength++)
-				(*table)->seqAfterExpression[(*table)->seqAfterExpressionLength] =
-						ruleChars.chars[(*table)->seqAfterExpressionLength];
-			(*table)->seqAfterExpression[(*table)->seqAfterExpressionLength] = 0;
-		}
-		break;
-
-	case CTO_CapsModeChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_CapsMode;
-				else {
-					compileError(nested, "Capital mode character undefined");
-					ok = 0;
-					break;
-				}
-			}
-		}
-		break;
-
-	case CTO_EmphModeChars:
-
-		c = NULL;
-		ok = 1;
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (c)
-					c->attributes |= CTC_EmphMode;
-				else {
-					compileError(nested, "Emphasis mode character undefined");
-					ok = 0;
-					break;
-				}
-			}
-		}
-		(*table)->usesEmphMode = 1;
-		break;
-
-	case CTO_BegComp:
-		tmp_offset = (*table)->begComp;
-		ok = compileBrailleIndicator(nested, "begin computer braille", CTO_BegCompRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->begComp = tmp_offset;
-		break;
-	case CTO_EndComp:
-		tmp_offset = (*table)->endComp;
-		ok = compileBrailleIndicator(nested, "end computer braslle", CTO_EndCompRule,
-				&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor, table);
-		(*table)->endComp = tmp_offset;
-		break;
-	case CTO_Syllable:
-		(*table)->syllables = 1;
-	case CTO_Always:
-	case CTO_NoCross:
-	case CTO_LargeSign:
-	case CTO_WholeWord:
-	case CTO_PartWord:
-	case CTO_JoinNum:
-	case CTO_JoinableWord:
-	case CTO_LowWord:
-	case CTO_SuffixableWord:
-	case CTO_PrefixableWord:
-	case CTO_BegWord:
-	case CTO_BegMidWord:
-	case CTO_MidWord:
-	case CTO_MidEndWord:
-	case CTO_EndWord:
-	case CTO_PrePunc:
-	case CTO_PostPunc:
-	case CTO_BegNum:
-	case CTO_MidNum:
-	case CTO_EndNum:
-	case CTO_Repeated:
-	case CTO_RepWord:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken))
-			if (getRuleDotsPattern(nested, &ruleDots, &lastToken)) {
-				if (ruleDots.length == 0)  // `=`
-					for (k = 0; k < ruleChars.length; k++) {
-						c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-						if (!c || !c->definitionRule) {
-							compileError(nested, "Character %s is not defined",
-									_lou_showString(&ruleChars.chars[k], 1));
-							return 0;
-						}
-					}
-				if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-							newRuleOffset, newRule, noback, nofor, table))
-					ok = 0;
-			}
-		// if (opcode == CTO_MidNum)
-		// {
-		//   TranslationTableCharacter *c = compile_findCharOrDots(ruleChars.chars[0], 0);
-		//   if(c)
-		//     c->attributes |= CTC_NumericMode;
-		// }
-		break;
-	case CTO_CompDots:
-	case CTO_Comp6:
-		if (!getRuleCharsText(nested, &ruleChars, &lastToken)) return 0;
-		if (ruleChars.length != 1 || ruleChars.chars[0] > 255) {
-			compileError(nested, "first operand must be 1 character and < 256");
-			return 0;
-		}
-		if (!getRuleDotsPattern(nested, &ruleDots, &lastToken)) return 0;
-		if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before, newRuleOffset,
-					newRule, noback, nofor, table))
-			ok = 0;
-		(*table)->compdotsPattern[ruleChars.chars[0]] = *newRuleOffset;
-		break;
-	case CTO_ExactDots:
-		if (!getRuleCharsText(nested, &ruleChars, &lastToken)) return 0;
-		if (ruleChars.chars[0] != '@') {
-			compileError(nested, "The operand must begin with an at sign (@)");
-			return 0;
-		}
-		for (k = 1; k < ruleChars.length; k++)
-			scratchPad.chars[k - 1] = ruleChars.chars[k];
-		scratchPad.length = ruleChars.length - 1;
-		if (!parseDots(nested, &ruleDots, &scratchPad)) return 0;
-		if (!addRule(nested, opcode, &ruleChars, &ruleDots, before, after, newRuleOffset,
-					newRule, noback, nofor, table))
-			ok = 0;
-		break;
-	case CTO_CapsNoCont:
-		ruleChars.length = 1;
-		ruleChars.chars[0] = 'a';
-		if (!addRule(nested, CTO_CapsNoContRule, &ruleChars, NULL, after, before,
-					newRuleOffset, newRule, noback, nofor, table))
-			ok = 0;
-		(*table)->capsNoCont = *newRuleOffset;
-		break;
-	case CTO_Replace:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			if (lastToken)
-				ruleDots.length = ruleDots.chars[0] = 0;
-			else {
-				getRuleDotsText(nested, &ruleDots, &lastToken);
-				if (ruleDots.chars[0] == '#')
-					ruleDots.length = ruleDots.chars[0] = 0;
-				else if (ruleDots.chars[0] == '\\' && ruleDots.chars[1] == '#')
-					memcpy(&ruleDots.chars[0], &ruleDots.chars[1],
-							ruleDots.length-- * CHARSIZE);
-			}
-		}
-		for (k = 0; k < ruleChars.length; k++)
-			addCharOrDots(nested, ruleChars.chars[k], 0, table);
-		for (k = 0; k < ruleDots.length; k++)
-			addCharOrDots(nested, ruleDots.chars[k], 0, table);
-		if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before, newRuleOffset,
-					newRule, noback, nofor, table))
-			ok = 0;
-		break;
-	case CTO_Correct:
-		(*table)->corrections = 1;
-		goto doPass;
-	case CTO_Pass2:
-		if ((*table)->numPasses < 2) (*table)->numPasses = 2;
-		goto doPass;
-	case CTO_Pass3:
-		if ((*table)->numPasses < 3) (*table)->numPasses = 3;
-		goto doPass;
-	case CTO_Pass4:
-		if ((*table)->numPasses < 4) (*table)->numPasses = 4;
-	doPass:
-	case CTO_Context:
-		if (!(nofor || noback)) {
-			compileError(nested, "%s or %s must be specified.",
-					_lou_findOpcodeName(CTO_NoFor), _lou_findOpcodeName(CTO_NoBack));
-			ok = 0;
-			break;
-		}
-		if (!compilePassOpcode(nested, opcode, *characterClasses, newRuleOffset, newRule,
-					noback, nofor, *ruleNames, table))
-			ok = 0;
-		break;
-	case CTO_Contraction:
-	case CTO_NoCont:
-	case CTO_CompBrl:
-	case CTO_Literal:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-			for (k = 0; k < ruleChars.length; k++) {
-				c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
-				if (!c || !c->definitionRule) {
-					compileError(nested, "Character %s is not defined",
-							_lou_showString(&ruleChars.chars[k], 1));
-					return 0;
-				}
-			}
-			if (!addRule(nested, opcode, &ruleChars, NULL, after, before, newRuleOffset,
-						newRule, noback, nofor, table))
-				ok = 0;
-		}
-		break;
-	case CTO_MultInd: {
-		int t;
-		ruleChars.length = 0;
-		if (getToken(nested, &token, "multiple braille indicators", &lastToken) &&
-				parseDots(nested, &cells, &token)) {
-			while ((t = getToken(nested, &token, "multind opcodes", &lastToken))) {
-				opcode = getOpcode(nested, &token, opcodeLengths);
-				if (opcode >= CTO_CapsLetter && opcode < CTO_MultInd)
-					ruleChars.chars[ruleChars.length++] = (widechar)opcode;
-				else {
-					compileError(nested, "Not a braille indicator opcode.");
-					ok = 0;
-				}
-				if (t == 2) break;
-			}
-		} else
-			ok = 0;
-		if (!addRule(nested, CTO_MultInd, &ruleChars, &cells, after, before,
-					newRuleOffset, newRule, noback, nofor, table))
-			ok = 0;
-		break;
-	}
-
-	case CTO_Class: {
-		CharsString characters;
-		const CharacterClass *class;
-		if (!*characterClasses) {
-			if (!allocateCharacterClasses(characterClasses, characterClassAttribute))
-				ok = 0;
-		}
-		if (getToken(nested, &token, "character class name", &lastToken)) {
-			class = findCharacterClass(&token, *characterClasses);
-			if (!class)
-				// no class with that name: create one
-				class = addCharacterClass(nested, &token.chars[0], token.length,
-						characterClasses, characterClassAttribute);
-			if (class) {
-				// there is a class with that name or a new class was successfully created
-				if (getCharacters(nested, &characters, &lastToken)) {
-					int index;
-					for (index = 0; index < characters.length; ++index) {
-						TranslationTableRule *defRule;
-						// get the character from the table and add the new class to its
-						// attributes
-						// if the character is not defined yet, define it
-						TranslationTableCharacter *character =
-								addCharOrDots(nested, characters.chars[index], 0, table);
-						character->attributes |= class->attribute;
-						// also add the attribute to the associated dots (if any)
-						if (character->definitionRule) {
-							defRule = (TranslationTableRule *)&(*table)
-											  ->ruleArea[character->definitionRule];
-							if (defRule->dotslen == 1) {
-								character = compile_findCharOrDots(
-										defRule->charsdots[defRule->charslen], 1, *table);
-								if (character) character->attributes |= class->attribute;
-							}
-						}
-					}
-				}
-			}
-		}
-		break;
-	}
-
-		{
-			TranslationTableCharacterAttributes *attributes;
-			const CharacterClass *class;
-		case CTO_After:
-			attributes = &after;
-			goto doClass;
-		case CTO_Before:
-			attributes = &before;
-		doClass:
-
-			if (!*characterClasses) {
-				if (!allocateCharacterClasses(characterClasses, characterClassAttribute))
-					ok = 0;
-			}
-			if (getCharacterClass(nested, &class, *characterClasses, &lastToken)) {
-				*attributes |= class->attribute;
-				goto doOpcode;
-			}
-			break;
-		}
-
-	case CTO_NoBack:
-		if (nofor) {
-			compileError(nested, "%s already specified.", _lou_findOpcodeName(CTO_NoFor));
-			ok = 0;
-			break;
-		}
-		noback = 1;
-		goto doOpcode;
-	case CTO_NoFor:
-		if (noback) {
-			compileError(
-					nested, "%s already specified.", _lou_findOpcodeName(CTO_NoBack));
-			ok = 0;
-			break;
-		}
-		nofor = 1;
-		goto doOpcode;
-
-	case CTO_EmpMatchBefore:
-		before |= CTC_EmpMatch;
-		goto doOpcode;
-	case CTO_EmpMatchAfter:
-		after |= CTC_EmpMatch;
-		goto doOpcode;
-
-	case CTO_SwapCc:
-	case CTO_SwapCd:
-	case CTO_SwapDd:
-		if (!compileSwap(nested, opcode, &lastToken, newRuleOffset, newRule, noback,
-					nofor, ruleNames, table))
-			ok = 0;
-		break;
-	case CTO_Hyphen:
-	case CTO_DecPoint:
-		//	case CTO_Apostrophe:
-		//	case CTO_Initial:
-		if (getRuleCharsText(nested, &ruleChars, &lastToken))
-			if (getRuleDotsPattern(nested, &ruleDots, &lastToken)) {
-				if (ruleChars.length != 1 || ruleDots.length < 1) {
-					compileError(nested,
-							"One Unicode character and at least one cell are required.");
-					ok = 0;
-				}
-				if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-							newRuleOffset, newRule, noback, nofor, table))
-					ok = 0;
-				// if (opcode == CTO_DecPoint)
-				// {
-				//   TranslationTableCharacter *c =
-				//   compile_findCharOrDots(ruleChars.chars[0], 0);
-				//   if(c)
-				//     c->attributes |= CTC_NumericMode;
-				// }
-			}
-		break;
 	case CTO_Space:
 		compileCharDef(nested, opcode, CTC_Space, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_Digit:
 		compileCharDef(nested, opcode, CTC_Digit, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_LitDigit:
 		compileCharDef(nested, opcode, CTC_LitDigit, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_Punctuation:
 		compileCharDef(nested, opcode, CTC_Punctuation, &lastToken, newRuleOffset,
-				newRule, noback, nofor, table);
+				newRule, noback, nofor, table, displayTable);
 		break;
 	case CTO_Math:
 		compileCharDef(nested, opcode, CTC_Math, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_Sign:
 		compileCharDef(nested, opcode, CTC_Sign, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_Letter:
 		compileCharDef(nested, opcode, CTC_Letter, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_UpperCase:
 		compileCharDef(nested, opcode, CTC_UpperCase, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_LowerCase:
 		compileCharDef(nested, opcode, CTC_LowerCase, &lastToken, newRuleOffset, newRule,
-				noback, nofor, table);
+				noback, nofor, table, displayTable);
 		break;
 	case CTO_Grouping:
 		ok = compileGrouping(nested, &lastToken, newRuleOffset, newRule, noback, nofor,
-				ruleNames, table);
+				ruleNames, table, displayTable);
 		break;
 	case CTO_UpLow:
-		ok = compileUplow(
-				nested, &lastToken, newRuleOffset, newRule, noback, nofor, table);
+		ok = compileUplow(nested, &lastToken, newRuleOffset, newRule, noback, nofor,
+				table, displayTable);
 		break;
 	case CTO_Display:
 		if (getRuleCharsText(nested, &ruleChars, &lastToken))
@@ -3624,13 +2682,1067 @@ doOpcode:
 							nested, "Exactly one character and one cell are required.");
 					ok = 0;
 				}
-				putCharAndDots(nested, ruleChars.chars[0], ruleDots.chars[0], table);
+				putCharAndDots(
+						nested, ruleChars.chars[0], ruleDots.chars[0], displayTable);
 			}
 		break;
 	default:
-		compileError(nested, "unimplemented opcode.");
-		ok = 0;
-		break;
+		if (!table) break;
+		switch (opcode) {
+		case CTO_None:
+			break;
+		case CTO_IncludeFile: {
+			CharsString includedFile;
+			if (getToken(nested, &token, "include file name", &lastToken))
+				if (parseChars(nested, &includedFile, &token))
+					if (!includeFile(nested, &includedFile, characterClasses,
+								characterClassAttribute, opcodeLengths, newRuleOffset,
+								newRule, ruleNames, table, displayTable))
+						ok = 0;
+			break;
+		}
+		case CTO_Locale:
+			compileWarning(nested,
+					"The locale opcode is not implemented. Use the locale meta data "
+					"instead.");
+			break;
+		case CTO_Undefined:
+			tmp_offset = (*table)->undefined;
+			ok = compileBrailleIndicator(nested, "undefined character opcode",
+					CTO_Undefined, &tmp_offset, &lastToken, newRuleOffset, newRule,
+					noback, nofor, table);
+			(*table)->undefined = tmp_offset;
+			break;
+
+		case CTO_Match: {
+			CharsString ptn_before, ptn_after;
+			TranslationTableOffset offset;
+			int len, mrk;
+
+			size_t patternsByteSize = sizeof(*patterns) * 27720;
+			patterns = (widechar *)malloc(patternsByteSize);
+			if (!patterns) _lou_outOfMemory();
+			memset(patterns, 0xffff, patternsByteSize);
+
+			noback = 1;
+			getCharacters(nested, &ptn_before, &lastToken);
+			getRuleCharsText(nested, &ruleChars, &lastToken);
+			getCharacters(nested, &ptn_after, &lastToken);
+			getRuleDotsPattern(nested, &ruleDots, &lastToken);
+
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
+						newRuleOffset, newRule, noback, nofor, table))
+				ok = 0;
+
+			if (ptn_before.chars[0] == '-' && ptn_before.length == 1)
+				len = _lou_pattern_compile(
+						&ptn_before.chars[0], 0, &patterns[1], 13841, *table);
+			else
+				len = _lou_pattern_compile(&ptn_before.chars[0], ptn_before.length,
+						&patterns[1], 13841, *table);
+			if (!len) {
+				ok = 0;
+				break;
+			}
+			mrk = patterns[0] = len + 1;
+			_lou_pattern_reverse(&patterns[1]);
+
+			if (ptn_after.chars[0] == '-' && ptn_after.length == 1)
+				len = _lou_pattern_compile(
+						&ptn_after.chars[0], 0, &patterns[mrk], 13841, *table);
+			else
+				len = _lou_pattern_compile(&ptn_after.chars[0], ptn_after.length,
+						&patterns[mrk], 13841, *table);
+			if (!len) {
+				ok = 0;
+				break;
+			}
+			len += mrk;
+
+			if (!allocateSpaceInTranslationTable(
+						nested, &offset, len * sizeof(widechar), table)) {
+				ok = 0;
+				break;
+			}
+
+			/* realloc may have moved table, so make sure newRule is still valid */
+			*newRule = (TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
+
+			memcpy(&(*table)->ruleArea[offset], patterns, len * sizeof(widechar));
+			(*newRule)->patterns = offset;
+
+			break;
+		}
+
+		case CTO_BackMatch: {
+			CharsString ptn_before, ptn_after;
+			TranslationTableOffset offset;
+			int len, mrk;
+
+			size_t patternsByteSize = sizeof(*patterns) * 27720;
+			patterns = (widechar *)malloc(patternsByteSize);
+			if (!patterns) _lou_outOfMemory();
+			memset(patterns, 0xffff, patternsByteSize);
+
+			nofor = 1;
+			getCharacters(nested, &ptn_before, &lastToken);
+			getRuleCharsText(nested, &ruleChars, &lastToken);
+			getCharacters(nested, &ptn_after, &lastToken);
+			getRuleDotsPattern(nested, &ruleDots, &lastToken);
+
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset,
+						newRule, noback, nofor, table))
+				ok = 0;
+
+			if (ptn_before.chars[0] == '-' && ptn_before.length == 1)
+				len = _lou_pattern_compile(
+						&ptn_before.chars[0], 0, &patterns[1], 13841, *table);
+			else
+				len = _lou_pattern_compile(&ptn_before.chars[0], ptn_before.length,
+						&patterns[1], 13841, *table);
+			if (!len) {
+				ok = 0;
+				break;
+			}
+			mrk = patterns[0] = len + 1;
+			_lou_pattern_reverse(&patterns[1]);
+
+			if (ptn_after.chars[0] == '-' && ptn_after.length == 1)
+				len = _lou_pattern_compile(
+						&ptn_after.chars[0], 0, &patterns[mrk], 13841, *table);
+			else
+				len = _lou_pattern_compile(&ptn_after.chars[0], ptn_after.length,
+						&patterns[mrk], 13841, *table);
+			if (!len) {
+				ok = 0;
+				break;
+			}
+			len += mrk;
+
+			if (!allocateSpaceInTranslationTable(
+						nested, &offset, len * sizeof(widechar), table)) {
+				ok = 0;
+				break;
+			}
+
+			/* realloc may have moved table, so make sure newRule is still valid */
+			*newRule = (TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
+
+			memcpy(&(*table)->ruleArea[offset], patterns, len * sizeof(widechar));
+			(*newRule)->patterns = offset;
+
+			break;
+		}
+
+		case CTO_BegCapsPhrase:
+			tmp_offset = (*table)->emphRules[capsRule][begPhraseOffset];
+			ok = compileBrailleIndicator(nested, "first word capital sign",
+					CTO_BegCapsPhraseRule, &tmp_offset, &lastToken, newRuleOffset,
+					newRule, noback, nofor, table);
+			(*table)->emphRules[capsRule][begPhraseOffset] = tmp_offset;
+			break;
+		case CTO_EndCapsPhrase:
+			switch (compileBeforeAfter(nested, &lastToken)) {
+			case 1:  // before
+				if ((*table)->emphRules[capsRule][endPhraseAfterOffset]) {
+					compileError(nested, "Capital sign after last word already defined.");
+					ok = 0;
+					break;
+				}
+				tmp_offset = (*table)->emphRules[capsRule][endPhraseBeforeOffset];
+				ok = compileBrailleIndicator(nested, "capital sign before last word",
+						CTO_EndCapsPhraseBeforeRule, &tmp_offset, &lastToken,
+						newRuleOffset, newRule, noback, nofor, table);
+				(*table)->emphRules[capsRule][endPhraseBeforeOffset] = tmp_offset;
+				break;
+			case 2:  // after
+				if ((*table)->emphRules[capsRule][endPhraseBeforeOffset]) {
+					compileError(
+							nested, "Capital sign before last word already defined.");
+					ok = 0;
+					break;
+				}
+				tmp_offset = (*table)->emphRules[capsRule][endPhraseAfterOffset];
+				ok = compileBrailleIndicator(nested, "capital sign after last word",
+						CTO_EndCapsPhraseAfterRule, &tmp_offset, &lastToken,
+						newRuleOffset, newRule, noback, nofor, table);
+				(*table)->emphRules[capsRule][endPhraseAfterOffset] = tmp_offset;
+				break;
+			default:  // error
+				compileError(nested, "Invalid lastword indicator location.");
+				ok = 0;
+				break;
+			}
+			break;
+		case CTO_BegCaps:
+			tmp_offset = (*table)->emphRules[capsRule][begOffset];
+			ok = compileBrailleIndicator(nested, "first letter capital sign",
+					CTO_BegCapsRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
+					noback, nofor, table);
+			(*table)->emphRules[capsRule][begOffset] = tmp_offset;
+			break;
+		case CTO_EndCaps:
+			tmp_offset = (*table)->emphRules[capsRule][endOffset];
+			ok = compileBrailleIndicator(nested, "last letter capital sign",
+					CTO_EndCapsRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
+					noback, nofor, table);
+			(*table)->emphRules[capsRule][endOffset] = tmp_offset;
+			break;
+		case CTO_CapsLetter:
+			tmp_offset = (*table)->emphRules[capsRule][letterOffset];
+			ok = compileBrailleIndicator(nested, "single letter capital sign",
+					CTO_CapsLetterRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
+					noback, nofor, table);
+			(*table)->emphRules[capsRule][letterOffset] = tmp_offset;
+			break;
+		case CTO_BegCapsWord:
+			tmp_offset = (*table)->emphRules[capsRule][begWordOffset];
+			ok = compileBrailleIndicator(nested, "capital word", CTO_BegCapsWordRule,
+					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
+					table);
+			(*table)->emphRules[capsRule][begWordOffset] = tmp_offset;
+			break;
+		case CTO_EndCapsWord:
+			tmp_offset = (*table)->emphRules[capsRule][endWordOffset];
+			ok = compileBrailleIndicator(nested, "capital word stop", CTO_EndCapsWordRule,
+					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
+					table);
+			(*table)->emphRules[capsRule][endWordOffset] = tmp_offset;
+			break;
+		case CTO_LenCapsPhrase:
+			ok = (*table)->emphRules[capsRule][lenPhraseOffset] =
+					compileNumber(nested, &lastToken);
+			break;
+
+		/* these 9 general purpose emphasis opcodes are compiled further down to more
+		 * specific internal opcodes:
+		 * - emphletter
+		 * - begemphword
+		 * - endemphword
+		 * - begemph
+		 * - endemph
+		 * - begemphphrase
+		 * - endemphphrase
+		 * - lenemphphrase
+		 */
+		case CTO_EmphClass:
+			if (getToken(nested, &token, "emphasis class", &lastToken))
+				if (parseChars(nested, &emphClass, &token)) {
+					char *s = malloc(sizeof(char) * (emphClass.length + 1));
+					for (k = 0; k < emphClass.length; k++)
+						s[k] = (char)emphClass.chars[k];
+					s[k++] = '\0';
+					for (i = 0; (*table)->emphClasses[i]; i++)
+						if (strcmp(s, (*table)->emphClasses[i]) == 0) {
+							_lou_logMessage(
+									LOU_LOG_WARN, "Duplicate emphasis class: %s", s);
+							warningCount++;
+							free(s);
+							return 1;
+						}
+					if (i < MAX_EMPH_CLASSES) {
+						switch (i) {
+						/* For backwards compatibility (i.e. because programs will assume
+						 * the first 3 typeform bits are `italic', `underline' and `bold')
+						 * we require that the first 3 emphclass definitions are (in that
+						 * order):
+						 *
+						 *   emphclass italic
+						 *   emphclass underline
+						 *   emphclass bold
+						 *
+						 * While it would be possible to use the emphclass opcode only for
+						 * defining
+						 * _additional_ classes (not allowing for them to be called
+						 * italic, underline or bold), thereby reducing the amount of
+						 * boilerplate, we deliberately choose not to do that in order to
+						 * not give italic, underline and bold any special status. The
+						 * hope is that eventually all programs will use liblouis for
+						 * emphasis the recommended way (i.e. by looking up the supported
+						 * typeforms in
+						 * the documentation or API) so that we can drop this restriction.
+						 */
+						case 0:
+							if (strcmp(s, "italic") != 0) {
+								_lou_logMessage(LOU_LOG_ERROR,
+										"First emphasis class must be \"italic\" but got "
+										"%s",
+										s);
+								errorCount++;
+								free(s);
+								return 0;
+							}
+							break;
+						case 1:
+							if (strcmp(s, "underline") != 0) {
+								_lou_logMessage(LOU_LOG_ERROR,
+										"Second emphasis class must be \"underline\" but "
+										"got "
+										"%s",
+										s);
+								errorCount++;
+								free(s);
+								return 0;
+							}
+							break;
+						case 2:
+							if (strcmp(s, "bold") != 0) {
+								_lou_logMessage(LOU_LOG_ERROR,
+										"Third emphasis class must be \"bold\" but got "
+										"%s",
+										s);
+								errorCount++;
+								free(s);
+								return 0;
+							}
+							break;
+						}
+						(*table)->emphClasses[i] = s;
+						(*table)->emphClasses[i + 1] = NULL;
+						ok = 1;
+						break;
+					} else {
+						_lou_logMessage(LOU_LOG_ERROR,
+								"Max number of emphasis classes (%i) reached",
+								MAX_EMPH_CLASSES);
+						errorCount++;
+						free(s);
+						ok = 0;
+						break;
+					}
+				}
+			compileError(nested, "emphclass must be followed by a valid class name.");
+			ok = 0;
+			break;
+		case CTO_EmphLetter:
+		case CTO_BegEmphWord:
+		case CTO_EndEmphWord:
+		case CTO_BegEmph:
+		case CTO_EndEmph:
+		case CTO_BegEmphPhrase:
+		case CTO_EndEmphPhrase:
+		case CTO_LenEmphPhrase:
+			ok = 0;
+			if (getToken(nested, &token, "emphasis class", &lastToken))
+				if (parseChars(nested, &emphClass, &token)) {
+					char *s = malloc(sizeof(char) * (emphClass.length + 1));
+					for (k = 0; k < emphClass.length; k++)
+						s[k] = (char)emphClass.chars[k];
+					s[k++] = '\0';
+					for (i = 0; (*table)->emphClasses[i]; i++)
+						if (strcmp(s, (*table)->emphClasses[i]) == 0) break;
+					if (!(*table)->emphClasses[i]) {
+						_lou_logMessage(
+								LOU_LOG_ERROR, "Emphasis class %s not declared", s);
+						errorCount++;
+						free(s);
+						break;
+					}
+					i++;  // in table->emphRules the first index is used for caps
+					if (opcode == CTO_EmphLetter) {
+						tmp_offset = (*table)->emphRules[i][letterOffset];
+						ok = compileBrailleIndicator(nested, "single letter",
+								CTO_Emph1LetterRule + letterOffset + (8 * i), &tmp_offset,
+								&lastToken, newRuleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][letterOffset] = tmp_offset;
+					} else if (opcode == CTO_BegEmphWord) {
+						tmp_offset = (*table)->emphRules[i][begWordOffset];
+						ok = compileBrailleIndicator(nested, "word",
+								CTO_Emph1LetterRule + begWordOffset + (8 * i),
+								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
+								nofor, table);
+						(*table)->emphRules[i][begWordOffset] = tmp_offset;
+					} else if (opcode == CTO_EndEmphWord) {
+						tmp_offset = (*table)->emphRules[i][endWordOffset];
+						ok = compileBrailleIndicator(nested, "word stop",
+								CTO_Emph1LetterRule + endWordOffset + (8 * i),
+								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
+								nofor, table);
+						(*table)->emphRules[i][endWordOffset] = tmp_offset;
+					} else if (opcode == CTO_BegEmph) {
+						/* fail if both begemph and any of begemphphrase or begemphword
+						 * are defined */
+						if ((*table)->emphRules[i][begWordOffset] ||
+								(*table)->emphRules[i][begPhraseOffset]) {
+							compileError(nested,
+									"Cannot define emphasis for both no context and word "
+									"or "
+									"phrase context, i.e. cannot have both begemph and "
+									"begemphword or begemphphrase.");
+							ok = 0;
+							break;
+						}
+						tmp_offset = (*table)->emphRules[i][begOffset];
+						ok = compileBrailleIndicator(nested, "first letter",
+								CTO_Emph1LetterRule + begOffset + (8 * i), &tmp_offset,
+								&lastToken, newRuleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][begOffset] = tmp_offset;
+					} else if (opcode == CTO_EndEmph) {
+						if ((*table)->emphRules[i][endWordOffset] ||
+								(*table)->emphRules[i][endPhraseBeforeOffset] ||
+								(*table)->emphRules[i][endPhraseAfterOffset]) {
+							compileError(nested,
+									"Cannot define emphasis for both no context and word "
+									"or "
+									"phrase context, i.e. cannot have both endemph and "
+									"endemphword or endemphphrase.");
+							ok = 0;
+							break;
+						}
+						tmp_offset = (*table)->emphRules[i][endOffset];
+						ok = compileBrailleIndicator(nested, "last letter",
+								CTO_Emph1LetterRule + endOffset + (8 * i), &tmp_offset,
+								&lastToken, newRuleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][endOffset] = tmp_offset;
+					} else if (opcode == CTO_BegEmphPhrase) {
+						tmp_offset = (*table)->emphRules[i][begPhraseOffset];
+						ok = compileBrailleIndicator(nested, "first word",
+								CTO_Emph1LetterRule + begPhraseOffset + (8 * i),
+								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
+								nofor, table);
+						(*table)->emphRules[i][begPhraseOffset] = tmp_offset;
+					} else if (opcode == CTO_EndEmphPhrase)
+						switch (compileBeforeAfter(nested, &lastToken)) {
+						case 1:  // before
+							if ((*table)->emphRules[i][endPhraseAfterOffset]) {
+								compileError(nested, "last word after already defined.");
+								ok = 0;
+								break;
+							}
+							tmp_offset = (*table)->emphRules[i][endPhraseBeforeOffset];
+							ok = compileBrailleIndicator(nested, "last word before",
+									CTO_Emph1LetterRule + endPhraseBeforeOffset + (8 * i),
+									&tmp_offset, &lastToken, newRuleOffset, newRule,
+									noback, nofor, table);
+							(*table)->emphRules[i][endPhraseBeforeOffset] = tmp_offset;
+							break;
+						case 2:  // after
+							if ((*table)->emphRules[i][endPhraseBeforeOffset]) {
+								compileError(nested, "last word before already defined.");
+								ok = 0;
+								break;
+							}
+							tmp_offset = (*table)->emphRules[i][endPhraseAfterOffset];
+							ok = compileBrailleIndicator(nested, "last word after",
+									CTO_Emph1LetterRule + endPhraseAfterOffset + (8 * i),
+									&tmp_offset, &lastToken, newRuleOffset, newRule,
+									noback, nofor, table);
+							(*table)->emphRules[i][endPhraseAfterOffset] = tmp_offset;
+							break;
+						default:  // error
+							compileError(nested, "Invalid lastword indicator location.");
+							ok = 0;
+							break;
+						}
+					else if (opcode == CTO_LenEmphPhrase)
+						ok = (*table)->emphRules[i][lenPhraseOffset] =
+								compileNumber(nested, &lastToken);
+					free(s);
+				}
+			break;
+
+		case CTO_LetterSign:
+			tmp_offset = (*table)->letterSign;
+			ok = compileBrailleIndicator(nested, "letter sign", CTO_LetterRule,
+					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
+					table);
+			(*table)->letterSign = tmp_offset;
+			break;
+		case CTO_NoLetsignBefore:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				if (((*table)->noLetsignBeforeCount + ruleChars.length) > LETSIGNSIZE) {
+					compileError(nested, "More than %d characters", LETSIGNSIZE);
+					ok = 0;
+					break;
+				}
+				for (k = 0; k < ruleChars.length; k++)
+					(*table)->noLetsignBefore[(*table)->noLetsignBeforeCount++] =
+							ruleChars.chars[k];
+			}
+			break;
+		case CTO_NoLetsign:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				if (((*table)->noLetsignCount + ruleChars.length) > LETSIGNSIZE) {
+					compileError(nested, "More than %d characters", LETSIGNSIZE);
+					ok = 0;
+					break;
+				}
+				for (k = 0; k < ruleChars.length; k++)
+					(*table)->noLetsign[(*table)->noLetsignCount++] = ruleChars.chars[k];
+			}
+			break;
+		case CTO_NoLetsignAfter:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				if (((*table)->noLetsignAfterCount + ruleChars.length) > LETSIGNSIZE) {
+					compileError(nested, "More than %d characters", LETSIGNSIZE);
+					ok = 0;
+					break;
+				}
+				for (k = 0; k < ruleChars.length; k++)
+					(*table)->noLetsignAfter[(*table)->noLetsignAfterCount++] =
+							ruleChars.chars[k];
+			}
+			break;
+		case CTO_NumberSign:
+			tmp_offset = (*table)->numberSign;
+			ok = compileBrailleIndicator(nested, "number sign", CTO_NumberRule,
+					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
+					table);
+			(*table)->numberSign = tmp_offset;
+			break;
+
+		case CTO_Attribute:
+
+			c = NULL;
+			ok = 1;
+			if (!getToken(nested, &ruleChars, "attribute number", &lastToken)) {
+				compileError(nested, "Expected attribute number.");
+				ok = 0;
+				break;
+			}
+
+			k = -1;
+			switch (ruleChars.chars[0]) {
+			case '0':
+				k = 0;
+				break;
+			case '1':
+				k = 1;
+				break;
+			case '2':
+				k = 2;
+				break;
+			case '3':
+				k = 3;
+				break;
+			case '4':
+				k = 4;
+				break;
+			case '5':
+				k = 5;
+				break;
+			case '6':
+				k = 6;
+				break;
+			case '7':
+				k = 7;
+				break;
+			}
+			if (k == -1) {
+				compileError(nested, "Invalid attribute number.");
+				ok = 0;
+				break;
+			}
+
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (i = 0; i < ruleChars.length; i++) {
+					c = compile_findCharOrDots(ruleChars.chars[i], 0, *table);
+					if (c)
+						c->attributes |= (CTC_UserDefined0 << k);
+					else {
+						compileError(nested, "Attribute character undefined");
+						ok = 0;
+						break;
+					}
+				}
+			}
+			break;
+
+		case CTO_NumericModeChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_NumericMode;
+					else {
+						compileError(nested, "Numeric mode character undefined");
+						ok = 0;
+						break;
+					}
+				}
+				(*table)->usesNumericMode = 1;
+			}
+			break;
+
+		case CTO_MidEndNumericModeChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_MidEndNumericMode;
+					else {
+						compileError(nested, "Midendnumeric mode character undefined");
+						ok = 0;
+						break;
+					}
+				}
+				(*table)->usesNumericMode = 1;
+			}
+			break;
+
+		case CTO_NumericNoContractChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_NumericNoContract;
+					else {
+						compileError(
+								nested, "Numeric no contraction character undefined");
+						ok = 0;
+						break;
+					}
+				}
+				(*table)->usesNumericMode = 1;
+			}
+			break;
+
+		case CTO_NoContractSign:
+
+			tmp_offset = (*table)->noContractSign;
+			ok = compileBrailleIndicator(nested, "no contractions sign",
+					CTO_NoContractRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
+					noback, nofor, table);
+			(*table)->noContractSign = tmp_offset;
+			break;
+
+		case CTO_SeqDelimiter:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_SeqDelimiter;
+					else {
+						compileError(nested, "Sequence delimiter character undefined");
+						ok = 0;
+						break;
+					}
+				}
+				(*table)->usesSequences = 1;
+			}
+			break;
+
+		case CTO_SeqBeforeChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_SeqBefore;
+					else {
+						compileError(nested, "Sequence before character undefined");
+						ok = 0;
+						break;
+					}
+				}
+			}
+			break;
+
+		case CTO_SeqAfterChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_SeqAfter;
+					else {
+						compileError(nested, "Sequence after character undefined");
+						ok = 0;
+						break;
+					}
+				}
+			}
+			break;
+
+		case CTO_SeqAfterPattern:
+
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				if (((*table)->seqPatternsCount + ruleChars.length + 1) >
+						SEQPATTERNSIZE) {
+					compileError(nested, "More than %d characters", SEQPATTERNSIZE);
+					ok = 0;
+					break;
+				}
+				for (k = 0; k < ruleChars.length; k++)
+					(*table)->seqPatterns[(*table)->seqPatternsCount++] =
+							ruleChars.chars[k];
+				(*table)->seqPatterns[(*table)->seqPatternsCount++] = 0;
+			}
+			break;
+		case CTO_SeqAfterExpression:
+
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for ((*table)->seqAfterExpressionLength = 0;
+						(*table)->seqAfterExpressionLength < ruleChars.length;
+						(*table)->seqAfterExpressionLength++)
+					(*table)->seqAfterExpression[(*table)->seqAfterExpressionLength] =
+							ruleChars.chars[(*table)->seqAfterExpressionLength];
+				(*table)->seqAfterExpression[(*table)->seqAfterExpressionLength] = 0;
+			}
+			break;
+
+		case CTO_CapsModeChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_CapsMode;
+					else {
+						compileError(nested, "Capital mode character undefined");
+						ok = 0;
+						break;
+					}
+				}
+			}
+			break;
+
+		case CTO_EmphModeChars:
+
+			c = NULL;
+			ok = 1;
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (c)
+						c->attributes |= CTC_EmphMode;
+					else {
+						compileError(nested, "Emphasis mode character undefined");
+						ok = 0;
+						break;
+					}
+				}
+			}
+			(*table)->usesEmphMode = 1;
+			break;
+
+		case CTO_BegComp:
+			tmp_offset = (*table)->begComp;
+			ok = compileBrailleIndicator(nested, "begin computer braille",
+					CTO_BegCompRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
+					noback, nofor, table);
+			(*table)->begComp = tmp_offset;
+			break;
+		case CTO_EndComp:
+			tmp_offset = (*table)->endComp;
+			ok = compileBrailleIndicator(nested, "end computer braslle", CTO_EndCompRule,
+					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
+					table);
+			(*table)->endComp = tmp_offset;
+			break;
+		case CTO_Syllable:
+			(*table)->syllables = 1;
+		case CTO_Always:
+		case CTO_NoCross:
+		case CTO_LargeSign:
+		case CTO_WholeWord:
+		case CTO_PartWord:
+		case CTO_JoinNum:
+		case CTO_JoinableWord:
+		case CTO_LowWord:
+		case CTO_SuffixableWord:
+		case CTO_PrefixableWord:
+		case CTO_BegWord:
+		case CTO_BegMidWord:
+		case CTO_MidWord:
+		case CTO_MidEndWord:
+		case CTO_EndWord:
+		case CTO_PrePunc:
+		case CTO_PostPunc:
+		case CTO_BegNum:
+		case CTO_MidNum:
+		case CTO_EndNum:
+		case CTO_Repeated:
+		case CTO_RepWord:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken))
+				if (getRuleDotsPattern(nested, &ruleDots, &lastToken)) {
+					if (ruleDots.length == 0)  // `=`
+						for (k = 0; k < ruleChars.length; k++) {
+							c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+							if (!c || !c->definitionRule) {
+								compileError(nested, "Character %s is not defined",
+										_lou_showString(&ruleChars.chars[k], 1));
+								return 0;
+							}
+						}
+					if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
+								newRuleOffset, newRule, noback, nofor, table))
+						ok = 0;
+				}
+			// if (opcode == CTO_MidNum)
+			// {
+			//   TranslationTableCharacter *c = compile_findCharOrDots(ruleChars.chars[0],
+			//   0); if(c)
+			//     c->attributes |= CTC_NumericMode;
+			// }
+			break;
+		case CTO_CompDots:
+		case CTO_Comp6:
+			if (!getRuleCharsText(nested, &ruleChars, &lastToken)) return 0;
+			if (ruleChars.length != 1 || ruleChars.chars[0] > 255) {
+				compileError(nested, "first operand must be 1 character and < 256");
+				return 0;
+			}
+			if (!getRuleDotsPattern(nested, &ruleDots, &lastToken)) return 0;
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
+						newRuleOffset, newRule, noback, nofor, table))
+				ok = 0;
+			(*table)->compdotsPattern[ruleChars.chars[0]] = *newRuleOffset;
+			break;
+		case CTO_ExactDots:
+			if (!getRuleCharsText(nested, &ruleChars, &lastToken)) return 0;
+			if (ruleChars.chars[0] != '@') {
+				compileError(nested, "The operand must begin with an at sign (@)");
+				return 0;
+			}
+			for (k = 1; k < ruleChars.length; k++)
+				scratchPad.chars[k - 1] = ruleChars.chars[k];
+			scratchPad.length = ruleChars.length - 1;
+			if (!parseDots(nested, &ruleDots, &scratchPad)) return 0;
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, before, after,
+						newRuleOffset, newRule, noback, nofor, table))
+				ok = 0;
+			break;
+		case CTO_CapsNoCont:
+			ruleChars.length = 1;
+			ruleChars.chars[0] = 'a';
+			if (!addRule(nested, CTO_CapsNoContRule, &ruleChars, NULL, after, before,
+						newRuleOffset, newRule, noback, nofor, table))
+				ok = 0;
+			(*table)->capsNoCont = *newRuleOffset;
+			break;
+		case CTO_Replace:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				if (lastToken)
+					ruleDots.length = ruleDots.chars[0] = 0;
+				else {
+					getRuleDotsText(nested, &ruleDots, &lastToken);
+					if (ruleDots.chars[0] == '#')
+						ruleDots.length = ruleDots.chars[0] = 0;
+					else if (ruleDots.chars[0] == '\\' && ruleDots.chars[1] == '#')
+						memcpy(&ruleDots.chars[0], &ruleDots.chars[1],
+								ruleDots.length-- * CHARSIZE);
+				}
+			}
+			for (k = 0; k < ruleChars.length; k++)
+				addCharOrDots(nested, ruleChars.chars[k], 0, table);
+			for (k = 0; k < ruleDots.length; k++)
+				addCharOrDots(nested, ruleDots.chars[k], 0, table);
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
+						newRuleOffset, newRule, noback, nofor, table))
+				ok = 0;
+			break;
+		case CTO_Correct:
+			(*table)->corrections = 1;
+			goto doPass;
+		case CTO_Pass2:
+			if ((*table)->numPasses < 2) (*table)->numPasses = 2;
+			goto doPass;
+		case CTO_Pass3:
+			if ((*table)->numPasses < 3) (*table)->numPasses = 3;
+			goto doPass;
+		case CTO_Pass4:
+			if ((*table)->numPasses < 4) (*table)->numPasses = 4;
+		doPass:
+		case CTO_Context:
+			if (!(nofor || noback)) {
+				compileError(nested, "%s or %s must be specified.",
+						_lou_findOpcodeName(CTO_NoFor), _lou_findOpcodeName(CTO_NoBack));
+				ok = 0;
+				break;
+			}
+			if (!compilePassOpcode(nested, opcode, *characterClasses, newRuleOffset,
+						newRule, noback, nofor, *ruleNames, table))
+				ok = 0;
+			break;
+		case CTO_Contraction:
+		case CTO_NoCont:
+		case CTO_CompBrl:
+		case CTO_Literal:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
+				for (k = 0; k < ruleChars.length; k++) {
+					c = compile_findCharOrDots(ruleChars.chars[k], 0, *table);
+					if (!c || !c->definitionRule) {
+						compileError(nested, "Character %s is not defined",
+								_lou_showString(&ruleChars.chars[k], 1));
+						return 0;
+					}
+				}
+				if (!addRule(nested, opcode, &ruleChars, NULL, after, before,
+							newRuleOffset, newRule, noback, nofor, table))
+					ok = 0;
+			}
+			break;
+		case CTO_MultInd: {
+			int t;
+			ruleChars.length = 0;
+			if (getToken(nested, &token, "multiple braille indicators", &lastToken) &&
+					parseDots(nested, &cells, &token)) {
+				while ((t = getToken(nested, &token, "multind opcodes", &lastToken))) {
+					opcode = getOpcode(nested, &token, opcodeLengths);
+					if (opcode >= CTO_CapsLetter && opcode < CTO_MultInd)
+						ruleChars.chars[ruleChars.length++] = (widechar)opcode;
+					else {
+						compileError(nested, "Not a braille indicator opcode.");
+						ok = 0;
+					}
+					if (t == 2) break;
+				}
+			} else
+				ok = 0;
+			if (!addRule(nested, CTO_MultInd, &ruleChars, &cells, after, before,
+						newRuleOffset, newRule, noback, nofor, table))
+				ok = 0;
+			break;
+		}
+
+		case CTO_Class: {
+			CharsString characters;
+			const CharacterClass *class;
+			if (!*characterClasses) {
+				if (!allocateCharacterClasses(characterClasses, characterClassAttribute))
+					ok = 0;
+			}
+			if (getToken(nested, &token, "character class name", &lastToken)) {
+				class = findCharacterClass(&token, *characterClasses);
+				if (!class)
+					// no class with that name: create one
+					class = addCharacterClass(nested, &token.chars[0], token.length,
+							characterClasses, characterClassAttribute);
+				if (class) {
+					// there is a class with that name or a new class was successfully
+					// created
+					if (getCharacters(nested, &characters, &lastToken)) {
+						int index;
+						for (index = 0; index < characters.length; ++index) {
+							TranslationTableRule *defRule;
+							// get the character from the table and add the new class to
+							// its attributes if the character is not defined yet, define
+							// it
+							TranslationTableCharacter *character = addCharOrDots(
+									nested, characters.chars[index], 0, table);
+							character->attributes |= class->attribute;
+							// also add the attribute to the associated dots (if any)
+							if (character->definitionRule) {
+								defRule = (TranslationTableRule *)&(*table)
+												  ->ruleArea[character->definitionRule];
+								if (defRule->dotslen == 1) {
+									character = compile_findCharOrDots(
+											defRule->charsdots[defRule->charslen], 1,
+											*table);
+									if (character)
+										character->attributes |= class->attribute;
+								}
+							}
+						}
+					}
+				}
+			}
+			break;
+		}
+
+			{
+				TranslationTableCharacterAttributes *attributes;
+				const CharacterClass *class;
+			case CTO_After:
+				attributes = &after;
+				goto doClass;
+			case CTO_Before:
+				attributes = &before;
+			doClass:
+
+				if (!*characterClasses) {
+					if (!allocateCharacterClasses(
+								characterClasses, characterClassAttribute))
+						ok = 0;
+				}
+				if (getCharacterClass(nested, &class, *characterClasses, &lastToken)) {
+					*attributes |= class->attribute;
+					goto doOpcode;
+				}
+				break;
+			}
+
+		case CTO_NoBack:
+			if (nofor) {
+				compileError(
+						nested, "%s already specified.", _lou_findOpcodeName(CTO_NoFor));
+				ok = 0;
+				break;
+			}
+			noback = 1;
+			goto doOpcode;
+		case CTO_NoFor:
+			if (noback) {
+				compileError(
+						nested, "%s already specified.", _lou_findOpcodeName(CTO_NoBack));
+				ok = 0;
+				break;
+			}
+			nofor = 1;
+			goto doOpcode;
+
+		case CTO_EmpMatchBefore:
+			before |= CTC_EmpMatch;
+			goto doOpcode;
+		case CTO_EmpMatchAfter:
+			after |= CTC_EmpMatch;
+			goto doOpcode;
+
+		case CTO_SwapCc:
+		case CTO_SwapCd:
+		case CTO_SwapDd:
+			if (!compileSwap(nested, opcode, &lastToken, newRuleOffset, newRule, noback,
+						nofor, ruleNames, table))
+				ok = 0;
+			break;
+		case CTO_Hyphen:
+		case CTO_DecPoint:
+			//	case CTO_Apostrophe:
+			//	case CTO_Initial:
+			if (getRuleCharsText(nested, &ruleChars, &lastToken))
+				if (getRuleDotsPattern(nested, &ruleDots, &lastToken)) {
+					if (ruleChars.length != 1 || ruleDots.length < 1) {
+						compileError(nested,
+								"One Unicode character and at least one cell are "
+								"required.");
+						ok = 0;
+					}
+					if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
+								newRuleOffset, newRule, noback, nofor, table))
+						ok = 0;
+					// if (opcode == CTO_DecPoint)
+					// {
+					//   TranslationTableCharacter *c =
+					//   compile_findCharOrDots(ruleChars.chars[0], 0);
+					//   if(c)
+					//     c->attributes |= CTC_NumericMode;
+					// }
+				}
+			break;
+		default:
+			compileError(nested, "unimplemented opcode.");
+			ok = 0;
+			break;
+		}
 	}
 
 	if (patterns != NULL) free(patterns);
@@ -3675,7 +3787,7 @@ compileString(const char *inString, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
 		short opcodeLengths[], TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, RuleName **ruleNames,
-		TranslationTableHeader **table) {
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	/* This function can be used to make changes to tables on the fly. */
 	int k;
 	FileInfo nested;
@@ -3690,7 +3802,7 @@ compileString(const char *inString, CharacterClass **characterClasses,
 	nested.line[k] = 0;
 	nested.linelen = k;
 	return compileRule(&nested, characterClasses, characterClassAttribute, opcodeLengths,
-			newRuleOffset, newRule, ruleNames, table);
+			newRuleOffset, newRule, ruleNames, table, displayTable);
 }
 
 static int
@@ -3948,7 +4060,7 @@ compileFile(const char *fileName, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
 		short opcodeLengths[], TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, RuleName **ruleNames,
-		TranslationTableHeader **table) {
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	FileInfo nested;
 	fileCount++;
 	nested.fileName = fileName;
@@ -3958,7 +4070,7 @@ compileFile(const char *fileName, CharacterClass **characterClasses,
 	if ((nested.in = fopen(nested.fileName, "rb"))) {
 		while (_lou_getALine(&nested))
 			compileRule(&nested, characterClasses, characterClassAttribute, opcodeLengths,
-					newRuleOffset, newRule, ruleNames, table);
+					newRuleOffset, newRule, ruleNames, table, displayTable);
 		fclose(nested.in);
 		return 1;
 	} else
@@ -3988,7 +4100,7 @@ includeFile(FileInfo *nested, CharsString *includedFile,
 		TranslationTableCharacterAttributes *characterClassAttribute,
 		short opcodeLengths[], TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, RuleName **ruleNames,
-		TranslationTableHeader **table) {
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	int k;
 	char includeThis[MAXSTRING];
 	char **tableFiles;
@@ -4013,7 +4125,7 @@ includeFile(FileInfo *nested, CharsString *includedFile,
 		return 0;
 	}
 	rv = compileFile(*tableFiles, characterClasses, characterClassAttribute,
-			opcodeLengths, newRuleOffset, newRule, ruleNames, table);
+			opcodeLengths, newRuleOffset, newRule, ruleNames, table, displayTable);
 	free_tablefiles(tableFiles);
 	return rv;
 }
@@ -4022,27 +4134,30 @@ includeFile(FileInfo *nested, CharsString *includedFile,
  * Compile source tables into a table in memory
  *
  */
-static TranslationTableHeader *
-compileTranslationTable(const char *tableList, CharacterClass **characterClasses,
+static int
+compileTable(const char *tableList, TranslationTableHeader **translationTable,
+		DisplayTableHeader **displayTable, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
 		short opcodeLengths[], TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, RuleName **ruleNames) {
-	TranslationTableHeader *table = NULL;
+	if (translationTable) *translationTable = NULL;
+	if (displayTable) *displayTable = NULL;
 	char **tableFiles;
 	char **subTable;
 	errorCount = warningCount = fileCount = 0;
 	*characterClasses = NULL;
 	*ruleNames = NULL;
-	if (tableList == NULL) return NULL;
+	if (tableList == NULL) return 0;
 	if (!opcodeLengths[0]) {
 		TranslationTableOpcode opcode;
 		for (opcode = 0; opcode < CTO_None; opcode++)
 			opcodeLengths[opcode] = (short)strlen(opcodeNames[opcode]);
 	}
-	allocateHeader(NULL, &table);
+	if (translationTable) allocateTranslationTable(NULL, translationTable);
+	if (displayTable) allocateDisplayTable(NULL, displayTable);
 
 	/* Initialize emphClasses array */
-	table->emphClasses[0] = NULL;
+	if (translationTable) (*translationTable)->emphClasses[0] = NULL;
 
 	/* Compile things that are necesary for the proper operation of
 	 * liblouis or liblouisxml or liblouisutdml */
@@ -4050,10 +4165,11 @@ compileTranslationTable(const char *tableList, CharacterClass **characterClasses
 	   liblouisutdml. Find a way to satisfy those requirements without hard coding
 	   some characters in every table notably behind the users back */
 	compileString("space \\x001b 1b escape", characterClasses, characterClassAttribute,
-			opcodeLengths, newRuleOffset, newRule, ruleNames, &table);
+			opcodeLengths, newRuleOffset, newRule, ruleNames, translationTable,
+			displayTable);
 	compileString("space \\xffff 123456789abcdef LOU_ENDSEGMENT", characterClasses,
 			characterClassAttribute, opcodeLengths, newRuleOffset, newRule, ruleNames,
-			&table);
+			translationTable, displayTable);
 
 	/* Compile all subtables in the list */
 	if (!(tableFiles = _lou_resolveTable(tableList, NULL))) {
@@ -4062,7 +4178,8 @@ compileTranslationTable(const char *tableList, CharacterClass **characterClasses
 	}
 	for (subTable = tableFiles; *subTable; subTable++)
 		if (!compileFile(*subTable, characterClasses, characterClassAttribute,
-					opcodeLengths, newRuleOffset, newRule, ruleNames, &table))
+					opcodeLengths, newRuleOffset, newRule, ruleNames, translationTable,
+					displayTable))
 			goto cleanup;
 
 /* Clean up after compiling files */
@@ -4072,13 +4189,20 @@ cleanup:
 	if (*ruleNames) deallocateRuleNames(ruleNames);
 	if (warningCount) _lou_logMessage(LOU_LOG_WARN, "%d warnings issued", warningCount);
 	if (!errorCount) {
-		setDefaults(table);
+		if (translationTable) setDefaults(*translationTable);
+		return 1;
 	} else {
 		_lou_logMessage(LOU_LOG_ERROR, "%d errors found.", errorCount);
-		if (table) free(table);
-		table = NULL;
+		if (translationTable) {
+			if (*translationTable) free(*translationTable);
+			*translationTable = NULL;
+		}
+		if (displayTable) {
+			if (*displayTable) free(*displayTable);
+			*displayTable = NULL;
+		}
+		return 0;
 	}
-	return table;
 }
 
 /* Return the emphasis classes declared in tableList. */
@@ -4112,44 +4236,91 @@ void *EXPORT_CALL
 lou_getTable(const char *tableList) {
 	/* Keep track of which tables have already been compiled */
 	int tableListLen;
-	ChainEntry *currentEntry = NULL;
-	ChainEntry *prevEntry = NULL;
-	TranslationTableHeader *newTable;
+	TranslationTableHeader *translationTable = NULL;
+	DisplayTableHeader *displayTable = NULL;
 	if (tableList == NULL || *tableList == 0) return NULL;
 	errorCount = fileCount = 0;
 	tableListLen = (int)strlen(tableList);
 	/* See if Table has already been compiled */
-	currentEntry = tableChain;
-	while (currentEntry != NULL) {
-		if (tableListLen == currentEntry->tableListLength &&
-				(memcmp(&currentEntry->tableList[0], tableList, tableListLen)) == 0) {
-			/* Move the table to the top of the table chain. */
-			if (prevEntry != NULL) {
-				prevEntry->next = currentEntry->next;
-				currentEntry->next = tableChain;
-				tableChain = currentEntry;
+	{
+		TranslationTableChainEntry *currentEntry = translationTableChain;
+		TranslationTableChainEntry *prevEntry = NULL;
+		while (currentEntry != NULL) {
+			if (tableListLen == currentEntry->tableListLength &&
+					(memcmp(&currentEntry->tableList[0], tableList, tableListLen)) == 0) {
+				/* Move the table to the top of the table chain. */
+				if (prevEntry != NULL) {
+					prevEntry->next = currentEntry->next;
+					currentEntry->next = translationTableChain;
+					translationTableChain = currentEntry;
+				}
+				translationTable = currentEntry->table;
+				break;
 			}
-			return (gTable = currentEntry->table);
+			prevEntry = currentEntry;
+			currentEntry = currentEntry->next;
 		}
-		prevEntry = currentEntry;
-		currentEntry = currentEntry->next;
 	}
-	if ((newTable = compileTranslationTable(tableList, &gCharacterClasses,
-				 &gCharacterClassAttribute, gOpcodeLengths, &gNewRuleOffset, &gNewRule,
-				 &gRuleNames))) {
-		/* Add a new entry to the top of the table chain. */
-		int entrySize = sizeof(ChainEntry) + tableListLen;
-		ChainEntry *newEntry = malloc(entrySize);
-		if (!newEntry) _lou_outOfMemory();
-		newEntry->next = tableChain;
-		newEntry->table = newTable;
-		newEntry->tableListLength = tableListLen;
-		memcpy(&newEntry->tableList[0], tableList, tableListLen);
-		tableChain = newEntry;
-		return (gTable = newEntry->table);
+	{
+		DisplayTableChainEntry *currentEntry = displayTableChain;
+		DisplayTableChainEntry *prevEntry = NULL;
+		while (currentEntry != NULL) {
+			if (tableListLen == currentEntry->tableListLength &&
+					(memcmp(&currentEntry->tableList[0], tableList, tableListLen)) == 0) {
+				/* Move the table to the top of the table chain. */
+				if (prevEntry != NULL) {
+					prevEntry->next = currentEntry->next;
+					currentEntry->next = displayTableChain;
+					displayTableChain = currentEntry;
+				}
+				displayTable = currentEntry->table;
+				break;
+			}
+			prevEntry = currentEntry;
+			currentEntry = currentEntry->next;
+		}
 	}
-	_lou_logMessage(LOU_LOG_ERROR, "%s could not be compiled", tableList);
-	return NULL;
+	if (translationTable == NULL || displayTable == NULL) {
+		TranslationTableHeader **newTranslationTable = NULL;
+		DisplayTableHeader **newDisplayTable = NULL;
+		if (translationTable == NULL) newTranslationTable = &translationTable;
+		if (displayTable == NULL) newDisplayTable = &displayTable;
+		if (compileTable(tableList, newTranslationTable, newDisplayTable,
+					&gCharacterClasses, &gCharacterClassAttribute, gOpcodeLengths,
+					&gNewRuleOffset, &gNewRule, &gRuleNames)) {
+			/* Add a new entry to the top of the table chain. */
+			if (newTranslationTable != NULL) {
+				int entrySize = sizeof(TranslationTableChainEntry) + tableListLen;
+				TranslationTableChainEntry *newEntry = malloc(entrySize);
+				if (!newEntry) _lou_outOfMemory();
+				newEntry->next = translationTableChain;
+				newEntry->table = *newTranslationTable;
+				newEntry->tableListLength = tableListLen;
+				memcpy(&newEntry->tableList[0], tableList, tableListLen);
+				translationTableChain = newEntry;
+			}
+			if (newDisplayTable != NULL) {
+				int entrySize = sizeof(DisplayTableChainEntry) + tableListLen;
+				DisplayTableChainEntry *newEntry = malloc(entrySize);
+				if (!newEntry) _lou_outOfMemory();
+				newEntry->next = displayTableChain;
+				newEntry->table = *newDisplayTable;
+				newEntry->tableListLength = tableListLen;
+				memcpy(&newEntry->tableList[0], tableList, tableListLen);
+				displayTableChain = newEntry;
+			}
+		} else {
+			_lou_logMessage(LOU_LOG_ERROR, "%s could not be compiled", tableList);
+			return NULL;
+		}
+	}
+	currentDisplayTable = displayTable;
+	return translationTable;
+}
+
+DisplayTableHeader *EXPORT_CALL
+_lou_getCurrentDisplayTable() {
+	return currentDisplayTable;
 }
 
 int EXPORT_CALL
@@ -4280,11 +4451,11 @@ _lou_allocMem(AllocBuf buffer, int index, int srcmax, int destmax) {
 
 void EXPORT_CALL
 lou_free(void) {
-	ChainEntry *currentEntry;
-	ChainEntry *previousEntry;
+	TranslationTableChainEntry *currentEntry;
+	TranslationTableChainEntry *previousEntry;
 	lou_logEnd();
-	if (tableChain != NULL) {
-		currentEntry = tableChain;
+	if (translationTableChain != NULL) {
+		currentEntry = translationTableChain;
 		while (currentEntry) {
 			int i;
 			TranslationTableHeader *t = (TranslationTableHeader *)currentEntry->table;
@@ -4294,7 +4465,7 @@ lou_free(void) {
 			currentEntry = currentEntry->next;
 			free(previousEntry);
 		}
-		tableChain = NULL;
+		translationTableChain = NULL;
 	}
 	if (typebuf != NULL) free(typebuf);
 	typebuf = NULL;
@@ -4343,8 +4514,8 @@ lou_compileString(const char *tableList, const char *inString) {
 	TranslationTableHeader *table = lou_getTable(tableList);
 	if (!table) return 0;
 	r = compileString(inString, &gCharacterClasses, &gCharacterClassAttribute,
-			gOpcodeLengths, &gNewRuleOffset, &gNewRule, &gRuleNames, &table);
-	gTable = table;
+			gOpcodeLengths, &gNewRuleOffset, &gNewRule, &gRuleNames, &table,
+			&currentDisplayTable);
 	return r;
 }
 

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4081,7 +4081,6 @@ cleanup:
 	return table;
 }
 
-static ChainEntry *lastTrans = NULL;
 /* Return the emphasis classes declared in tableList. */
 char const **EXPORT_CALL
 lou_getEmphClasses(const char *tableList) {
@@ -4114,43 +4113,39 @@ lou_getTable(const char *tableList) {
 	/* Keep track of which tables have already been compiled */
 	int tableListLen;
 	ChainEntry *currentEntry = NULL;
-	ChainEntry *lastEntry = NULL;
+	ChainEntry *prevEntry = NULL;
 	TranslationTableHeader *newTable;
 	if (tableList == NULL || *tableList == 0) return NULL;
 	errorCount = fileCount = 0;
 	tableListLen = (int)strlen(tableList);
-	/* See if this is the last table used. */
-	if (lastTrans != NULL)
-		if (tableListLen == lastTrans->tableListLength &&
-				(memcmp(&lastTrans->tableList[0], tableList, tableListLen)) == 0)
-			return (gTable = lastTrans->table);
 	/* See if Table has already been compiled */
 	currentEntry = tableChain;
 	while (currentEntry != NULL) {
 		if (tableListLen == currentEntry->tableListLength &&
 				(memcmp(&currentEntry->tableList[0], tableList, tableListLen)) == 0) {
-			lastTrans = currentEntry;
+			/* Move the table to the top of the table chain. */
+			if (prevEntry != NULL) {
+				prevEntry->next = currentEntry->next;
+				currentEntry->next = tableChain;
+				tableChain = currentEntry;
+			}
 			return (gTable = currentEntry->table);
 		}
-		lastEntry = currentEntry;
+		prevEntry = currentEntry;
 		currentEntry = currentEntry->next;
 	}
 	if ((newTable = compileTranslationTable(tableList, &gCharacterClasses,
 				 &gCharacterClassAttribute, gOpcodeLengths, &gNewRuleOffset, &gNewRule,
 				 &gRuleNames))) {
-		/* Add a new entry to the table chain. */
+		/* Add a new entry to the top of the table chain. */
 		int entrySize = sizeof(ChainEntry) + tableListLen;
 		ChainEntry *newEntry = malloc(entrySize);
 		if (!newEntry) _lou_outOfMemory();
-		if (tableChain == NULL)
-			tableChain = newEntry;
-		else
-			lastEntry->next = newEntry;
-		newEntry->next = NULL;
+		newEntry->next = tableChain;
 		newEntry->table = newTable;
 		newEntry->tableListLength = tableListLen;
 		memcpy(&newEntry->tableList[0], tableList, tableListLen);
-		lastTrans = newEntry;
+		tableChain = newEntry;
 		return (gTable = newEntry->table);
 	}
 	_lou_logMessage(LOU_LOG_ERROR, "%s could not be compiled", tableList);
@@ -4300,7 +4295,6 @@ lou_free(void) {
 			free(previousEntry);
 		}
 		tableChain = NULL;
-		lastTrans = NULL;
 	}
 	if (typebuf != NULL) free(typebuf);
 	typebuf = NULL;

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -487,6 +487,14 @@ typedef struct /* one state */
 	widechar numTrans;
 } HyphenationState;
 
+typedef struct {
+	TranslationTableOffset tableSize;
+	TranslationTableOffset bytesUsed;
+	TranslationTableOffset charToDots[HASHNUM];
+	TranslationTableOffset dotsToChar[HASHNUM];
+	TranslationTableOffset ruleArea[1]; /** Space for storing all rules and values */
+} DisplayTableHeader;
+
 /**
  * Translation table header
  */
@@ -533,8 +541,6 @@ typedef struct { /* translation table */
 	int noLetsignAfterCount;
 	TranslationTableOffset characters[HASHNUM]; /** Character definitions */
 	TranslationTableOffset dots[HASHNUM];		/** Dot definitions */
-	TranslationTableOffset charToDots[HASHNUM];
-	TranslationTableOffset dotsToChar[HASHNUM];
 	TranslationTableOffset compdotsPattern[256];
 	TranslationTableOffset swapDefinitions[NUMSWAPS];
 	TranslationTableOffset forPassRules[MAXPASS + 1];
@@ -646,6 +652,9 @@ _lou_getDotsForChar(widechar c);
  */
 widechar EXPORT_CALL
 _lou_getCharFromDots(widechar d);
+
+DisplayTableHeader *EXPORT_CALL
+_lou_getCurrentDisplayTable();
 
 /**
  * Allocate memory for internal buffers

--- a/tools/lou_debug.c
+++ b/tools/lou_debug.c
@@ -76,6 +76,7 @@ more.\n\n",
 #define BUFSIZE 256
 
 static const TranslationTableHeader *table;
+static const DisplayTableHeader *displayTable;
 static char inputBuffer[BUFSIZE];
 
 static int
@@ -362,11 +363,11 @@ show_charMap(int startHash) {
 	else
 		k = startHash;
 	for (; k < HASHNUM; k++)
-		if (table->charToDots[k]) {
+		if (displayTable->charToDots[k]) {
 			printf("Hash=%d\n", k);
-			nextChar = table->charToDots[k];
+			nextChar = displayTable->charToDots[k];
 			while (nextChar) {
-				thisChar = (CharOrDots *)&table->ruleArea[nextChar];
+				thisChar = (CharOrDots *)&displayTable->ruleArea[nextChar];
 				printf("Char: %s ", print_chars(&thisChar->lookFor, 1));
 				printf("dots=%s\n", _lou_showDots(&thisChar->found, 1));
 				printf("=> ");
@@ -390,11 +391,11 @@ show_dotsMap(int startHash) {
 	else
 		k = startHash;
 	for (; k < HASHNUM; k++)
-		if (table->dotsToChar[k]) {
+		if (displayTable->dotsToChar[k]) {
 			printf("Hash=%d\n", k);
-			nextDots = table->dotsToChar[k];
+			nextDots = displayTable->dotsToChar[k];
 			while (nextDots) {
-				thisDots = (CharOrDots *)&table->ruleArea[nextDots];
+				thisDots = (CharOrDots *)&displayTable->ruleArea[nextDots];
 				printf("Dots: %s ", _lou_showDots(&thisDots->lookFor, 1));
 				printf("char=%s\n", print_chars(&thisDots->found, 1));
 				printf("=> ");
@@ -483,7 +484,7 @@ particular(void) {
 			getInput();
 			if (!_lou_extParseChars(inputBuffer, parsed)) break;
 			startHash = _lou_charHash(*parsed);
-			if (table->charToDots[startHash] == 0) {
+			if (displayTable->charToDots[startHash] == 0) {
 				printf("Character not in table.\n");
 				break;
 			}
@@ -494,7 +495,7 @@ particular(void) {
 			getInput();
 			if (!_lou_extParseDots(inputBuffer, parsed)) break;
 			startHash = _lou_charHash(*parsed);
-			if (table->dotsToChar[startHash] == 0) {
+			if (displayTable->dotsToChar[startHash] == 0) {
 				printf("Dot pattern not in table.\n");
 				break;
 			}
@@ -647,6 +648,7 @@ main(int argc, char **argv) {
 		lou_free();
 		exit(EXIT_FAILURE);
 	}
+	displayTable = _lou_getCurrentDisplayTable();
 	getCommands();
 	lou_free();
 	exit(EXIT_SUCCESS);


### PR DESCRIPTION
It is still possible to use a translation table as a display table, and the API is not changed yet.

The next steps are
- to add a separate argument for the display table to the API
- to add new options for the display table to the tools
- to use the new API to implement `display: ...` in the "lou_checkyaml" tool
- to add deprecation warnings when a display table contains rules other than `display`
- to make it possible to specify a display table that is not really a table but implemented in C (notably for Unicode braille, and possibly the dotsIO mode can be replaced with a special display table)
- to add more options for controlling the displaying, like e.g. ignoring virtual dots (see https://github.com/liblouis/liblouis/issues/750)