### PR TITLE
Add a display table to match Word CX

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,8 @@ issues]].
   Γεωργακαράκου (Maria Georgakarakou).
 - Improvements and fixes to Spanish contracted braille. Details in
   #741. Thanks to Juan Pablo Bello.
+- Add a display table to match Word CX which is used in Norway and
+  Sweden, and maybe also in other countries thanks to Lars Bjørndal.
 
 ** Other changes
 - Metadata keys and values are now case insensitive, thanks to Dave

--- a/tables/wordcx.dis
+++ b/tables/wordcx.dis
@@ -1,0 +1,90 @@
+#
+# Useful for convertion from or to the charset used to simulate
+# braille patterns on screen in Word CX / CX for Word. The table is 6
+# dot only. The character mapping is derived from the publication
+# Håndtok i punktskrift, Offentlig utvalg for punktskrift.
+#
+# Copyright (C) 2019 Lars Bjørndal <lars@lamasti.net>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+# display \X0020 0		# 032 space
+display \X0021 5 		# 033 exclamation mark
+display \X0022 4 		# 034 quotation mark
+display \X0023 3456 		# 035 number sign
+display \X0024 46 		# 036 dollar sign
+display \X0025 123456 		# 037 percent sign
+display \X0026 12346 		# 038 ampersand
+display \X0027 6 		# 039 apostrophe
+display \X0028 236 		# 040 left parenthesis
+display \X0029 356 		# 041 right parenthesis
+display \X002A 35 		# 042 asterisk
+display \X002B 235 		# 043 plus sign
+display \X002C 2 		# 044 comma
+display \X002D 36 		# 045 hyphen-minus
+display \X002E 3 		# 046 full stop
+display \X002F 256 		# 047 solidus
+display \X0030 346 		# 048 digit zero
+display \X0031 16 		# 049 digit one
+display \X0032 126 		# 050 digit two
+display \X0033 146 		# 051 digit three
+display \X0034 1456 		# 052 digit four
+display \X0035 156 		# 053 digit five
+display \X0036 1246 		# 054 digit six
+display \X0037 12456 		# 055 digit seven
+display \X0038 1256 		# 056 digit eight
+display \X0039 246 		# 057 digit nine
+display \X003A 25 		# 058 colon
+display \X003B 23 		# 059 semicolon
+display \X003C 56 		# 060 less-than sign
+display \X003D 2356 		# 061 equals sign
+display \X003E 45 		# 062 greater-than sign
+display \X003F 26 		# 063 question mark
+display \X0040 345 		# 064 commercial at
+
+
+display \X005B 12356 		# 091 left square bracket
+display \X005C 34 		# 092 reverse solidus
+display \X005D 23456 		# 093 right square bracket
+display \X005E 2346 		# 094 circumflex accent
+display \X005F 456 		# 095 low line
+display \X0061 1 		# 097 latin small letter a
+display \X0062 12 		# 098 latin small letter b
+display \X0063 14 		# 099 latin small letter c
+display \X0064 145 		# 100 latin small letter d
+display \X0065 15 		# 101 latin small letter e
+display \X0066 124 		# 102 latin small letter f
+display \X0067 1245 		# 103 latin small letter g
+display \X0068 125 		# 104 latin small letter h
+display \X0069 24 		# 105 latin small letter i
+display \X006A 245 		# 106 latin small letter j
+display \X006B 13 		# 107 latin small letter k
+display \X006C 123 		# 108 latin small letter l
+display \X006D 134 		# 109 latin small letter m
+display \X006E 1345 		# 110 latin small letter n
+display \X006F 135 		# 111 latin small letter o
+display \X0070 1234 		# 112 latin small letter p
+display \X0071 12345 		# 113 latin small letter q
+display \X0072 1235 		# 114 latin small letter r
+display \X0073 234 		# 115 latin small letter s
+display \X0074 2345 		# 116 latin small letter t
+display \X0075 136 		# 117 latin small letter u
+display \X0076 1236 		# 118 latin small letter v
+display \X0077 2456 		# 119 latin small letter w
+display \X0078 1346 		# 120 latin small letter x
+display \X0079 13456 		# 121 latin small letter y
+display \X007A 1356 		# 122 latin small letter z


### PR DESCRIPTION
It's a display table that matches chars used by Word CX to display
braille patterns on screen. I know for sure that Word CX is used in
Norway and Sweden, and maybe also in other countries. I'm quite sure
that the char mapping is the same in the two countries, and because of
that, I named the table wordcx.dis, not no-no-wordcx.dis.