### PR TITLE
tables/nl-chardefs.uti: Bullet and dot operators fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -170,6 +170,7 @@ TABLE AND TEST CONTRIBUTORS
   Nicolas Pitre <nico@cam.org>
   Nicolai Svendsen <chojiro1990@gmail.com>
   Patrick Zajda
+  Paul Rambags <paulrambags@dedicon.nl>
   Paul Wood <paulw.torchtrust@gmail.com>
   Peter Engström <peter.engstrom@indexbraille.com> from Index Braille
   Peter Vágner <pvdeejay@gmail.com>

--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,8 @@ issues]].
   Sweden, and maybe also in other countries thanks to Lars Bjørndal.
 - Fix handling of colon within number in Dutch braille, thanks to Jake
   Kyle.
+- Fix translation of bullet and dot operators in Dutch braille, thanks
+  to Paul Rambags
 - Added North American Braille Computer Code table (en-nabcc.utb)
   which is the counterpart of the text_nabcc.dis display table. Thanks
   to Dave Mielke.

--- a/tables/nl-chardefs.uti
+++ b/tables/nl-chardefs.uti
@@ -2,7 +2,7 @@
 #  Copyright (C) 2010, 2011 by DocArch <http://www.docarch.be>
 #  Copyright (C) 2014, 2019 by Bert Frees
 #  Copyright (C) 2014 by CBB <http://www.cbb.nl>
-#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
+#  Copyright (C) 2015, 2016, 2018-2019 by Dedicon <http://www.dedicon.nl>
 #
 #  This file is part of liblouis.
 #

--- a/tables/nl-chardefs.uti
+++ b/tables/nl-chardefs.uti
@@ -27,6 +27,7 @@
 #     Created by Bert Frees <bertfrees@gmail.com>
 #     Modified by Henri Apperloo <h.apperloo@cbb.nl>
 #     Modified by Davy Kager <DavyKager@dedicon.nl>
+#     Modified by Paul Rambags <paulrambags@dedicon.nl>
 #
 #     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
 #                Van toepassing vanaf 19 april 2018 »
@@ -256,7 +257,8 @@ math        \x2212        36                  −                   MINUS SIGN
 math        \x2215        34                  ∕                   DIVISION SLASH
 math        \x2216        5-16                ∖                   SET MINUS
 math        \x2217        35                  ∗                   ASTERISK OPERATOR
-math        \x2219        5-256               ∙                   BULLET OPERATOR
+math        \x2219        236                 ∙                   BULLET OPERATOR
+math        \x22C5        236                 ⋅                   DOT OPERATOR
 
 
 # ----------------------------------------------------------------------------------------------

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -4,7 +4,7 @@
 #
 # Copyright © 2010-2011 by DocArch <http://www.docarch.be>
 # Copyright © 2014-2015, 2019 by Bert Frees
-# Copyright © 2015-2016, 2018 by Dedicon <http://www.dedicon.nl>
+# Copyright © 2015-2016, 2018-2019 by Dedicon <http://www.dedicon.nl>
 # Copyright © 2019 by Transkript <http://www.transkript.be>
 #
 # Copying and distribution of this file, with or without modification,
@@ -120,6 +120,8 @@ tests:
   - [3 x 3 = 9, ⠼⠉ ⠭ ⠼⠉ ⠶ ⠼⠊]
   - [3 * 3 = 9, ⠼⠉ ⠔ ⠼⠉ ⠶ ⠼⠊]
   - [3 · 3 = 9, ⠼⠉ ⠦ ⠼⠉ ⠶ ⠼⠊]
+  - [3 ∙ 3 = 9, ⠼⠉ ⠦ ⠼⠉ ⠶ ⠼⠊]
+  - [3 ⋅ 3 = 9, ⠼⠉ ⠦ ⠼⠉ ⠶ ⠼⠊]
   - [3 × 3 = 9, ⠼⠉ ⠦ ⠼⠉ ⠶ ⠼⠊]
   - ['8 : 4 = 2', ⠼⠓ ⠒ ⠼⠙ ⠶ ⠼⠃]
   - [8 / 4 = 2, ⠼⠓ ⠌ ⠼⠙ ⠶ ⠼⠃]


### PR DESCRIPTION
The bullet and dot operators in the Dutch chardefs must be converted to (236).