### PR TITLE
Further separate display from translation

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -640,9 +640,6 @@ putCharAndDots(FileInfo *nested, widechar c, widechar d, DisplayTableHeader **ta
 	return 1;
 }
 
-static TranslationTableOffset gNewRuleOffset = 0;
-static TranslationTableRule *gNewRule = NULL;
-
 static inline const char *
 getPartName(int actionPart) {
 	return actionPart ? "action" : "test";
@@ -740,7 +737,7 @@ NOT_FOUND:
 /* The following functions are called by addRule to handle various cases. */
 
 static void
-addForwardRuleWithSingleChar(FileInfo *nested, TranslationTableOffset *newRuleOffset,
+addForwardRuleWithSingleChar(FileInfo *nested, TranslationTableOffset newRuleOffset,
 		TranslationTableRule *newRule, TranslationTableHeader **table) {
 	/* direction = 0, newRule->charslen = 1 */
 	TranslationTableRule *currentRule;
@@ -762,7 +759,7 @@ addForwardRuleWithSingleChar(FileInfo *nested, TranslationTableOffset *newRuleOf
 	// (possibly overwriting previous definition rules)
 	// adding the attributes to the character has already been done elsewhere
 	if (newRule->opcode >= CTO_Space && newRule->opcode < CTO_UpLow)
-		character->definitionRule = *newRuleOffset;
+		character->definitionRule = newRuleOffset;
 	// add the new rule to the list of rules associated with this character
 	// if the new rule is a character definition rule, it is inserted at the end of the
 	// list
@@ -776,11 +773,11 @@ addForwardRuleWithSingleChar(FileInfo *nested, TranslationTableOffset *newRuleOf
 		currentOffsetPtr = &currentRule->charsnext;
 	}
 	newRule->charsnext = *currentOffsetPtr;
-	*currentOffsetPtr = *newRuleOffset;
+	*currentOffsetPtr = newRuleOffset;
 }
 
 static void
-addForwardRuleWithMultipleChars(TranslationTableOffset *newRuleOffset,
+addForwardRuleWithMultipleChars(TranslationTableOffset newRuleOffset,
 		TranslationTableRule *newRule, TranslationTableHeader *table) {
 	/* direction = 0 newRule->charslen > 1 */
 	TranslationTableRule *currentRule = NULL;
@@ -795,12 +792,12 @@ addForwardRuleWithMultipleChars(TranslationTableOffset *newRuleOffset,
 		currentOffsetPtr = &currentRule->charsnext;
 	}
 	newRule->charsnext = *currentOffsetPtr;
-	*currentOffsetPtr = *newRuleOffset;
+	*currentOffsetPtr = newRuleOffset;
 }
 
 static void
 addBackwardRuleWithSingleCell(FileInfo *nested, widechar cell,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule *newRule,
+		TranslationTableOffset newRuleOffset, TranslationTableRule *newRule,
 		TranslationTableHeader **table) {
 	/* direction = 1, newRule->dotslen = 1 */
 	TranslationTableRule *currentRule;
@@ -812,7 +809,7 @@ addBackwardRuleWithSingleCell(FileInfo *nested, widechar cell,
 	// adding attributes)
 	dots = addCharOrDots(nested, cell, 1, table);
 	if (newRule->opcode >= CTO_Space && newRule->opcode < CTO_UpLow)
-		dots->definitionRule = *newRuleOffset;
+		dots->definitionRule = newRuleOffset;
 	currentOffsetPtr = &dots->otherRules;
 	while (*currentOffsetPtr) {
 		currentRule = (TranslationTableRule *)&(*table)->ruleArea[*currentOffsetPtr];
@@ -822,12 +819,12 @@ addBackwardRuleWithSingleCell(FileInfo *nested, widechar cell,
 		currentOffsetPtr = &currentRule->dotsnext;
 	}
 	newRule->dotsnext = *currentOffsetPtr;
-	*currentOffsetPtr = *newRuleOffset;
+	*currentOffsetPtr = newRuleOffset;
 }
 
 static void
 addBackwardRuleWithMultipleCells(widechar *cells, int count,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule *newRule,
+		TranslationTableOffset newRuleOffset, TranslationTableRule *newRule,
 		TranslationTableHeader *table) {
 	/* direction = 1, newRule->dotslen > 1 */
 	TranslationTableRule *currentRule = NULL;
@@ -847,11 +844,11 @@ addBackwardRuleWithMultipleCells(widechar *cells, int count,
 		currentOffsetPtr = &currentRule->dotsnext;
 	}
 	newRule->dotsnext = *currentOffsetPtr;
-	*currentOffsetPtr = *newRuleOffset;
+	*currentOffsetPtr = newRuleOffset;
 }
 
 static int
-addForwardPassRule(TranslationTableOffset *newRuleOffset, TranslationTableRule *newRule,
+addForwardPassRule(TranslationTableOffset newRuleOffset, TranslationTableRule *newRule,
 		TranslationTableHeader *table) {
 	TranslationTableOffset *currentOffsetPtr;
 	TranslationTableRule *currentRule;
@@ -880,12 +877,12 @@ addForwardPassRule(TranslationTableOffset *newRuleOffset, TranslationTableRule *
 		currentOffsetPtr = &currentRule->charsnext;
 	}
 	newRule->charsnext = *currentOffsetPtr;
-	*currentOffsetPtr = *newRuleOffset;
+	*currentOffsetPtr = newRuleOffset;
 	return 1;
 }
 
 static int
-addBackwardPassRule(TranslationTableOffset *newRuleOffset, TranslationTableRule *newRule,
+addBackwardPassRule(TranslationTableOffset newRuleOffset, TranslationTableRule *newRule,
 		TranslationTableHeader *table) {
 	TranslationTableOffset *currentOffsetPtr;
 	TranslationTableRule *currentRule;
@@ -914,7 +911,7 @@ addBackwardPassRule(TranslationTableOffset *newRuleOffset, TranslationTableRule 
 		currentOffsetPtr = &currentRule->dotsnext;
 	}
 	newRule->dotsnext = *currentOffsetPtr;
-	*currentOffsetPtr = *newRuleOffset;
+	*currentOffsetPtr = newRuleOffset;
 	return 1;
 }
 
@@ -926,14 +923,14 @@ addRule(FileInfo *nested, TranslationTableOpcode opcode, CharsString *ruleChars,
 		TranslationTableHeader **table) {
 	/* Add a rule to the table, using the hash function to find the start of
 	 * chains and chaining both the chars and dots strings */
+	TranslationTableOffset ruleOffset;
 	int ruleSize = sizeof(TranslationTableRule) - (DEFAULTRULESIZE * CHARSIZE);
 	if (ruleChars) ruleSize += CHARSIZE * ruleChars->length;
 	if (ruleDots) ruleSize += CHARSIZE * ruleDots->length;
-	if (!allocateSpaceInTranslationTable(nested, newRuleOffset, ruleSize, table))
-		return 0;
-	TranslationTableRule *rule =
-			(TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
-	*newRule = rule;
+	if (!allocateSpaceInTranslationTable(nested, &ruleOffset, ruleSize, table)) return 0;
+	TranslationTableRule *rule = (TranslationTableRule *)&(*table)->ruleArea[ruleOffset];
+	if (newRule) *newRule = rule;
+	if (newRuleOffset) *newRuleOffset = ruleOffset;
 	rule->opcode = opcode;
 	rule->after = after;
 	rule->before = before;
@@ -953,16 +950,16 @@ addRule(FileInfo *nested, TranslationTableOpcode opcode, CharsString *ruleChars,
 	if (opcode >= CTO_Context && opcode <= CTO_Pass4)
 		if (!(opcode == CTO_Context && rule->charslen > 0)) {
 			if (!nofor)
-				if (!addForwardPassRule(newRuleOffset, rule, *table)) return 0;
+				if (!addForwardPassRule(ruleOffset, rule, *table)) return 0;
 			if (!noback)
-				if (!addBackwardPassRule(newRuleOffset, rule, *table)) return 0;
+				if (!addBackwardPassRule(ruleOffset, rule, *table)) return 0;
 			return 1;
 		}
 	if (!nofor) {
 		if (rule->charslen == 1)
-			addForwardRuleWithSingleChar(nested, newRuleOffset, rule, table);
+			addForwardRuleWithSingleChar(nested, ruleOffset, rule, table);
 		else if (rule->charslen > 1)
-			addForwardRuleWithMultipleChars(newRuleOffset, rule, *table);
+			addForwardRuleWithMultipleChars(ruleOffset, rule, *table);
 	}
 	if (!noback) {
 		widechar *cells;
@@ -977,9 +974,9 @@ addRule(FileInfo *nested, TranslationTableOpcode opcode, CharsString *ruleChars,
 		}
 
 		if (count == 1)
-			addBackwardRuleWithSingleCell(nested, *cells, newRuleOffset, rule, table);
+			addBackwardRuleWithSingleCell(nested, *cells, ruleOffset, rule, table);
 		else if (count > 1)
-			addBackwardRuleWithMultipleCells(cells, count, newRuleOffset, rule, *table);
+			addBackwardRuleWithMultipleCells(cells, count, ruleOffset, rule, *table);
 	}
 	return 1;
 }
@@ -1452,7 +1449,6 @@ static int
 includeFile(FileInfo *nested, CharsString *includedFile,
 		CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule,
 		RuleName **ruleNames, TranslationTableHeader **table,
 		DisplayTableHeader **displayTable);
 
@@ -1471,7 +1467,7 @@ findRuleName(const CharsString *name, RuleName *ruleNames) {
 }
 
 static int
-addRuleName(FileInfo *nested, CharsString *name, TranslationTableOffset *newRuleOffset,
+addRuleName(FileInfo *nested, CharsString *name, TranslationTableOffset newRuleOffset,
 		RuleName **ruleNames) {
 	int k;
 	struct RuleName *nameRule;
@@ -1491,7 +1487,7 @@ addRuleName(FileInfo *nested, CharsString *name, TranslationTableOffset *newRule
 		}
 	}
 	nameRule->length = name->length;
-	nameRule->ruleOffset = *newRuleOffset;
+	nameRule->ruleOffset = newRuleOffset;
 	nameRule->next = *ruleNames;
 	*ruleNames = nameRule;
 	return 1;
@@ -1538,6 +1534,7 @@ compileSwap(FileInfo *nested, TranslationTableOpcode opcode, int *lastToken,
 	CharsString name;
 	CharsString matches;
 	CharsString replacements;
+	TranslationTableOffset ruleOffset;
 	if (!getToken(nested, &name, "name operand", lastToken)) return 0;
 	if (!getToken(nested, &matches, "matches operand", lastToken)) return 0;
 	if (!getToken(nested, &replacements, "replacements operand", lastToken)) return 0;
@@ -1551,10 +1548,11 @@ compileSwap(FileInfo *nested, TranslationTableOpcode opcode, int *lastToken,
 	} else {
 		if (!compileSwapDots(nested, &replacements, &ruleDots)) return 0;
 	}
-	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
+	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, &ruleOffset, newRule,
 				noback, nofor, table))
 		return 0;
-	if (!addRuleName(nested, &name, newRuleOffset, ruleNames)) return 0;
+	if (!addRuleName(nested, &name, ruleOffset, ruleNames)) return 0;
+	if (newRuleOffset) *newRuleOffset = ruleOffset;
 	return 1;
 }
 
@@ -2094,7 +2092,7 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode,
 
 static int
 compileBrailleIndicator(FileInfo *nested, const char *ermsg,
-		TranslationTableOpcode opcode, TranslationTableOffset *rule, int *lastToken,
+		TranslationTableOpcode opcode, int *lastToken,
 		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule, int noback,
 		int nofor, TranslationTableHeader **table) {
 	CharsString token;
@@ -2104,7 +2102,6 @@ compileBrailleIndicator(FileInfo *nested, const char *ermsg,
 			if (!addRule(nested, opcode, NULL, &cells, 0, 0, newRuleOffset, newRule,
 						noback, nofor, table))
 				return 0;
-	*rule = *newRuleOffset;
 	return 1;
 }
 
@@ -2148,6 +2145,7 @@ compileGrouping(FileInfo *nested, int *lastToken, TranslationTableOffset *newRul
 		return 0;
 	}
 	if (table) {
+		TranslationTableOffset ruleOffset;
 		TranslationTableCharacter *charsDotsPtr;
 		charsDotsPtr = addCharOrDots(nested, groupChars.chars[0], 0, table);
 		charsDotsPtr->attributes |= CTC_Math;
@@ -2165,10 +2163,11 @@ compileGrouping(FileInfo *nested, int *lastToken, TranslationTableOffset *newRul
 		charsDotsPtr->attributes |= CTC_Math;
 		charsDotsPtr->uppercase = charsDotsPtr->realchar;
 		charsDotsPtr->lowercase = charsDotsPtr->realchar;
-		if (!addRule(nested, CTO_Grouping, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
+		if (!addRule(nested, CTO_Grouping, &groupChars, &dotsParsed, 0, 0, &ruleOffset,
 					newRule, noback, nofor, table))
 			return 0;
-		if (!addRuleName(nested, &name, newRuleOffset, ruleNames)) return 0;
+		if (!addRuleName(nested, &name, ruleOffset, ruleNames)) return 0;
+		if (newRuleOffset) *newRuleOffset = ruleOffset;
 	}
 	if (displayTable) {
 		putCharAndDots(nested, groupChars.chars[0], dotsParsed.chars[0], displayTable);
@@ -2596,7 +2595,6 @@ compileRule(FileInfo *nested, CharacterClass **characterClasses,
 	int k, i;
 	int noback, nofor;
 	noback = nofor = 0;
-	TranslationTableOffset tmp_offset;
 doOpcode:
 	if (!getToken(nested, &token, NULL, &lastToken)) return 1;	/* blank line */
 	if (token.chars[0] == '#' || token.chars[0] == '<') return 1; /* comment */
@@ -2674,8 +2672,7 @@ doOpcode:
 			if (getToken(nested, &token, "include file name", &lastToken))
 				if (parseChars(nested, &includedFile, &token))
 					if (!includeFile(nested, &includedFile, characterClasses,
-								characterClassAttribute, newRuleOffset, newRule,
-								ruleNames, table, displayTable))
+								characterClassAttribute, ruleNames, table, displayTable))
 						ok = 0;
 			break;
 		}
@@ -2684,17 +2681,21 @@ doOpcode:
 					"The locale opcode is not implemented. Use the locale meta data "
 					"instead.");
 			break;
-		case CTO_Undefined:
-			tmp_offset = (*table)->undefined;
+		case CTO_Undefined: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->undefined;
 			ok = compileBrailleIndicator(nested, "undefined character opcode",
-					CTO_Undefined, &tmp_offset, &lastToken, newRuleOffset, newRule,
-					noback, nofor, table);
-			(*table)->undefined = tmp_offset;
+					CTO_Undefined, &lastToken, &ruleOffset, newRule, noback, nofor,
+					table);
+			(*table)->undefined = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-
+		}
 		case CTO_Match: {
+			TranslationTableRule *rule;
+			TranslationTableOffset ruleOffset;
 			CharsString ptn_before, ptn_after;
-			TranslationTableOffset offset;
+			TranslationTableOffset patternsOffset;
 			int len, mrk;
 
 			size_t patternsByteSize = sizeof(*patterns) * 27720;
@@ -2709,9 +2710,10 @@ doOpcode:
 			getRuleDotsPattern(nested, &ruleDots, &lastToken);
 
 			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-						newRuleOffset, newRule, noback, nofor, table))
+						&ruleOffset, &rule, noback, nofor, table)) {
 				ok = 0;
-
+				break;
+			}
 			if (ptn_before.chars[0] == '-' && ptn_before.length == 1)
 				len = _lou_pattern_compile(
 						&ptn_before.chars[0], 0, &patterns[1], 13841, *table);
@@ -2738,23 +2740,26 @@ doOpcode:
 			len += mrk;
 
 			if (!allocateSpaceInTranslationTable(
-						nested, &offset, len * sizeof(widechar), table)) {
+						nested, &patternsOffset, len * sizeof(widechar), table)) {
 				ok = 0;
 				break;
 			}
 
-			/* realloc may have moved table, so make sure newRule is still valid */
-			*newRule = (TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
+			/* realloc may have moved table, so make sure rule is still valid */
+			rule = (TranslationTableRule *)&(*table)->ruleArea[ruleOffset];
+			memcpy(&(*table)->ruleArea[patternsOffset], patterns, len * sizeof(widechar));
+			rule->patterns = patternsOffset;
 
-			memcpy(&(*table)->ruleArea[offset], patterns, len * sizeof(widechar));
-			(*newRule)->patterns = offset;
-
+			if (newRule) *newRule = rule;
+			if (newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 
 		case CTO_BackMatch: {
+			TranslationTableRule *rule;
+			TranslationTableOffset ruleOffset;
 			CharsString ptn_before, ptn_after;
-			TranslationTableOffset offset;
+			TranslationTableOffset patternOffset;
 			int len, mrk;
 
 			size_t patternsByteSize = sizeof(*patterns) * 27720;
@@ -2768,10 +2773,11 @@ doOpcode:
 			getCharacters(nested, &ptn_after, &lastToken);
 			getRuleDotsPattern(nested, &ruleDots, &lastToken);
 
-			if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset,
-						newRule, noback, nofor, table))
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, &ruleOffset, &rule,
+						noback, nofor, table)) {
 				ok = 0;
-
+				break;
+			}
 			if (ptn_before.chars[0] == '-' && ptn_before.length == 1)
 				len = _lou_pattern_compile(
 						&ptn_before.chars[0], 0, &patterns[1], 13841, *table);
@@ -2798,28 +2804,35 @@ doOpcode:
 			len += mrk;
 
 			if (!allocateSpaceInTranslationTable(
-						nested, &offset, len * sizeof(widechar), table)) {
+						nested, &patternOffset, len * sizeof(widechar), table)) {
 				ok = 0;
 				break;
 			}
 
-			/* realloc may have moved table, so make sure newRule is still valid */
-			*newRule = (TranslationTableRule *)&(*table)->ruleArea[*newRuleOffset];
+			/* realloc may have moved table, so make sure rule is still valid */
+			rule = (TranslationTableRule *)&(*table)->ruleArea[ruleOffset];
 
-			memcpy(&(*table)->ruleArea[offset], patterns, len * sizeof(widechar));
-			(*newRule)->patterns = offset;
+			memcpy(&(*table)->ruleArea[patternOffset], patterns, len * sizeof(widechar));
+			rule->patterns = patternOffset;
 
+			if (newRule) *newRule = rule;
+			if (newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 
-		case CTO_BegCapsPhrase:
-			tmp_offset = (*table)->emphRules[capsRule][begPhraseOffset];
+		case CTO_BegCapsPhrase: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset =
+					(*table)->emphRules[capsRule][begPhraseOffset];
 			ok = compileBrailleIndicator(nested, "first word capital sign",
-					CTO_BegCapsPhraseRule, &tmp_offset, &lastToken, newRuleOffset,
-					newRule, noback, nofor, table);
-			(*table)->emphRules[capsRule][begPhraseOffset] = tmp_offset;
+					CTO_BegCapsPhraseRule, &lastToken, &ruleOffset, newRule, noback,
+					nofor, table);
+			(*table)->emphRules[capsRule][begPhraseOffset] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-		case CTO_EndCapsPhrase:
+		}
+		case CTO_EndCapsPhrase: {
+			TranslationTableOffset ruleOffset;
 			switch (compileBeforeAfter(nested, &lastToken)) {
 			case 1:  // before
 				if ((*table)->emphRules[capsRule][endPhraseAfterOffset]) {
@@ -2827,11 +2840,14 @@ doOpcode:
 					ok = 0;
 					break;
 				}
-				tmp_offset = (*table)->emphRules[capsRule][endPhraseBeforeOffset];
+				// not passing pointer because compileBrailleIndicator may reallocate
+				// table
+				ruleOffset = (*table)->emphRules[capsRule][endPhraseBeforeOffset];
 				ok = compileBrailleIndicator(nested, "capital sign before last word",
-						CTO_EndCapsPhraseBeforeRule, &tmp_offset, &lastToken,
-						newRuleOffset, newRule, noback, nofor, table);
-				(*table)->emphRules[capsRule][endPhraseBeforeOffset] = tmp_offset;
+						CTO_EndCapsPhraseBeforeRule, &lastToken, &ruleOffset, newRule,
+						noback, nofor, table);
+				(*table)->emphRules[capsRule][endPhraseBeforeOffset] = ruleOffset;
+				if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 				break;
 			case 2:  // after
 				if ((*table)->emphRules[capsRule][endPhraseBeforeOffset]) {
@@ -2840,11 +2856,14 @@ doOpcode:
 					ok = 0;
 					break;
 				}
-				tmp_offset = (*table)->emphRules[capsRule][endPhraseAfterOffset];
+				// not passing pointer because compileBrailleIndicator may reallocate
+				// table
+				ruleOffset = (*table)->emphRules[capsRule][endPhraseAfterOffset];
 				ok = compileBrailleIndicator(nested, "capital sign after last word",
-						CTO_EndCapsPhraseAfterRule, &tmp_offset, &lastToken,
-						newRuleOffset, newRule, noback, nofor, table);
-				(*table)->emphRules[capsRule][endPhraseAfterOffset] = tmp_offset;
+						CTO_EndCapsPhraseAfterRule, &lastToken, &ruleOffset, newRule,
+						noback, nofor, table);
+				(*table)->emphRules[capsRule][endPhraseAfterOffset] = ruleOffset;
+				if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 				break;
 			default:  // error
 				compileError(nested, "Invalid lastword indicator location.");
@@ -2852,41 +2871,58 @@ doOpcode:
 				break;
 			}
 			break;
-		case CTO_BegCaps:
-			tmp_offset = (*table)->emphRules[capsRule][begOffset];
+		}
+		case CTO_BegCaps: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->emphRules[capsRule][begOffset];
 			ok = compileBrailleIndicator(nested, "first letter capital sign",
-					CTO_BegCapsRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-					noback, nofor, table);
-			(*table)->emphRules[capsRule][begOffset] = tmp_offset;
+					CTO_BegCapsRule, &lastToken, &ruleOffset, newRule, noback, nofor,
+					table);
+			(*table)->emphRules[capsRule][begOffset] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-		case CTO_EndCaps:
-			tmp_offset = (*table)->emphRules[capsRule][endOffset];
+		}
+		case CTO_EndCaps: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->emphRules[capsRule][endOffset];
 			ok = compileBrailleIndicator(nested, "last letter capital sign",
-					CTO_EndCapsRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-					noback, nofor, table);
-			(*table)->emphRules[capsRule][endOffset] = tmp_offset;
+					CTO_EndCapsRule, &lastToken, &ruleOffset, newRule, noback, nofor,
+					table);
+			(*table)->emphRules[capsRule][endOffset] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-		case CTO_CapsLetter:
-			tmp_offset = (*table)->emphRules[capsRule][letterOffset];
+		}
+		case CTO_CapsLetter: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset =
+					(*table)->emphRules[capsRule][letterOffset];
 			ok = compileBrailleIndicator(nested, "single letter capital sign",
-					CTO_CapsLetterRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-					noback, nofor, table);
-			(*table)->emphRules[capsRule][letterOffset] = tmp_offset;
+					CTO_CapsLetterRule, &lastToken, &ruleOffset, newRule, noback, nofor,
+					table);
+			(*table)->emphRules[capsRule][letterOffset] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-		case CTO_BegCapsWord:
-			tmp_offset = (*table)->emphRules[capsRule][begWordOffset];
+		}
+		case CTO_BegCapsWord: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset =
+					(*table)->emphRules[capsRule][begWordOffset];
 			ok = compileBrailleIndicator(nested, "capital word", CTO_BegCapsWordRule,
-					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
-					table);
-			(*table)->emphRules[capsRule][begWordOffset] = tmp_offset;
+					&lastToken, &ruleOffset, newRule, noback, nofor, table);
+			(*table)->emphRules[capsRule][begWordOffset] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-		case CTO_EndCapsWord:
-			tmp_offset = (*table)->emphRules[capsRule][endWordOffset];
+		}
+		case CTO_EndCapsWord: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset =
+					(*table)->emphRules[capsRule][endWordOffset];
 			ok = compileBrailleIndicator(nested, "capital word stop", CTO_EndCapsWordRule,
-					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
-					table);
-			(*table)->emphRules[capsRule][endWordOffset] = tmp_offset;
+					&lastToken, &ruleOffset, newRule, noback, nofor, table);
+			(*table)->emphRules[capsRule][endWordOffset] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
+		}
 		case CTO_LenCapsPhrase:
 			ok = (*table)->emphRules[capsRule][lenPhraseOffset] =
 					compileNumber(nested, &lastToken);
@@ -2999,8 +3035,9 @@ doOpcode:
 		case CTO_EndEmph:
 		case CTO_BegEmphPhrase:
 		case CTO_EndEmphPhrase:
-		case CTO_LenEmphPhrase:
+		case CTO_LenEmphPhrase: {
 			ok = 0;
+			TranslationTableOffset ruleOffset = 0;
 			if (getToken(nested, &token, "emphasis class", &lastToken))
 				if (parseChars(nested, &emphClass, &token)) {
 					char *s = malloc(sizeof(char) * (emphClass.length + 1));
@@ -3018,25 +3055,29 @@ doOpcode:
 					}
 					i++;  // in table->emphRules the first index is used for caps
 					if (opcode == CTO_EmphLetter) {
-						tmp_offset = (*table)->emphRules[i][letterOffset];
+						// not passing pointer because compileBrailleIndicator may
+						// reallocate table
+						ruleOffset = (*table)->emphRules[i][letterOffset];
 						ok = compileBrailleIndicator(nested, "single letter",
-								CTO_Emph1LetterRule + letterOffset + (8 * i), &tmp_offset,
-								&lastToken, newRuleOffset, newRule, noback, nofor, table);
-						(*table)->emphRules[i][letterOffset] = tmp_offset;
+								CTO_Emph1LetterRule + letterOffset + (8 * i), &lastToken,
+								&ruleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][letterOffset] = ruleOffset;
 					} else if (opcode == CTO_BegEmphWord) {
-						tmp_offset = (*table)->emphRules[i][begWordOffset];
+						// not passing pointer because compileBrailleIndicator may
+						// reallocate table
+						ruleOffset = (*table)->emphRules[i][begWordOffset];
 						ok = compileBrailleIndicator(nested, "word",
-								CTO_Emph1LetterRule + begWordOffset + (8 * i),
-								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
-								nofor, table);
-						(*table)->emphRules[i][begWordOffset] = tmp_offset;
+								CTO_Emph1LetterRule + begWordOffset + (8 * i), &lastToken,
+								&ruleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][begWordOffset] = ruleOffset;
 					} else if (opcode == CTO_EndEmphWord) {
-						tmp_offset = (*table)->emphRules[i][endWordOffset];
+						// not passing pointer because compileBrailleIndicator may
+						// reallocate table
+						ruleOffset = (*table)->emphRules[i][endWordOffset];
 						ok = compileBrailleIndicator(nested, "word stop",
-								CTO_Emph1LetterRule + endWordOffset + (8 * i),
-								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
-								nofor, table);
-						(*table)->emphRules[i][endWordOffset] = tmp_offset;
+								CTO_Emph1LetterRule + endWordOffset + (8 * i), &lastToken,
+								&ruleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][endWordOffset] = ruleOffset;
 					} else if (opcode == CTO_BegEmph) {
 						/* fail if both begemph and any of begemphphrase or begemphword
 						 * are defined */
@@ -3050,11 +3091,13 @@ doOpcode:
 							ok = 0;
 							break;
 						}
-						tmp_offset = (*table)->emphRules[i][begOffset];
+						// not passing pointer because compileBrailleIndicator may
+						// reallocate table
+						ruleOffset = (*table)->emphRules[i][begOffset];
 						ok = compileBrailleIndicator(nested, "first letter",
-								CTO_Emph1LetterRule + begOffset + (8 * i), &tmp_offset,
-								&lastToken, newRuleOffset, newRule, noback, nofor, table);
-						(*table)->emphRules[i][begOffset] = tmp_offset;
+								CTO_Emph1LetterRule + begOffset + (8 * i), &lastToken,
+								&ruleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][begOffset] = ruleOffset;
 					} else if (opcode == CTO_EndEmph) {
 						if ((*table)->emphRules[i][endWordOffset] ||
 								(*table)->emphRules[i][endPhraseBeforeOffset] ||
@@ -3067,18 +3110,21 @@ doOpcode:
 							ok = 0;
 							break;
 						}
-						tmp_offset = (*table)->emphRules[i][endOffset];
+						// not passing pointer because compileBrailleIndicator may
+						// reallocate table
+						ruleOffset = (*table)->emphRules[i][endOffset];
 						ok = compileBrailleIndicator(nested, "last letter",
-								CTO_Emph1LetterRule + endOffset + (8 * i), &tmp_offset,
-								&lastToken, newRuleOffset, newRule, noback, nofor, table);
-						(*table)->emphRules[i][endOffset] = tmp_offset;
+								CTO_Emph1LetterRule + endOffset + (8 * i), &lastToken,
+								&ruleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][endOffset] = ruleOffset;
 					} else if (opcode == CTO_BegEmphPhrase) {
-						tmp_offset = (*table)->emphRules[i][begPhraseOffset];
+						// not passing pointer because compileBrailleIndicator may
+						// reallocate table
+						ruleOffset = (*table)->emphRules[i][begPhraseOffset];
 						ok = compileBrailleIndicator(nested, "first word",
 								CTO_Emph1LetterRule + begPhraseOffset + (8 * i),
-								&tmp_offset, &lastToken, newRuleOffset, newRule, noback,
-								nofor, table);
-						(*table)->emphRules[i][begPhraseOffset] = tmp_offset;
+								&lastToken, &ruleOffset, newRule, noback, nofor, table);
+						(*table)->emphRules[i][begPhraseOffset] = ruleOffset;
 					} else if (opcode == CTO_EndEmphPhrase)
 						switch (compileBeforeAfter(nested, &lastToken)) {
 						case 1:  // before
@@ -3087,12 +3133,14 @@ doOpcode:
 								ok = 0;
 								break;
 							}
-							tmp_offset = (*table)->emphRules[i][endPhraseBeforeOffset];
+							// not passing pointer because compileBrailleIndicator may
+							// reallocate table
+							ruleOffset = (*table)->emphRules[i][endPhraseBeforeOffset];
 							ok = compileBrailleIndicator(nested, "last word before",
 									CTO_Emph1LetterRule + endPhraseBeforeOffset + (8 * i),
-									&tmp_offset, &lastToken, newRuleOffset, newRule,
-									noback, nofor, table);
-							(*table)->emphRules[i][endPhraseBeforeOffset] = tmp_offset;
+									&lastToken, &ruleOffset, newRule, noback, nofor,
+									table);
+							(*table)->emphRules[i][endPhraseBeforeOffset] = ruleOffset;
 							break;
 						case 2:  // after
 							if ((*table)->emphRules[i][endPhraseBeforeOffset]) {
@@ -3100,12 +3148,14 @@ doOpcode:
 								ok = 0;
 								break;
 							}
-							tmp_offset = (*table)->emphRules[i][endPhraseAfterOffset];
+							// not passing pointer because compileBrailleIndicator may
+							// reallocate table
+							ruleOffset = (*table)->emphRules[i][endPhraseAfterOffset];
 							ok = compileBrailleIndicator(nested, "last word after",
 									CTO_Emph1LetterRule + endPhraseAfterOffset + (8 * i),
-									&tmp_offset, &lastToken, newRuleOffset, newRule,
-									noback, nofor, table);
-							(*table)->emphRules[i][endPhraseAfterOffset] = tmp_offset;
+									&lastToken, &ruleOffset, newRule, noback, nofor,
+									table);
+							(*table)->emphRules[i][endPhraseAfterOffset] = ruleOffset;
 							break;
 						default:  // error
 							compileError(nested, "Invalid lastword indicator location.");
@@ -3117,15 +3167,18 @@ doOpcode:
 								compileNumber(nested, &lastToken);
 					free(s);
 				}
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-
-		case CTO_LetterSign:
-			tmp_offset = (*table)->letterSign;
+		}
+		case CTO_LetterSign: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->letterSign;
 			ok = compileBrailleIndicator(nested, "letter sign", CTO_LetterRule,
-					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
-					table);
-			(*table)->letterSign = tmp_offset;
+					&lastToken, &ruleOffset, newRule, noback, nofor, table);
+			(*table)->letterSign = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
+		}
 		case CTO_NoLetsignBefore:
 			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
 				if (((*table)->noLetsignBeforeCount + ruleChars.length) > LETSIGNSIZE) {
@@ -3161,14 +3214,15 @@ doOpcode:
 							ruleChars.chars[k];
 			}
 			break;
-		case CTO_NumberSign:
-			tmp_offset = (*table)->numberSign;
+		case CTO_NumberSign: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->numberSign;
 			ok = compileBrailleIndicator(nested, "number sign", CTO_NumberRule,
-					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
-					table);
-			(*table)->numberSign = tmp_offset;
+					&lastToken, &ruleOffset, newRule, noback, nofor, table);
+			(*table)->numberSign = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-
+		}
 		case CTO_Attribute:
 
 			c = NULL;
@@ -3284,15 +3338,16 @@ doOpcode:
 			}
 			break;
 
-		case CTO_NoContractSign:
-
-			tmp_offset = (*table)->noContractSign;
+		case CTO_NoContractSign: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->noContractSign;
 			ok = compileBrailleIndicator(nested, "no contractions sign",
-					CTO_NoContractRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-					noback, nofor, table);
-			(*table)->noContractSign = tmp_offset;
+					CTO_NoContractRule, &lastToken, &ruleOffset, newRule, noback, nofor,
+					table);
+			(*table)->noContractSign = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
-
+		}
 		case CTO_SeqDelimiter:
 
 			c = NULL;
@@ -3412,20 +3467,25 @@ doOpcode:
 			(*table)->usesEmphMode = 1;
 			break;
 
-		case CTO_BegComp:
-			tmp_offset = (*table)->begComp;
+		case CTO_BegComp: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->begComp;
 			ok = compileBrailleIndicator(nested, "begin computer braille",
-					CTO_BegCompRule, &tmp_offset, &lastToken, newRuleOffset, newRule,
-					noback, nofor, table);
-			(*table)->begComp = tmp_offset;
-			break;
-		case CTO_EndComp:
-			tmp_offset = (*table)->endComp;
-			ok = compileBrailleIndicator(nested, "end computer braslle", CTO_EndCompRule,
-					&tmp_offset, &lastToken, newRuleOffset, newRule, noback, nofor,
+					CTO_BegCompRule, &lastToken, &ruleOffset, newRule, noback, nofor,
 					table);
-			(*table)->endComp = tmp_offset;
+			(*table)->begComp = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
+		}
+		case CTO_EndComp: {
+			// not passing pointer because compileBrailleIndicator may reallocate table
+			TranslationTableOffset ruleOffset = (*table)->endComp;
+			ok = compileBrailleIndicator(nested, "end computer braslle", CTO_EndCompRule,
+					&lastToken, &ruleOffset, newRule, noback, nofor, table);
+			(*table)->endComp = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
+			break;
+		}
 		case CTO_Syllable:
 			(*table)->syllables = 1;
 		case CTO_Always:
@@ -3473,7 +3533,8 @@ doOpcode:
 			// }
 			break;
 		case CTO_CompDots:
-		case CTO_Comp6:
+		case CTO_Comp6: {
+			TranslationTableOffset ruleOffset;
 			if (!getRuleCharsText(nested, &ruleChars, &lastToken)) return 0;
 			if (ruleChars.length != 1 || ruleChars.chars[0] > 255) {
 				compileError(nested, "first operand must be 1 character and < 256");
@@ -3481,10 +3542,12 @@ doOpcode:
 			}
 			if (!getRuleDotsPattern(nested, &ruleDots, &lastToken)) return 0;
 			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-						newRuleOffset, newRule, noback, nofor, table))
+						&ruleOffset, newRule, noback, nofor, table))
 				ok = 0;
-			(*table)->compdotsPattern[ruleChars.chars[0]] = *newRuleOffset;
+			(*table)->compdotsPattern[ruleChars.chars[0]] = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
+		}
 		case CTO_ExactDots:
 			if (!getRuleCharsText(nested, &ruleChars, &lastToken)) return 0;
 			if (ruleChars.chars[0] != '@') {
@@ -3499,14 +3562,17 @@ doOpcode:
 						newRuleOffset, newRule, noback, nofor, table))
 				ok = 0;
 			break;
-		case CTO_CapsNoCont:
+		case CTO_CapsNoCont: {
+			TranslationTableOffset ruleOffset;
 			ruleChars.length = 1;
 			ruleChars.chars[0] = 'a';
 			if (!addRule(nested, CTO_CapsNoContRule, &ruleChars, NULL, after, before,
-						newRuleOffset, newRule, noback, nofor, table))
+						&ruleOffset, newRule, noback, nofor, table))
 				ok = 0;
-			(*table)->capsNoCont = *newRuleOffset;
+			(*table)->capsNoCont = ruleOffset;
+			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
+		}
 		case CTO_Replace:
 			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
 				if (lastToken)
@@ -3763,7 +3829,6 @@ lou_readCharFromFile(const char *fileName, int *mode) {
 static int
 compileString(const char *inString, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule,
 		RuleName **ruleNames, TranslationTableHeader **table,
 		DisplayTableHeader **displayTable) {
 	/* This function can be used to make changes to tables on the fly. */
@@ -3779,8 +3844,8 @@ compileString(const char *inString, CharacterClass **characterClasses,
 	for (k = 0; inString[k]; k++) nested.line[k] = inString[k];
 	nested.line[k] = 0;
 	nested.linelen = k;
-	return compileRule(&nested, characterClasses, characterClassAttribute, newRuleOffset,
-			newRule, ruleNames, table, displayTable);
+	return compileRule(&nested, characterClasses, characterClassAttribute, NULL, NULL,
+			ruleNames, table, displayTable);
 }
 
 static int
@@ -4036,7 +4101,6 @@ static int fileCount = 0;
 static int
 compileFile(const char *fileName, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule,
 		RuleName **ruleNames, TranslationTableHeader **table,
 		DisplayTableHeader **displayTable) {
 	FileInfo nested;
@@ -4047,8 +4111,8 @@ compileFile(const char *fileName, CharacterClass **characterClasses,
 	nested.lineNumber = 0;
 	if ((nested.in = fopen(nested.fileName, "rb"))) {
 		while (_lou_getALine(&nested))
-			compileRule(&nested, characterClasses, characterClassAttribute, newRuleOffset,
-					newRule, ruleNames, table, displayTable);
+			compileRule(&nested, characterClasses, characterClassAttribute, NULL, NULL,
+					ruleNames, table, displayTable);
 		fclose(nested.in);
 		return 1;
 	} else
@@ -4076,7 +4140,6 @@ static int
 includeFile(FileInfo *nested, CharsString *includedFile,
 		CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule,
 		RuleName **ruleNames, TranslationTableHeader **table,
 		DisplayTableHeader **displayTable) {
 	int k;
@@ -4102,8 +4165,8 @@ includeFile(FileInfo *nested, CharsString *includedFile,
 				includeThis);
 		return 0;
 	}
-	rv = compileFile(*tableFiles, characterClasses, characterClassAttribute,
-			newRuleOffset, newRule, ruleNames, table, displayTable);
+	rv = compileFile(*tableFiles, characterClasses, characterClassAttribute, ruleNames,
+			table, displayTable);
 	free_tablefiles(tableFiles);
 	return rv;
 }
@@ -4116,7 +4179,6 @@ static int
 compileTable(const char *tableList, TranslationTableHeader **translationTable,
 		DisplayTableHeader **displayTable, CharacterClass **characterClasses,
 		TranslationTableCharacterAttributes *characterClassAttribute,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule,
 		RuleName **ruleNames) {
 	if (translationTable) *translationTable = NULL;
 	if (displayTable) *displayTable = NULL;
@@ -4143,8 +4205,7 @@ compileTable(const char *tableList, TranslationTableHeader **translationTable,
 	   liblouisutdml. Find a way to satisfy those requirements without hard coding
 	   some characters in every table notably behind the users back */
 	compileString("space \\xffff 123456789abcdef LOU_ENDSEGMENT", characterClasses,
-			characterClassAttribute, newRuleOffset, newRule, ruleNames, translationTable,
-			displayTable);
+			characterClassAttribute, ruleNames, translationTable, displayTable);
 
 	/* Compile all subtables in the list */
 	if (!(tableFiles = _lou_resolveTable(tableList, NULL))) {
@@ -4152,8 +4213,8 @@ compileTable(const char *tableList, TranslationTableHeader **translationTable,
 		goto cleanup;
 	}
 	for (subTable = tableFiles; *subTable; subTable++)
-		if (!compileFile(*subTable, characterClasses, characterClassAttribute,
-					newRuleOffset, newRule, ruleNames, translationTable, displayTable))
+		if (!compileFile(*subTable, characterClasses, characterClassAttribute, ruleNames,
+					translationTable, displayTable))
 			goto cleanup;
 
 /* Clean up after compiling files */
@@ -4260,8 +4321,7 @@ lou_getTable(const char *tableList) {
 		if (translationTable == NULL) newTranslationTable = &translationTable;
 		if (displayTable == NULL) newDisplayTable = &displayTable;
 		if (compileTable(tableList, newTranslationTable, newDisplayTable,
-					&gCharacterClasses, &gCharacterClassAttribute, &gNewRuleOffset,
-					&gNewRule, &gRuleNames)) {
+					&gCharacterClasses, &gCharacterClassAttribute, &gRuleNames)) {
 			/* Add a new entry to the top of the table chain. */
 			if (newTranslationTable != NULL) {
 				int entrySize = sizeof(TranslationTableChainEntry) + tableListLen;
@@ -4488,7 +4548,7 @@ lou_compileString(const char *tableList, const char *inString) {
 	TranslationTableHeader *table = lou_getTable(tableList);
 	if (!table) return 0;
 	r = compileString(inString, &gCharacterClasses, &gCharacterClassAttribute,
-			&gNewRuleOffset, &gNewRule, &gRuleNames, &table, &currentDisplayTable);
+			&gRuleNames, &table, &currentDisplayTable);
 	return r;
 }
 

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -87,8 +87,6 @@ typedef struct CharsString {
 static int errorCount;
 static int warningCount;
 
-static DisplayTableHeader *currentDisplayTable;
-
 typedef struct TranslationTableChainEntry {
 	struct TranslationTableChainEntry *next;
 	TranslationTableHeader *table;
@@ -554,7 +552,7 @@ addCharOrDots(FileInfo *nested, widechar c, int m, TranslationTableHeader **tabl
 }
 
 static CharOrDots *
-getCharOrDots(widechar c, int m, DisplayTableHeader *table) {
+getCharOrDots(widechar c, int m, const DisplayTableHeader *table) {
 	CharOrDots *cdPtr;
 	TranslationTableOffset bucket;
 	unsigned long int makeHash = _lou_charHash(c);
@@ -571,15 +569,15 @@ getCharOrDots(widechar c, int m, DisplayTableHeader *table) {
 }
 
 widechar EXPORT_CALL
-_lou_getDotsForChar(widechar c) {
-	CharOrDots *cdPtr = getCharOrDots(c, 0, currentDisplayTable);
+_lou_getDotsForChar(widechar c, const DisplayTableHeader *table) {
+	CharOrDots *cdPtr = getCharOrDots(c, 0, table);
 	if (cdPtr) return cdPtr->found;
 	return LOU_DOTS;
 }
 
 widechar EXPORT_CALL
-_lou_getCharFromDots(widechar d) {
-	CharOrDots *cdPtr = getCharOrDots(d, 1, currentDisplayTable);
+_lou_getCharFromDots(widechar d, const DisplayTableHeader *table) {
+	CharOrDots *cdPtr = getCharOrDots(d, 1, table);
 	if (cdPtr) return cdPtr->found;
 	return ' ';
 }
@@ -2579,11 +2577,40 @@ doOpcode:
 	if (nested->lineNumber == 1 &&
 			(eqasc2uni((unsigned char *)"ISO", token.chars, 3) ||
 					eqasc2uni((unsigned char *)"UTF-8", token.chars, 5))) {
-		if (table) compileHyphenation(nested, &token, &lastToken, table);
+		if (table)
+			compileHyphenation(nested, &token, &lastToken, table);
+		else
+			/* ignore the whole file */
+			while (_lou_getALine(nested))
+				;
 		return 1;
 	}
 	opcode = getOpcode(nested, &token);
-	switch (opcode) { /* Carry out operations */
+	switch (opcode) {
+	case CTO_IncludeFile: {
+		CharsString includedFile;
+		if (getToken(nested, &token, "include file name", &lastToken))
+			if (parseChars(nested, &includedFile, &token))
+				if (!includeFile(nested, &includedFile, table, displayTable)) ok = 0;
+		break;
+	}
+	case CTO_NoBack:
+		if (nofor) {
+			compileError(nested, "%s already specified.", _lou_findOpcodeName(CTO_NoFor));
+			ok = 0;
+			break;
+		}
+		noback = 1;
+		goto doOpcode;
+	case CTO_NoFor:
+		if (noback) {
+			compileError(
+					nested, "%s already specified.", _lou_findOpcodeName(CTO_NoBack));
+			ok = 0;
+			break;
+		}
+		nofor = 1;
+		goto doOpcode;
 	case CTO_Space:
 		compileCharDef(nested, opcode, CTC_Space, &lastToken, newRuleOffset, newRule,
 				noback, nofor, table, displayTable);
@@ -2629,6 +2656,7 @@ doOpcode:
 				table, displayTable);
 		break;
 	case CTO_Display:
+		if (!displayTable) break;
 		if (getRuleCharsText(nested, &ruleChars, &lastToken))
 			if (getRuleDotsPattern(nested, &ruleDots, &lastToken)) {
 				if (ruleChars.length != 1 || ruleDots.length != 1) {
@@ -2640,18 +2668,12 @@ doOpcode:
 						nested, ruleChars.chars[0], ruleDots.chars[0], displayTable);
 			}
 		break;
+	/* now only opcodes follow that don't modify the display table */
 	default:
 		if (!table) break;
 		switch (opcode) {
 		case CTO_None:
 			break;
-		case CTO_IncludeFile: {
-			CharsString includedFile;
-			if (getToken(nested, &token, "include file name", &lastToken))
-				if (parseChars(nested, &includedFile, &token))
-					if (!includeFile(nested, &includedFile, table, displayTable)) ok = 0;
-			break;
-		}
 		case CTO_Locale:
 			compileWarning(nested,
 					"The locale opcode is not implemented. Use the locale meta data "
@@ -3697,25 +3719,6 @@ doOpcode:
 				break;
 			}
 
-		case CTO_NoBack:
-			if (nofor) {
-				compileError(
-						nested, "%s already specified.", _lou_findOpcodeName(CTO_NoFor));
-				ok = 0;
-				break;
-			}
-			noback = 1;
-			goto doOpcode;
-		case CTO_NoFor:
-			if (noback) {
-				compileError(
-						nested, "%s already specified.", _lou_findOpcodeName(CTO_NoBack));
-				ok = 0;
-				break;
-			}
-			nofor = 1;
-			goto doOpcode;
-
 		case CTO_EmpMatchBefore:
 			before |= CTC_EmpMatch;
 			goto doOpcode;
@@ -4138,14 +4141,16 @@ includeFile(FileInfo *nested, CharsString *includedFile, TranslationTableHeader 
  *
  */
 static int
-compileTable(const char *tableList, TranslationTableHeader **translationTable,
-		DisplayTableHeader **displayTable) {
-	if (translationTable) *translationTable = NULL;
-	if (displayTable) *displayTable = NULL;
+compileTable(const char *tableList, const char *displayTableList,
+		TranslationTableHeader **translationTable, DisplayTableHeader **displayTable) {
 	char **tableFiles;
 	char **subTable;
+	if (translationTable && !tableList) return 0;
+	if (displayTable && !displayTableList) return 0;
+	if (!translationTable && !displayTable) return 0;
+	if (translationTable) *translationTable = NULL;
+	if (displayTable) *displayTable = NULL;
 	errorCount = warningCount = fileCount = 0;
-	if (tableList == NULL) return 0;
 	if (!opcodeLengths[0]) {
 		TranslationTableOpcode opcode;
 		for (opcode = 0; opcode < CTO_None; opcode++)
@@ -4168,13 +4173,38 @@ compileTable(const char *tableList, TranslationTableHeader **translationTable,
 	compileString("space \\xffff 123456789abcdef LOU_ENDSEGMENT", translationTable,
 			displayTable);
 
-	/* Compile all subtables in the list */
-	if (!(tableFiles = _lou_resolveTable(tableList, NULL))) {
-		errorCount++;
-		goto cleanup;
+	if (displayTable && translationTable && strcmp(tableList, displayTableList) == 0) {
+		/* Compile the display and translation tables in one go */
+
+		/* Compile all subtables in the list */
+		if (!(tableFiles = _lou_resolveTable(tableList, NULL))) {
+			errorCount++;
+			goto cleanup;
+		}
+		for (subTable = tableFiles; *subTable; subTable++)
+			if (!compileFile(*subTable, translationTable, displayTable)) goto cleanup;
+	} else {
+		/* Compile the display and translation tables separately */
+
+		if (displayTable) {
+			if (!(tableFiles = _lou_resolveTable(displayTableList, NULL))) {
+				errorCount++;
+				goto cleanup;
+			}
+			for (subTable = tableFiles; *subTable; subTable++)
+				if (!compileFile(*subTable, NULL, displayTable)) goto cleanup;
+			free_tablefiles(tableFiles);
+			tableFiles = NULL;
+		}
+		if (translationTable) {
+			if (!(tableFiles = _lou_resolveTable(tableList, NULL))) {
+				errorCount++;
+				goto cleanup;
+			}
+			for (subTable = tableFiles; *subTable; subTable++)
+				if (!compileFile(*subTable, translationTable, NULL)) goto cleanup;
+		}
 	}
-	for (subTable = tableFiles; *subTable; subTable++)
-		if (!compileFile(*subTable, translationTable, displayTable)) goto cleanup;
 
 /* Clean up after compiling files */
 cleanup:
@@ -4202,7 +4232,7 @@ char const **EXPORT_CALL
 lou_getEmphClasses(const char *tableList) {
 	const char *names[MAX_EMPH_CLASSES + 1];
 	unsigned int count = 0;
-	const TranslationTableHeader *table = lou_getTable(tableList);
+	const TranslationTableHeader *table = _lou_getTranslationTable(tableList);
 	if (!table) return NULL;
 
 	while (count < MAX_EMPH_CLASSES) {
@@ -4223,94 +4253,138 @@ lou_getEmphClasses(const char *tableList) {
 	}
 }
 
+void
+getTable(const char *tableList, const char *displayTableList,
+		TranslationTableHeader **translationTable, DisplayTableHeader **displayTable);
+
+void EXPORT_CALL
+_lou_getTable(const char *tableList, const char *displayTableList,
+		const TranslationTableHeader **translationTable,
+		const DisplayTableHeader **displayTable) {
+	TranslationTableHeader *newTable;
+	DisplayTableHeader *newDisplayTable;
+	getTable(tableList, displayTableList, &newTable, &newDisplayTable);
+	*translationTable = newTable;
+	*displayTable = newDisplayTable;
+}
+
 /* Checks and loads tableList. */
-void *EXPORT_CALL
+const void *EXPORT_CALL
 lou_getTable(const char *tableList) {
+	const TranslationTableHeader *table;
+	const DisplayTableHeader *displayTable;
+	_lou_getTable(tableList, tableList, &table, &displayTable);
+	if (!table || !displayTable) return NULL;
+	return table;
+}
+
+const TranslationTableHeader *EXPORT_CALL
+_lou_getTranslationTable(const char *tableList) {
+	TranslationTableHeader *table;
+	getTable(tableList, NULL, &table, NULL);
+	return table;
+}
+
+const DisplayTableHeader *EXPORT_CALL
+_lou_getDisplayTable(const char *tableList) {
+	DisplayTableHeader *table;
+	getTable(NULL, tableList, NULL, &table);
+	return table;
+}
+
+void
+getTable(const char *translationTableList, const char *displayTableList,
+		TranslationTableHeader **translationTable, DisplayTableHeader **displayTable) {
 	/* Keep track of which tables have already been compiled */
-	int tableListLen;
-	TranslationTableHeader *translationTable = NULL;
-	DisplayTableHeader *displayTable = NULL;
-	if (tableList == NULL || *tableList == 0) return NULL;
-	errorCount = fileCount = 0;
-	tableListLen = (int)strlen(tableList);
-	/* See if Table has already been compiled */
-	{
+	int translationTableListLen, displayTableListLen = 0;
+	if (translationTableList == NULL || *translationTableList == 0)
+		translationTable = NULL;
+	if (displayTableList == NULL || *displayTableList == 0) displayTable = NULL;
+	/* See if translation table has already been compiled */
+	if (translationTable) {
+		translationTableListLen = (int)strlen(translationTableList);
+		*translationTable = NULL;
 		TranslationTableChainEntry *currentEntry = translationTableChain;
 		TranslationTableChainEntry *prevEntry = NULL;
 		while (currentEntry != NULL) {
-			if (tableListLen == currentEntry->tableListLength &&
-					(memcmp(&currentEntry->tableList[0], tableList, tableListLen)) == 0) {
+			if (translationTableListLen == currentEntry->tableListLength &&
+					(memcmp(&currentEntry->tableList[0], translationTableList,
+							translationTableListLen)) == 0) {
 				/* Move the table to the top of the table chain. */
 				if (prevEntry != NULL) {
 					prevEntry->next = currentEntry->next;
 					currentEntry->next = translationTableChain;
 					translationTableChain = currentEntry;
 				}
-				translationTable = currentEntry->table;
+				*translationTable = currentEntry->table;
 				break;
 			}
 			prevEntry = currentEntry;
 			currentEntry = currentEntry->next;
 		}
 	}
-	{
+	/* See if display table has already been compiled */
+	if (displayTable) {
+		displayTableListLen = (int)strlen(displayTableList);
+		*displayTable = NULL;
 		DisplayTableChainEntry *currentEntry = displayTableChain;
 		DisplayTableChainEntry *prevEntry = NULL;
 		while (currentEntry != NULL) {
-			if (tableListLen == currentEntry->tableListLength &&
-					(memcmp(&currentEntry->tableList[0], tableList, tableListLen)) == 0) {
+			if (displayTableListLen == currentEntry->tableListLength &&
+					(memcmp(&currentEntry->tableList[0], displayTableList,
+							displayTableListLen)) == 0) {
 				/* Move the table to the top of the table chain. */
 				if (prevEntry != NULL) {
 					prevEntry->next = currentEntry->next;
 					currentEntry->next = displayTableChain;
 					displayTableChain = currentEntry;
 				}
-				displayTable = currentEntry->table;
+				*displayTable = currentEntry->table;
 				break;
 			}
 			prevEntry = currentEntry;
 			currentEntry = currentEntry->next;
 		}
 	}
-	if (translationTable == NULL || displayTable == NULL) {
-		TranslationTableHeader **newTranslationTable = NULL;
-		DisplayTableHeader **newDisplayTable = NULL;
-		if (translationTable == NULL) newTranslationTable = &translationTable;
-		if (displayTable == NULL) newDisplayTable = &displayTable;
-		if (compileTable(tableList, newTranslationTable, newDisplayTable)) {
+	if ((translationTable && *translationTable == NULL) ||
+			(displayTable && *displayTable == NULL)) {
+		TranslationTableHeader *newTranslationTable = NULL;
+		DisplayTableHeader *newDisplayTable = NULL;
+		if (compileTable(translationTableList, displayTableList,
+					(translationTable && *translationTable == NULL) ? &newTranslationTable
+																	: NULL,
+					(displayTable && *displayTable == NULL) ? &newDisplayTable : NULL)) {
 			/* Add a new entry to the top of the table chain. */
 			if (newTranslationTable != NULL) {
-				int entrySize = sizeof(TranslationTableChainEntry) + tableListLen;
+				int entrySize =
+						sizeof(TranslationTableChainEntry) + translationTableListLen;
 				TranslationTableChainEntry *newEntry = malloc(entrySize);
 				if (!newEntry) _lou_outOfMemory();
 				newEntry->next = translationTableChain;
-				newEntry->table = *newTranslationTable;
-				newEntry->tableListLength = tableListLen;
-				memcpy(&newEntry->tableList[0], tableList, tableListLen);
+				newEntry->table = newTranslationTable;
+				newEntry->tableListLength = translationTableListLen;
+				memcpy(&newEntry->tableList[0], translationTableList,
+						translationTableListLen);
 				translationTableChain = newEntry;
+				*translationTable = newTranslationTable;
 			}
 			if (newDisplayTable != NULL) {
-				int entrySize = sizeof(DisplayTableChainEntry) + tableListLen;
+				int entrySize = sizeof(DisplayTableChainEntry) + displayTableListLen;
 				DisplayTableChainEntry *newEntry = malloc(entrySize);
 				if (!newEntry) _lou_outOfMemory();
 				newEntry->next = displayTableChain;
-				newEntry->table = *newDisplayTable;
-				newEntry->tableListLength = tableListLen;
-				memcpy(&newEntry->tableList[0], tableList, tableListLen);
+				newEntry->table = newDisplayTable;
+				newEntry->tableListLength = displayTableListLen;
+				memcpy(&newEntry->tableList[0], displayTableList, displayTableListLen);
 				displayTableChain = newEntry;
+				*displayTable = newDisplayTable;
 			}
 		} else {
-			_lou_logMessage(LOU_LOG_ERROR, "%s could not be compiled", tableList);
-			return NULL;
+			_lou_logMessage(
+					LOU_LOG_ERROR, "%s could not be compiled", translationTableList);
+			return;
 		}
 	}
-	currentDisplayTable = displayTable;
-	return translationTable;
-}
-
-DisplayTableHeader *EXPORT_CALL
-_lou_getCurrentDisplayTable() {
-	return currentDisplayTable;
 }
 
 int EXPORT_CALL
@@ -4322,7 +4396,7 @@ lou_checkTable(const char *tableList) {
 formtype EXPORT_CALL
 lou_getTypeformForEmphClass(const char *tableList, const char *emphClass) {
 	int i;
-	TranslationTableHeader *table = lou_getTable(tableList);
+	const TranslationTableHeader *table = _lou_getTranslationTable(tableList);
 	if (!table) return 0;
 	for (i = 0; table->emphClasses[i]; i++)
 		if (strcmp(emphClass, table->emphClasses[i]) == 0) return italic << i;
@@ -4502,11 +4576,26 @@ lou_charSize(void) {
 
 int EXPORT_CALL
 lou_compileString(const char *tableList, const char *inString) {
-	int r;
-	TranslationTableHeader *table = lou_getTable(tableList);
+	TranslationTableHeader *table;
+	DisplayTableHeader *displayTable;
+	getTable(tableList, tableList, &table, &displayTable);
 	if (!table) return 0;
-	r = compileString(inString, &table, &currentDisplayTable);
-	return r;
+	if (!compileString(inString, &table, &displayTable)) return 0;
+	return 1;
+}
+
+int EXPORT_CALL
+_lou_compileTranslationRule(const char *tableList, const char *inString) {
+	TranslationTableHeader *table;
+	getTable(tableList, NULL, &table, NULL);
+	return compileString(inString, &table, NULL);
+}
+
+int EXPORT_CALL
+_lou_compileDisplayRule(const char *tableList, const char *inString) {
+	DisplayTableHeader *table;
+	getTable(NULL, tableList, NULL, &table);
+	return compileString(inString, NULL, &table);
 }
 
 /**

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -465,6 +465,20 @@ typedef struct /* one state */
 	widechar numTrans;
 } HyphenationState;
 
+typedef struct CharacterClass {
+	struct CharacterClass *next;
+	TranslationTableCharacterAttributes attribute;
+	widechar length;
+	widechar name[1];
+} CharacterClass;
+
+typedef struct RuleName {
+	struct RuleName *next;
+	TranslationTableOffset ruleOffset;
+	widechar length;
+	widechar name[1];
+} RuleName;
+
 typedef struct {
 	TranslationTableOffset tableSize;
 	TranslationTableOffset bytesUsed;
@@ -498,6 +512,11 @@ typedef struct { /* translation table */
 
 	/* emphRules, including caps. */
 	TranslationTableOffset emphRules[MAX_EMPH_CLASSES + 1][9];
+
+	/* state needed during compilation */
+	CharacterClass *characterClasses;
+	TranslationTableCharacterAttributes nextCharacterClassAttribute;
+	RuleName *ruleNames;
 
 	TranslationTableOffset begComp;
 	TranslationTableOffset compBegEmph1;

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -748,13 +748,12 @@ int EXPORT_CALL
 _lou_extParseDots(const char *inString, widechar *outString);
 
 int EXPORT_CALL
-_lou_translateWithTracing(const char *tableList, const widechar *inbuf, int *inlen,
-		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
-		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
-		int *rulesLen);
+_lou_translate(const char *tableList, const widechar *inbuf, int *inlen, widechar *outbuf,
+		int *outlen, formtype *typeform, char *spacing, int *outputPos, int *inputPos,
+		int *cursorPos, int mode, const TranslationTableRule **rules, int *rulesLen);
 
 int EXPORT_CALL
-_lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int *inlen,
+_lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
 		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
 		int *rulesLen);

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -641,17 +641,31 @@ _lou_defaultTableResolver(const char *tableList, const char *base);
  * TODO: move to commonTranslationFunctions.c
  */
 widechar EXPORT_CALL
-_lou_getDotsForChar(widechar c);
+_lou_getDotsForChar(widechar c, const DisplayTableHeader *table);
 
 /**
  * Return character corresponding to a single-cell dot pattern.
  * TODO: move to commonTranslationFunctions.c
  */
 widechar EXPORT_CALL
-_lou_getCharFromDots(widechar d);
+_lou_getCharFromDots(widechar d, const DisplayTableHeader *table);
 
-DisplayTableHeader *EXPORT_CALL
-_lou_getCurrentDisplayTable();
+void EXPORT_CALL
+_lou_getTable(const char *tableList, const char *displayTableList,
+		const TranslationTableHeader **translationTable,
+		const DisplayTableHeader **displayTable);
+
+const TranslationTableHeader *EXPORT_CALL
+_lou_getTranslationTable(const char *tableList);
+
+const DisplayTableHeader *EXPORT_CALL
+_lou_getDisplayTable(const char *tableList);
+
+int EXPORT_CALL
+_lou_compileTranslationRule(const char *tableList, const char *inString);
+
+int EXPORT_CALL
+_lou_compileDisplayRule(const char *tableList, const char *inString);
 
 /**
  * Allocate memory for internal buffers
@@ -748,15 +762,16 @@ int EXPORT_CALL
 _lou_extParseDots(const char *inString, widechar *outString);
 
 int EXPORT_CALL
-_lou_translate(const char *tableList, const widechar *inbuf, int *inlen, widechar *outbuf,
-		int *outlen, formtype *typeform, char *spacing, int *outputPos, int *inputPos,
-		int *cursorPos, int mode, const TranslationTableRule **rules, int *rulesLen);
+_lou_translate(const char *tableList, const char *displayTableList, const widechar *inbuf,
+		int *inlen, widechar *outbuf, int *outlen, formtype *typeform, char *spacing,
+		int *outputPos, int *inputPos, int *cursorPos, int mode,
+		const TranslationTableRule **rules, int *rulesLen);
 
 int EXPORT_CALL
-_lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
-		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
-		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
-		int *rulesLen);
+_lou_backTranslate(const char *tableList, const char *displayTableList,
+		const widechar *inbuf, int *inlen, widechar *outbuf, int *outlen,
+		formtype *typeform, char *spacing, int *outputPos, int *inputPos, int *cursorPos,
+		int mode, const TranslationTableRule **rules, int *rulesLen);
 
 void EXPORT_CALL
 _lou_resetPassVariables(void);

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -223,7 +223,7 @@ lou_logEnd(void);
  * and by the tools.
  */
 LIBLOUIS_API
-void *EXPORT_CALL
+const void *EXPORT_CALL
 lou_getTable(const char *tableList);
 
 /**

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -140,12 +140,12 @@ int EXPORT_CALL
 lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
 		int *inputPos, int *cursorPos, int modex) {
-	return _lou_backTranslateWithTracing(tableList, inbuf, inlen, outbuf, outlen,
-			typeform, spacing, outputPos, inputPos, cursorPos, modex, NULL, NULL);
+	return _lou_backTranslate(tableList, inbuf, inlen, outbuf, outlen, typeform, spacing,
+			outputPos, inputPos, cursorPos, modex, NULL, NULL);
 }
 
 int EXPORT_CALL
-_lou_backTranslateWithTracing(const char *tableList, const widechar *inbuf, int *inlen,
+_lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
 		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
 		int *rulesLen) {

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -108,21 +108,24 @@ typedef struct {
 } PassRuleMatch;
 
 static int
-backTranslateString(const TranslationTableHeader *table, int mode, int currentPass,
+backTranslateString(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, int currentPass,
 		const InString *input, OutString *output, char *spacebuf, int *posMapping,
 		int *realInlen, int *cursorPosition, int *cursorStatus,
 		const TranslationTableRule **appliedRules, int *appliedRulesCount,
 		int maxAppliedRules);
 static int
-makeCorrections(const TranslationTableHeader *table, int mode, int currentPass,
+makeCorrections(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, int *realInlen,
 		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
 		int *appliedRulesCount, int maxAppliedRules);
 static int
-translatePass(const TranslationTableHeader *table, int mode, int currentPass,
-		const InString *input, OutString *output, int *posMapping, int *realInlen,
-		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
-		int *appliedRulesCount, int maxAppliedRules);
+translatePass(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
+		int mode, int currentPass, const InString *input, OutString *output,
+		int *posMapping, int *realInlen, int *cursorPosition, int *cursorStatus,
+		const TranslationTableRule **appliedRules, int *appliedRulesCount,
+		int maxAppliedRules);
 static void
 passSelectRule(const TranslationTableHeader *table, int pos, int currentPass,
 		const InString *input, TranslationTableOpcode *currentOpcode,
@@ -140,15 +143,17 @@ int EXPORT_CALL
 lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
 		int *inputPos, int *cursorPos, int modex) {
-	return _lou_backTranslate(tableList, inbuf, inlen, outbuf, outlen, typeform, spacing,
-			outputPos, inputPos, cursorPos, modex, NULL, NULL);
+	return _lou_backTranslate(tableList, tableList, inbuf, inlen, outbuf, outlen,
+			typeform, spacing, outputPos, inputPos, cursorPos, modex, NULL, NULL);
 }
 
 int EXPORT_CALL
-_lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
-		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
-		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
-		int *rulesLen) {
+_lou_backTranslate(const char *tableList, const char *displayTableList,
+		const widechar *inbuf, int *inlen, widechar *outbuf, int *outlen,
+		formtype *typeform, char *spacing, int *outputPos, int *inputPos, int *cursorPos,
+		int mode, const TranslationTableRule **rules, int *rulesLen) {
+	const TranslationTableHeader *table;
+	const DisplayTableHeader *displayTable;
 	InString input;
 	OutString output;
 	unsigned char *typebuf = NULL;
@@ -174,7 +179,8 @@ _lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 	if (tableList == NULL || inbuf == NULL || inlen == NULL || outbuf == NULL ||
 			outlen == NULL)
 		return 0;
-	const TranslationTableHeader *table = lou_getTable(tableList);
+	if (displayTableList == NULL) displayTableList = tableList;
+	_lou_getTable(tableList, displayTableList, &table, &displayTable);
 	if (table == NULL) return 0;
 
 	if (!_lou_isValidMode(mode))
@@ -194,8 +200,8 @@ _lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 			if ((mode & dotsIO))
 				passbuf1[k] = inbuf[k] | LOU_DOTS;
 			else
-				passbuf1[k] = _lou_getDotsForChar(inbuf[k]);
-		passbuf1[srcmax] = _lou_getDotsForChar(' ');
+				passbuf1[k] = _lou_getDotsForChar(inbuf[k], displayTable);
+		passbuf1[srcmax] = _lou_getDotsForChar(' ', displayTable);
 		input = (InString){ .chars = passbuf1, .length = srcmax, .bufferIndex = idx };
 	}
 	idx = getStringBuffer(*outlen);
@@ -239,18 +245,19 @@ _lou_backTranslate(const char *tableList, const widechar *inbuf, int *inlen,
 		int realInlen;
 		switch (currentPass) {
 		case 1:
-			goodTrans = backTranslateString(table, mode, currentPass, &input, &output,
-					spacebuf, passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
-					appliedRules, &appliedRulesCount, maxAppliedRules);
+			goodTrans = backTranslateString(table, displayTable, mode, currentPass,
+					&input, &output, spacebuf, passPosMapping, &realInlen,
+					&cursorPosition, &cursorStatus, appliedRules, &appliedRulesCount,
+					maxAppliedRules);
 			break;
 		case 0:
-			goodTrans = makeCorrections(table, mode, currentPass, &input, &output,
-					passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
+			goodTrans = makeCorrections(table, displayTable, mode, currentPass, &input,
+					&output, passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
 					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		default:
-			goodTrans = translatePass(table, mode, currentPass, &input, &output,
-					passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
+			goodTrans = translatePass(table, displayTable, mode, currentPass, &input,
+					&output, passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
 					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		}
@@ -545,9 +552,10 @@ back_passDoTest(const TranslationTableHeader *table, int pos, const InString *in
 		TranslationTableOpcode currentOpcode, const TranslationTableRule *currentRule,
 		const widechar **passInstructions, int *passIC, PassRuleMatch *match);
 static int
-back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase,
+back_passDoAction(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int *pos, int mode, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int *nextUpper, int allUpper, int allUpperPhrase,
 		TranslationTableOpcode currentOpcode, const TranslationTableRule *currentRule,
 		const widechar *passInstructions, int passIC, PassRuleMatch match);
 
@@ -905,9 +913,10 @@ undefinedDots(widechar dots, int mode, OutString *output, int pos, int *posMappi
 }
 
 static int
-putCharacter(widechar dots, const TranslationTableHeader *table, int pos, int mode,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase) {
+putCharacter(widechar dots, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int pos, int mode, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int *nextUpper, int allUpper, int allUpperPhrase) {
 	/* Output character(s) corresponding to a Unicode braille Character */
 	TranslationTableOffset offset = (back_findCharOrDots(dots, 1, table))->definitionRule;
 	if (offset) {
@@ -918,7 +927,7 @@ putCharacter(widechar dots, const TranslationTableHeader *table, int pos, int mo
 			return back_updatePositions(&rule->charsdots[0], rule->dotslen,
 					rule->charslen, table, pos, input, output, posMapping, cursorPosition,
 					cursorStatus, nextUpper, allUpper, allUpperPhrase);
-		c = _lou_getCharFromDots(dots);
+		c = _lou_getCharFromDots(dots, displayTable);
 		return back_updatePositions(&c, 1, 1, table, pos, input, output, posMapping,
 				cursorPosition, cursorStatus, nextUpper, allUpper, allUpperPhrase);
 	}
@@ -927,13 +936,14 @@ putCharacter(widechar dots, const TranslationTableHeader *table, int pos, int mo
 
 static int
 putCharacters(const widechar *characters, int count, const TranslationTableHeader *table,
-		int pos, int mode, const InString *input, OutString *output, int *posMapping,
-		int *cursorPosition, int *cursorStatus, int *nextUpper, int allUpper,
-		int allUpperPhrase) {
+		const DisplayTableHeader *displayTable, int pos, int mode, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int *nextUpper, int allUpper, int allUpperPhrase) {
 	int k;
 	for (k = 0; k < count; k++)
-		if (!putCharacter(characters[k], table, pos, mode, input, output, posMapping,
-					cursorPosition, cursorStatus, nextUpper, allUpper, allUpperPhrase))
+		if (!putCharacter(characters[k], table, displayTable, pos, mode, input, output,
+					posMapping, cursorPosition, cursorStatus, nextUpper, allUpper,
+					allUpperPhrase))
 			return 0;
 	return 1;
 }
@@ -963,7 +973,8 @@ compareChars(const widechar *address1, const widechar *address2, int count, int 
 }
 
 static int
-makeCorrections(const TranslationTableHeader *table, int mode, int currentPass,
+makeCorrections(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, int *realInlen,
 		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
 		int *appliedRulesCount, int maxAppliedRules) {
@@ -1040,8 +1051,8 @@ makeCorrections(const TranslationTableHeader *table, int mode, int currentPass,
 		case CTO_Correct:
 			if (appliedRules != NULL && *appliedRulesCount < maxAppliedRules)
 				appliedRules[(*appliedRulesCount)++] = currentRule;
-			if (!back_passDoAction(table, &pos, mode, input, output, posMapping,
-						cursorPosition, cursorStatus, &nextUpper, allUpper,
+			if (!back_passDoAction(table, displayTable, &pos, mode, input, output,
+						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch))
 				goto failure;
@@ -1056,7 +1067,8 @@ failure:
 }
 
 static int
-backTranslateString(const TranslationTableHeader *table, int mode, int currentPass,
+backTranslateString(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, int currentPass,
 		const InString *input, OutString *output, char *spacebuf, int *posMapping,
 		int *realInlen, int *cursorPosition, int *cursorStatus,
 		const TranslationTableRule **appliedRules, int *appliedRulesCount,
@@ -1182,8 +1194,8 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 		/* replacement processing */
 		switch (currentOpcode) {
 		case CTO_Context:
-			if (!back_passDoAction(table, &pos, mode, input, output, posMapping,
-						cursorPosition, cursorStatus, &nextUpper, allUpper,
+			if (!back_passDoAction(table, displayTable, &pos, mode, input, output,
+						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch))
 				return 0;
@@ -1191,8 +1203,9 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 		case CTO_Replace:
 			while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			if (!putCharacters(&currentRule->charsdots[0], currentRule->charslen, table,
-						pos, mode, input, output, posMapping, cursorPosition,
-						cursorStatus, &nextUpper, allUpper, allUpperPhrase))
+						displayTable, pos, mode, input, output, posMapping,
+						cursorPosition, cursorStatus, &nextUpper, allUpper,
+						allUpperPhrase))
 				goto failure;
 			break;
 		case CTO_None:
@@ -1221,9 +1234,9 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 			} else {
 				int srclim = pos + currentDotslen;
 				while (1) {
-					if (!putCharacter(input->chars[pos], table, pos, mode, input, output,
-								posMapping, cursorPosition, cursorStatus, &nextUpper,
-								allUpper, allUpperPhrase))
+					if (!putCharacter(input->chars[pos], table, displayTable, pos, mode,
+								input, output, posMapping, cursorPosition, cursorStatus,
+								&nextUpper, allUpper, allUpperPhrase))
 						goto failure;
 					if (++pos == srclim) break;
 				}
@@ -1243,8 +1256,8 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 			passSelectRule(table, pos, currentPass, input, &currentOpcode, &currentRule,
 					&passInstructions, &passIC, &patternMatch);
 			if (currentOpcode == CTO_Context) {
-				back_passDoAction(table, &pos, mode, input, output, posMapping,
-						cursorPosition, cursorStatus, &nextUpper, allUpper,
+				back_passDoAction(table, displayTable, &pos, mode, input, output,
+						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch);
 			}
@@ -1475,15 +1488,16 @@ back_passDoTest(const TranslationTableHeader *table, int pos, const InString *in
 }
 
 static int
-copyCharacters(int from, int to, const TranslationTableHeader *table, int mode,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase,
+copyCharacters(int from, int to, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int *nextUpper, int allUpper, int allUpperPhrase,
 		TranslationTableOpcode currentOpcode) {
 	if (currentOpcode == CTO_Context) {
 		while (from < to) {
-			if (!putCharacter(input->chars[from], table, from, mode, input, output,
-						posMapping, cursorPosition, cursorStatus, nextUpper, allUpper,
-						allUpperPhrase))
+			if (!putCharacter(input->chars[from], table, displayTable, from, mode, input,
+						output, posMapping, cursorPosition, cursorStatus, nextUpper,
+						allUpper, allUpperPhrase))
 				return 0;
 			from++;
 		}
@@ -1503,9 +1517,10 @@ copyCharacters(int from, int to, const TranslationTableHeader *table, int mode,
 }
 
 static int
-back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase,
+back_passDoAction(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int *pos, int mode, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int *nextUpper, int allUpper, int allUpperPhrase,
 		TranslationTableOpcode currentOpcode, const TranslationTableRule *currentRule,
 		const widechar *passInstructions, int passIC, PassRuleMatch match) {
 	int k;
@@ -1513,9 +1528,9 @@ back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
 	int destStartReplace;
 	int newPos = match.endReplace;
 
-	if (!copyCharacters(match.startMatch, match.startReplace, table, mode, input, output,
-				posMapping, cursorPosition, cursorStatus, nextUpper, allUpper,
-				allUpperPhrase, currentOpcode))
+	if (!copyCharacters(match.startMatch, match.startReplace, table, displayTable, mode,
+				input, output, posMapping, cursorPosition, cursorStatus, nextUpper,
+				allUpper, allUpperPhrase, currentOpcode))
 		return 0;
 	destStartReplace = output->length;
 
@@ -1550,9 +1565,9 @@ back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
 			}
 		}
 
-			if (!copyCharacters(match.startReplace, match.endReplace, table, mode, input,
-						output, posMapping, cursorPosition, cursorStatus, nextUpper,
-						allUpper, allUpperPhrase, currentOpcode))
+			if (!copyCharacters(match.startReplace, match.endReplace, table, displayTable,
+						mode, input, output, posMapping, cursorPosition, cursorStatus,
+						nextUpper, allUpper, allUpperPhrase, currentOpcode))
 				return 0;
 			newPos = match.endMatch;
 			passIC++;
@@ -1577,10 +1592,11 @@ passSelectRule(const TranslationTableHeader *table, int pos, int currentPass,
 }
 
 static int
-translatePass(const TranslationTableHeader *table, int mode, int currentPass,
-		const InString *input, OutString *output, int *posMapping, int *realInlen,
-		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
-		int *appliedRulesCount, int maxAppliedRules) {
+translatePass(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
+		int mode, int currentPass, const InString *input, OutString *output,
+		int *posMapping, int *realInlen, int *cursorPosition, int *cursorStatus,
+		const TranslationTableRule **appliedRules, int *appliedRulesCount,
+		int maxAppliedRules) {
 	int pos;
 	int nextUpper = 0;
 	int allUpper = 0;
@@ -1601,8 +1617,8 @@ translatePass(const TranslationTableHeader *table, int mode, int currentPass,
 		case CTO_Pass4:
 			if (appliedRules != NULL && *appliedRulesCount < maxAppliedRules)
 				appliedRules[(*appliedRulesCount)++] = currentRule;
-			if (!back_passDoAction(table, &pos, mode, input, output, posMapping,
-						cursorPosition, cursorStatus, &nextUpper, allUpper,
+			if (!back_passDoAction(table, displayTable, &pos, mode, input, output,
+						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch))
 				goto failure;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1065,12 +1065,12 @@ int EXPORT_CALL
 lou_translate(const char *tableList, const widechar *inbufx, int *inlen, widechar *outbuf,
 		int *outlen, formtype *typeform, char *spacing, int *outputPos, int *inputPos,
 		int *cursorPos, int mode) {
-	return _lou_translateWithTracing(tableList, inbufx, inlen, outbuf, outlen, typeform,
-			spacing, outputPos, inputPos, cursorPos, mode, NULL, NULL);
+	return _lou_translate(tableList, inbufx, inlen, outbuf, outlen, typeform, spacing,
+			outputPos, inputPos, cursorPos, mode, NULL, NULL);
 }
 
 int EXPORT_CALL
-_lou_translateWithTracing(const char *tableList, const widechar *inbufx, int *inlen,
+_lou_translate(const char *tableList, const widechar *inbufx, int *inlen,
 		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
 		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
 		int *rulesLen) {

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -123,17 +123,18 @@ typedef struct {
 } PassRuleMatch;
 
 static int
-putCharacter(widechar c, const TranslationTableHeader *table, int pos,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int mode);
+putCharacter(widechar c, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int pos, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int mode);
 static int
 passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 		int transOpcode, const TranslationTableRule *transRule, int *passCharDots,
 		const widechar **passInstructions, int *passIC, PassRuleMatch *match,
 		TranslationTableRule **groupingRule, widechar *groupingOp);
 static int
-passDoAction(const TranslationTableHeader *table, const InString **input,
-		OutString *output, int *posMapping, int transOpcode,
+passDoAction(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
+		const InString **input, OutString *output, int *posMapping, int transOpcode,
 		const TranslationTableRule **transRule, int passCharDots,
 		const widechar *passInstructions, int passIC, int *pos, PassRuleMatch match,
 		int *cursorPosition, int *cursorStatus, TranslationTableRule *groupingRule,
@@ -222,9 +223,10 @@ compareChars(const widechar *address1, const widechar *address2, int count, int 
 }
 
 static int
-makeCorrections(const TranslationTableHeader *table, const InString *input,
-		OutString *output, int *posMapping, formtype *typebuf, int *realInlen,
-		int *posIncremented, int *cursorPosition, int *cursorStatus, int mode) {
+makeCorrections(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, const InString *input, OutString *output,
+		int *posMapping, formtype *typebuf, int *realInlen, int *posIncremented,
+		int *cursorPosition, int *cursorStatus, int mode) {
 	int pos;
 	int transOpcode;
 	const TranslationTableRule *transRule;
@@ -299,9 +301,10 @@ makeCorrections(const TranslationTableHeader *table, const InString *input,
 			int posBefore = pos;
 			if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 				appliedRules[appliedRulesCount++] = transRule;
-			if (!passDoAction(table, &input, output, posMapping, transOpcode, &transRule,
-						passCharDots, passInstructions, passIC, &pos, patternMatch,
-						cursorPosition, cursorStatus, groupingRule, groupingOp, mode))
+			if (!passDoAction(table, displayTable, &input, output, posMapping,
+						transOpcode, &transRule, passCharDots, passInstructions, passIC,
+						&pos, patternMatch, cursorPosition, cursorStatus, groupingRule,
+						groupingOp, mode))
 				goto failure;
 			if (input->bufferIndex != inputBefore->bufferIndex &&
 					inputBefore->bufferIndex != origInput->bufferIndex)
@@ -853,12 +856,13 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 
 static int
 copyCharacters(int from, int to, const TranslationTableHeader *table,
-		const InString *input, OutString *output, int *posMapping, int transOpcode,
-		int *cursorPosition, int *cursorStatus, int mode) {
+		const DisplayTableHeader *displayTable, const InString *input, OutString *output,
+		int *posMapping, int transOpcode, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	if (transOpcode == CTO_Context) {
 		while (from < to) {
-			if (!putCharacter(input->chars[from], table, from, input, output, posMapping,
-						cursorPosition, cursorStatus, mode))
+			if (!putCharacter(input->chars[from], table, displayTable, from, input,
+						output, posMapping, cursorPosition, cursorStatus, mode))
 				return 0;
 			from++;
 		}
@@ -878,8 +882,8 @@ copyCharacters(int from, int to, const TranslationTableHeader *table,
 }
 
 static int
-passDoAction(const TranslationTableHeader *table, const InString **input,
-		OutString *output, int *posMapping, int transOpcode,
+passDoAction(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
+		const InString **input, OutString *output, int *posMapping, int transOpcode,
 		const TranslationTableRule **transRule, int passCharDots,
 		const widechar *passInstructions, int passIC, int *pos, PassRuleMatch match,
 		int *cursorPosition, int *cursorStatus, TranslationTableRule *groupingRule,
@@ -891,8 +895,8 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 	int destStartReplace;
 	int newPos = match.endReplace;
 
-	if (!copyCharacters(match.startMatch, match.startReplace, table, *input, output,
-				posMapping, transOpcode, cursorPosition, cursorStatus, mode))
+	if (!copyCharacters(match.startMatch, match.startReplace, table, displayTable, *input,
+				output, posMapping, transOpcode, cursorPosition, cursorStatus, mode))
 		return 0;
 	destStartReplace = output->length;
 
@@ -954,9 +958,9 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 			}
 		}
 
-			if (!copyCharacters(match.startReplace, match.endReplace, table, *input,
-						output, posMapping, transOpcode, cursorPosition, cursorStatus,
-						mode))
+			if (!copyCharacters(match.startReplace, match.endReplace, table, displayTable,
+						*input, output, posMapping, transOpcode, cursorPosition,
+						cursorStatus, mode))
 				return 0;
 			newPos = match.endMatch;
 			passIC++;
@@ -983,9 +987,10 @@ passSelectRule(const TranslationTableHeader *table, int pos, int currentPass,
 }
 
 static int
-translatePass(const TranslationTableHeader *table, int currentPass, const InString *input,
-		OutString *output, int *posMapping, int *realInlen, int *posIncremented,
-		int *cursorPosition, int *cursorStatus, int mode) {
+translatePass(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
+		int currentPass, const InString *input, OutString *output, int *posMapping,
+		int *realInlen, int *posIncremented, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	int pos;
 	int transOpcode;
 	const TranslationTableRule *transRule;
@@ -1014,9 +1019,10 @@ translatePass(const TranslationTableHeader *table, int currentPass, const InStri
 			int posBefore = pos;
 			if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 				appliedRules[appliedRulesCount++] = transRule;
-			if (!passDoAction(table, &input, output, posMapping, transOpcode, &transRule,
-						passCharDots, passInstructions, passIC, &pos, patternMatch,
-						cursorPosition, cursorStatus, groupingRule, groupingOp, mode))
+			if (!passDoAction(table, displayTable, &input, output, posMapping,
+						transOpcode, &transRule, passCharDots, passInstructions, passIC,
+						&pos, patternMatch, cursorPosition, cursorStatus, groupingRule,
+						groupingOp, mode))
 				goto failure;
 			if (input->bufferIndex != inputBefore->bufferIndex &&
 					inputBefore->bufferIndex != origInput->bufferIndex)
@@ -1047,7 +1053,8 @@ failure:
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 static int
-translateString(const TranslationTableHeader *table, int mode, int currentPass,
+translateString(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, formtype *typebuf,
 		unsigned char *srcSpacing, unsigned char *destSpacing, unsigned int *wordBuffer,
 		EmphasisInfo *emphasisBuffer, int haveEmphasis, int *realInlen,
@@ -1065,15 +1072,15 @@ int EXPORT_CALL
 lou_translate(const char *tableList, const widechar *inbufx, int *inlen, widechar *outbuf,
 		int *outlen, formtype *typeform, char *spacing, int *outputPos, int *inputPos,
 		int *cursorPos, int mode) {
-	return _lou_translate(tableList, inbufx, inlen, outbuf, outlen, typeform, spacing,
-			outputPos, inputPos, cursorPos, mode, NULL, NULL);
+	return _lou_translate(tableList, tableList, inbufx, inlen, outbuf, outlen, typeform,
+			spacing, outputPos, inputPos, cursorPos, mode, NULL, NULL);
 }
 
 int EXPORT_CALL
-_lou_translate(const char *tableList, const widechar *inbufx, int *inlen,
-		widechar *outbuf, int *outlen, formtype *typeform, char *spacing, int *outputPos,
-		int *inputPos, int *cursorPos, int mode, const TranslationTableRule **rules,
-		int *rulesLen) {
+_lou_translate(const char *tableList, const char *displayTableList,
+		const widechar *inbufx, int *inlen, widechar *outbuf, int *outlen,
+		formtype *typeform, char *spacing, int *outputPos, int *inputPos, int *cursorPos,
+		int mode, const TranslationTableRule **rules, int *rulesLen) {
 	// int i;
 	// for(i = 0; i < *inlen; i++)
 	// {
@@ -1087,6 +1094,7 @@ _lou_translate(const char *tableList, const widechar *inbufx, int *inlen,
 	// *outlen = i;
 	// return 1;
 	const TranslationTableHeader *table;
+	const DisplayTableHeader *displayTable;
 	InString input;
 	OutString output;
 	// posMapping contains position mapping info between the initial input and the output
@@ -1122,7 +1130,8 @@ _lou_translate(const char *tableList, const widechar *inbufx, int *inlen,
 	if (!_lou_isValidMode(mode))
 		_lou_logMessage(LOU_LOG_ERROR, "Invalid mode parameter: %d", mode);
 
-	table = lou_getTable(tableList);
+	if (displayTableList == NULL) displayTableList = tableList;
+	_lou_getTable(tableList, displayTableList, &table, &displayTable);
 	if (table == NULL || *inlen < 0 || *outlen < 0) return 0;
 	k = 0;
 	while (k < *inlen && inbufx[k]) k++;
@@ -1216,19 +1225,21 @@ _lou_translate(const char *tableList, const widechar *inbufx, int *inlen,
 		int realInlen;
 		switch (currentPass) {
 		case 0:
-			goodTrans = makeCorrections(table, &input, &output, passPosMapping, typebuf,
-					&realInlen, &posIncremented, &cursorPosition, &cursorStatus, mode);
+			goodTrans = makeCorrections(table, displayTable, &input, &output,
+					passPosMapping, typebuf, &realInlen, &posIncremented, &cursorPosition,
+					&cursorStatus, mode);
 			break;
 		case 1: {
-			goodTrans = translateString(table, mode, currentPass, &input, &output,
-					passPosMapping, typebuf, srcSpacing, destSpacing, wordBuffer,
+			goodTrans = translateString(table, displayTable, mode, currentPass, &input,
+					&output, passPosMapping, typebuf, srcSpacing, destSpacing, wordBuffer,
 					emphasisBuffer, haveEmphasis, &realInlen, &posIncremented,
 					&cursorPosition, &cursorStatus, compbrlStart, compbrlEnd);
 			break;
 		}
 		default:
-			goodTrans = translatePass(table, currentPass, &input, &output, passPosMapping,
-					&realInlen, &posIncremented, &cursorPosition, &cursorStatus, mode);
+			goodTrans = translatePass(table, displayTable, currentPass, &input, &output,
+					passPosMapping, &realInlen, &posIncremented, &cursorPosition,
+					&cursorStatus, mode);
 			break;
 		}
 		passPosMapping[output.length] = realInlen;
@@ -1273,7 +1284,7 @@ _lou_translate(const char *tableList, const widechar *inbufx, int *inlen,
 				else
 					outbuf[k] = output.chars[k];
 			} else
-				outbuf[k] = _lou_getCharFromDots(output.chars[k]);
+				outbuf[k] = _lou_getCharFromDots(output.chars[k], displayTable);
 		}
 		*inlen = posMapping[output.length];
 		*outlen = output.length;
@@ -1430,10 +1441,11 @@ hyphenateWord(const widechar *word, int wordSize, char *hyphens,
 }
 
 static int
-doCompTrans(int start, int end, const TranslationTableHeader *table, int *pos,
-		const InString *input, OutString *output, int *posMapping,
-		EmphasisInfo *emphasisBuffer, const TranslationTableRule **transRule,
-		int *cursorPosition, int *cursorStatus, int mode);
+doCompTrans(int start, int end, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int *pos, const InString *input,
+		OutString *output, int *posMapping, EmphasisInfo *emphasisBuffer,
+		const TranslationTableRule **transRule, int *cursorPosition, int *cursorStatus,
+		int mode);
 
 static int
 for_updatePositions(const widechar *outChars, int inLength, int outLength, int shift,
@@ -2206,9 +2218,10 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output, i
 }
 
 static int
-undefinedCharacter(widechar c, const TranslationTableHeader *table, int pos,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int mode) {
+undefinedCharacter(widechar c, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int pos, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	/* Display an undefined character in the output buffer */
 	if (table->undefined) {
 		TranslationTableRule *rule =
@@ -2225,7 +2238,7 @@ undefinedCharacter(widechar c, const TranslationTableHeader *table, int pos,
 
 	for (unsigned int k = 0; k < length; k += 1) {
 		widechar c = text[k];
-		widechar d = _lou_getDotsForChar(c);
+		widechar d = _lou_getDotsForChar(c, displayTable);
 		if (d == LOU_DOTS) d = _lou_charToFallbackDots(c);
 		dots[k] = d;
 	}
@@ -2235,9 +2248,10 @@ undefinedCharacter(widechar c, const TranslationTableHeader *table, int pos,
 }
 
 static int
-putCharacter(widechar character, const TranslationTableHeader *table, int pos,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int mode) {
+putCharacter(widechar character, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int pos, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	/* Insert the dots equivalent of a character into the output buffer */
 	const TranslationTableRule *rule = NULL;
 	TranslationTableCharacter *chardef = NULL;
@@ -2255,24 +2269,25 @@ putCharacter(widechar character, const TranslationTableHeader *table, int pos,
 		if (rule->dotslen)
 			return for_updatePositions(&rule->charsdots[1], 1, rule->dotslen, 0, pos,
 					input, output, posMapping, cursorPosition, cursorStatus);
-		d = _lou_getDotsForChar(character);
+		d = _lou_getDotsForChar(character, displayTable);
 		return for_updatePositions(&d, 1, 1, 0, pos, input, output, posMapping,
 				cursorPosition, cursorStatus);
 	}
-	return undefinedCharacter(character, table, pos, input, output, posMapping,
-			cursorPosition, cursorStatus, mode);
+	return undefinedCharacter(character, table, displayTable, pos, input, output,
+			posMapping, cursorPosition, cursorStatus, mode);
 }
 
 static int
 putCharacters(const widechar *characters, int count, const TranslationTableHeader *table,
-		int pos, const InString *input, OutString *output, int *posMapping,
-		int *cursorPosition, int *cursorStatus, int mode) {
+		const DisplayTableHeader *displayTable, int pos, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	/* Insert the dot equivalents of a series of characters in the output
 	 * buffer */
 	int k;
 	for (k = 0; k < count; k++)
-		if (!putCharacter(characters[k], table, pos, input, output, posMapping,
-					cursorPosition, cursorStatus, mode))
+		if (!putCharacter(characters[k], table, displayTable, pos, input, output,
+					posMapping, cursorPosition, cursorStatus, mode))
 			return 0;
 	return 1;
 }
@@ -2287,10 +2302,11 @@ typedef struct {
 } LastWord;
 
 static int
-doCompbrl(const TranslationTableHeader *table, int *pos, const InString *input,
-		OutString *output, int *posMapping, EmphasisInfo *emphasisBuffer,
-		const TranslationTableRule **transRule, int *cursorPosition, int *cursorStatus,
-		const LastWord *lastWord, int *insertEmphasesFrom, int mode) {
+doCompbrl(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
+		int *pos, const InString *input, OutString *output, int *posMapping,
+		EmphasisInfo *emphasisBuffer, const TranslationTableRule **transRule,
+		int *cursorPosition, int *cursorStatus, const LastWord *lastWord,
+		int *insertEmphasesFrom, int mode) {
 	/* Handle strings containing substrings defined by the compbrl opcode */
 	int stringStart, stringEnd;
 	if (checkAttr(input->chars[*pos], CTC_Space, 0, table)) return 1;
@@ -2307,14 +2323,15 @@ doCompbrl(const TranslationTableHeader *table, int *pos, const InString *input,
 	stringStart++;
 	for (stringEnd = *pos; stringEnd < input->length; stringEnd++)
 		if (checkAttr(input->chars[stringEnd], CTC_Space, 0, table)) break;
-	return doCompTrans(stringStart, stringEnd, table, pos, input, output, posMapping,
-			emphasisBuffer, transRule, cursorPosition, cursorStatus, mode);
+	return doCompTrans(stringStart, stringEnd, table, displayTable, pos, input, output,
+			posMapping, emphasisBuffer, transRule, cursorPosition, cursorStatus, mode);
 }
 
 static int
-putCompChar(widechar character, const TranslationTableHeader *table, int pos,
-		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
-		int *cursorStatus, int mode) {
+putCompChar(widechar character, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int pos, const InString *input,
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	/* Insert the dots equivalent of a character into the output buffer */
 	widechar d;
 	TranslationTableOffset offset = (findCharOrDots(character, 0, table))->definitionRule;
@@ -2324,19 +2341,20 @@ putCompChar(widechar character, const TranslationTableHeader *table, int pos,
 		if (rule->dotslen)
 			return for_updatePositions(&rule->charsdots[1], 1, rule->dotslen, 0, pos,
 					input, output, posMapping, cursorPosition, cursorStatus);
-		d = _lou_getDotsForChar(character);
+		d = _lou_getDotsForChar(character, displayTable);
 		return for_updatePositions(&d, 1, 1, 0, pos, input, output, posMapping,
 				cursorPosition, cursorStatus);
 	}
-	return undefinedCharacter(character, table, pos, input, output, posMapping,
-			cursorPosition, cursorStatus, mode);
+	return undefinedCharacter(character, table, displayTable, pos, input, output,
+			posMapping, cursorPosition, cursorStatus, mode);
 }
 
 static int
-doCompTrans(int start, int end, const TranslationTableHeader *table, int *pos,
-		const InString *input, OutString *output, int *posMapping,
-		EmphasisInfo *emphasisBuffer, const TranslationTableRule **transRule,
-		int *cursorPosition, int *cursorStatus, int mode) {
+doCompTrans(int start, int end, const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int *pos, const InString *input,
+		OutString *output, int *posMapping, EmphasisInfo *emphasisBuffer,
+		const TranslationTableRule **transRule, int *cursorPosition, int *cursorStatus,
+		int mode) {
 	const TranslationTableRule *indicRule;
 	int k;
 	int haveEndsegment = 0;
@@ -2362,8 +2380,8 @@ doCompTrans(int start, int end, const TranslationTableHeader *table, int *pos,
 						(*transRule)->charslen, (*transRule)->dotslen, 0, *pos, input,
 						output, posMapping, cursorPosition, cursorStatus))
 				return 0;
-		} else if (!putCompChar(input->chars[k], table, *pos, input, output, posMapping,
-						   cursorPosition, cursorStatus, mode))
+		} else if (!putCompChar(input->chars[k], table, displayTable, *pos, input, output,
+						   posMapping, cursorPosition, cursorStatus, mode))
 			return 0;
 	}
 	if (*cursorStatus != 2 && brailleIndicatorDefined(table->endComp, table, &indicRule))
@@ -3340,7 +3358,8 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 }
 
 static int
-translateString(const TranslationTableHeader *table, int mode, int currentPass,
+translateString(const TranslationTableHeader *table,
+		const DisplayTableHeader *displayTable, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, formtype *typebuf,
 		unsigned char *srcSpacing, unsigned char *destSpacing, unsigned int *wordBuffer,
 		EmphasisInfo *emphasisBuffer, int haveEmphasis, int *realInlen,
@@ -3393,8 +3412,9 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 	while (pos < input->length) { /* the main translation loop */
 		if ((pos >= compbrlStart) && (pos < compbrlEnd)) {
 			int cs = 2;  // cursor status for this call
-			if (!doCompTrans(pos, compbrlEnd, table, &pos, input, output, posMapping,
-						emphasisBuffer, &transRule, cursorPosition, &cs, mode))
+			if (!doCompTrans(pos, compbrlEnd, table, displayTable, &pos, input, output,
+						posMapping, emphasisBuffer, &transRule, cursorPosition, &cs,
+						mode))
 				goto failure;
 			continue;
 		}
@@ -3410,7 +3430,7 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		// insertEmphases();
 		if (!dontContract) dontContract = typebuf[pos] & no_contract;
 		if (typebuf[pos] & no_translate) {
-			widechar c = _lou_getDotsForChar(input->chars[pos]);
+			widechar c = _lou_getDotsForChar(input->chars[pos], displayTable);
 			if (input->chars[pos] < 32 || input->chars[pos] > 126) goto failure;
 			if (!for_updatePositions(&c, 1, 1, 0, pos, input, output, posMapping,
 						cursorPosition, cursorStatus))
@@ -3435,9 +3455,9 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		{
 		case CTO_CompBrl:
 		case CTO_Literal:
-			if (!doCompbrl(table, &pos, input, output, posMapping, emphasisBuffer,
-						&transRule, cursorPosition, cursorStatus, &lastWord,
-						&insertEmphasesFrom, mode))
+			if (!doCompbrl(table, displayTable, &pos, input, output, posMapping,
+						emphasisBuffer, &transRule, cursorPosition, cursorStatus,
+						&lastWord, &insertEmphasesFrom, mode))
 				goto failure;
 			continue;
 		default:
@@ -3471,10 +3491,10 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 				int posBefore = pos;
 				if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 					appliedRules[appliedRulesCount++] = transRule;
-				if (!passDoAction(table, &input, output, posMapping, transOpcode,
-							&transRule, passCharDots, passInstructions, passIC, &pos,
-							patternMatch, cursorPosition, cursorStatus, groupingRule,
-							groupingOp, mode))
+				if (!passDoAction(table, displayTable, &input, output, posMapping,
+							transOpcode, &transRule, passCharDots, passInstructions,
+							passIC, &pos, patternMatch, cursorPosition, cursorStatus,
+							groupingRule, groupingOp, mode))
 					goto failure;
 				if (input->bufferIndex != inputBefore->bufferIndex &&
 						inputBefore->bufferIndex != origInput->bufferIndex)
@@ -3543,13 +3563,13 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		case CTO_Replace:
 			pos += transCharslen;
 			if (!putCharacters(&transRule->charsdots[transCharslen], transRule->dotslen,
-						table, pos, input, output, posMapping, cursorPosition,
-						cursorStatus, mode))
+						table, displayTable, pos, input, output, posMapping,
+						cursorPosition, cursorStatus, mode))
 				goto failure;
 			break;
 		case CTO_None:
-			if (!undefinedCharacter(input->chars[pos], table, pos, input, output,
-						posMapping, cursorPosition, cursorStatus, mode))
+			if (!undefinedCharacter(input->chars[pos], table, displayTable, pos, input,
+						output, posMapping, cursorPosition, cursorStatus, mode))
 				goto failure;
 			pos++;
 			break;
@@ -3558,8 +3578,8 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 			 * the table defines a capital sign. */
 			if (!(mode & (compbrlAtCursor | compbrlLeftCursor)) &&
 					(transRule->dotslen == 1 && capsletterDefined(table))) {
-				if (!putCharacter(curCharDef->lowercase, table, pos, input, output,
-							posMapping, cursorPosition, cursorStatus, mode))
+				if (!putCharacter(curCharDef->lowercase, table, displayTable, pos, input,
+							output, posMapping, cursorPosition, cursorStatus, mode))
 					goto failure;
 				pos++;
 				break;
@@ -3580,8 +3600,8 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 				pos += transCharslen;
 			} else {
 				for (k = 0; k < transCharslen; k++) {
-					if (!putCharacter(input->chars[pos], table, pos, input, output,
-								posMapping, cursorPosition, cursorStatus, mode))
+					if (!putCharacter(input->chars[pos], table, displayTable, pos, input,
+								output, posMapping, cursorPosition, cursorStatus, mode))
 						goto failure;
 					pos++;
 				}
@@ -3796,19 +3816,19 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 int EXPORT_CALL
 lou_dotsToChar(
 		const char *tableList, widechar *inbuf, widechar *outbuf, int length, int mode) {
-	const TranslationTableHeader *table;
+	const DisplayTableHeader *table;
 	int k;
 	widechar dots;
 	if (tableList == NULL || inbuf == NULL || outbuf == NULL) return 0;
 
-	table = lou_getTable(tableList);
+	table = _lou_getDisplayTable(tableList);
 	if (table == NULL || length <= 0) return 0;
 	for (k = 0; k < length; k++) {
 		dots = inbuf[k];
 		if (!(dots & LOU_DOTS) &&
 				(dots & 0xff00) == LOU_ROW_BRAILLE) /* Unicode braille */
 			dots = (dots & 0x00ff) | LOU_DOTS;
-		outbuf[k] = _lou_getCharFromDots(dots);
+		outbuf[k] = _lou_getCharFromDots(dots, table);
 	}
 	return 1;
 }
@@ -3816,16 +3836,16 @@ lou_dotsToChar(
 int EXPORT_CALL
 lou_charToDots(const char *tableList, const widechar *inbuf, widechar *outbuf, int length,
 		int mode) {
-	const TranslationTableHeader *table;
+	const DisplayTableHeader *table;
 	int k;
 	if (tableList == NULL || inbuf == NULL || outbuf == NULL) return 0;
 
-	table = lou_getTable(tableList);
+	table = _lou_getDisplayTable(tableList);
 	if (table == NULL || length <= 0) return 0;
 	for (k = 0; k < length; k++)
 		if ((mode & ucBrl))
-			outbuf[k] = ((_lou_getDotsForChar(inbuf[k]) & 0xff) | LOU_ROW_BRAILLE);
+			outbuf[k] = ((_lou_getDotsForChar(inbuf[k], table) & 0xff) | LOU_ROW_BRAILLE);
 		else
-			outbuf[k] = _lou_getDotsForChar(inbuf[k]);
+			outbuf[k] = _lou_getDotsForChar(inbuf[k], table);
 	return 1;
 }

--- a/liblouis/maketable.c
+++ b/liblouis/maketable.c
@@ -24,10 +24,11 @@
 #include "internal.h"
 
 static const TranslationTableHeader *table;
+static const DisplayTableHeader *displayTable;
 
 extern void
 loadTable(const char *tableList) {
-	table = lou_getTable(tableList);
+	_lou_getTable(tableList, tableList, &table, &displayTable);
 }
 
 extern int
@@ -71,7 +72,7 @@ toDotPattern(widechar *braille, char *pattern) {
 	for (length = 0; braille[length]; length++)
 		;
 	dots = (widechar *)malloc((length + 1) * sizeof(widechar));
-	for (i = 0; i < length; i++) dots[i] = _lou_getDotsForChar(braille[i]);
+	for (i = 0; i < length; i++) dots[i] = _lou_getDotsForChar(braille[i], displayTable);
 	strcpy(pattern, _lou_showDots(dots, length));
 	free(dots);
 }
@@ -95,7 +96,8 @@ printRule(TranslationTableRule *rule, widechar *rule_string) {
 		for (int k = 0; k < rule->charslen; k++) rule_string[l++] = rule->charsdots[k];
 		rule_string[l++] = ' ';
 		for (int k = 0; k < rule->dotslen; k++)
-			rule_string[l++] = _lou_getCharFromDots(rule->charsdots[rule->charslen + k]);
+			rule_string[l++] = _lou_getCharFromDots(
+					rule->charsdots[rule->charslen + k], displayTable);
 		rule_string[l++] = '\0';
 		return 1;
 	}
@@ -229,8 +231,8 @@ find_matching_rules(widechar *text, int text_len, widechar *braille, int braille
 					(rule->dotslen == braille_len && rule->charslen < text_len))
 				goto inhibit;
 			for (k = 0; k < rule->dotslen; k++)
-				if (_lou_getCharFromDots(rule->charsdots[rule->charslen + k]) !=
-						braille[k])
+				if (_lou_getCharFromDots(rule->charsdots[rule->charslen + k],
+							displayTable) != braille[k])
 					goto inhibit;
 
 			/* don't let this rule be inhibited by an earlier rule */

--- a/tests/braille-specs/da-dk-g18.yaml
+++ b/tests/braille-specs/da-dk-g18.yaml
@@ -1,3 +1,6 @@
+# The display tables have been separated from the translation tables. But in
+# the case of this test some display relevant stuff is still defined in the
+# translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,da-dk-g18.ctb
 table:
   locale: da

--- a/tests/braille-specs/da-dk-g18.yaml
+++ b/tests/braille-specs/da-dk-g18.yaml
@@ -1,4 +1,4 @@
-display: unicode-without-blank.dis
+display: unicode-without-blank.dis,da-dk-g18.ctb
 table:
   locale: da
   grade: 1

--- a/tests/braille-specs/fr-bfu-comp6.yaml
+++ b/tests/braille-specs/fr-bfu-comp6.yaml
@@ -1,3 +1,6 @@
+# The display tables have been separated from the translation tables. But in
+# the case of this test some display relevant stuff is still defined in the
+# translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,fr-bfu-comp6.utb
 table:
   locale: fr

--- a/tests/braille-specs/fr-bfu-comp6.yaml
+++ b/tests/braille-specs/fr-bfu-comp6.yaml
@@ -1,4 +1,4 @@
-display: unicode-without-blank.dis
+display: unicode-without-blank.dis,fr-bfu-comp6.utb
 table:
   locale: fr
   type: literary

--- a/tests/braille-specs/fr-bfu-g2.yaml
+++ b/tests/braille-specs/fr-bfu-g2.yaml
@@ -1,3 +1,6 @@
+# The display tables have been separated from the translation tables. But in
+# the case of this test some display relevant stuff is still defined in the
+# translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,fr-bfu-g2.ctb
 table:
   locale: fr

--- a/tests/braille-specs/fr-bfu-g2.yaml
+++ b/tests/braille-specs/fr-bfu-g2.yaml
@@ -1,4 +1,4 @@
-display: unicode-without-blank.dis
+display: unicode-without-blank.dis,fr-bfu-g2.ctb
 table:
   locale: fr
   grade: 2

--- a/tests/braille-specs/no_harness.yaml
+++ b/tests/braille-specs/no_harness.yaml
@@ -1,3 +1,6 @@
+# The display tables have been separated from the translation tables. But in
+# the case of this test some display relevant stuff is still defined in the
+# translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,no-no-g0.utb
 table:
   locale: no

--- a/tests/braille-specs/no_harness.yaml
+++ b/tests/braille-specs/no_harness.yaml
@@ -1,4 +1,4 @@
-display: unicode-without-blank.dis
+display: unicode-without-blank.dis,no-no-g0.utb
 table:
   locale: no
   grade: 0
@@ -719,15 +719,15 @@ tests:
   -
     - • Før kunne foreldre og elever søke om fritak fra faget kristendom. Da fikk elevene faget alternativ livssynsundervisning i stedet.
     - ⠶ ⠠⠋⠪⠗ ⠅⠥⠝⠝⠑ ⠋⠕⠗⠑⠇⠙⠗⠑ ⠕⠛ ⠑⠇⠑⠧⠑⠗ ⠎⠪⠅⠑ ⠕⠍ ⠋⠗⠊⠞⠁⠅ ⠋⠗⠁ ⠋⠁⠛⠑⠞ ⠅⠗⠊⠎⠞⠑⠝⠙⠕⠍⠄ ⠠⠙⠁ ⠋⠊⠅⠅ ⠑⠇⠑⠧⠑⠝⠑ ⠋⠁⠛⠑⠞ ⠁⠇⠞⠑⠗⠝⠁⠞⠊⠧ ⠇⠊⠧⠎⠎⠽⠝⠎⠥⠝⠙⠑⠗⠧⠊⠎⠝⠊⠝⠛ ⠊ ⠎⠞⠑⠙⠑⠞⠄
-    - {xfail: true}
+    - {xfail: "the nbsp comes out untranslated instead of being translated to a simple space"}
   -
     - '• I 1997 ble de to fagene slått sammen til ett fag: kristendoms-, religions- og livssynskunnskap (KRL).'
     - ⠶ ⠠⠊ ⠼⠁⠊⠊⠛ ⠃⠇⠑ ⠙⠑ ⠞⠕ ⠋⠁⠛⠑⠝⠑ ⠎⠇⠡⠞⠞ ⠎⠁⠍⠍⠑⠝ ⠞⠊⠇ ⠑⠞⠞ ⠋⠁⠛⠒ ⠅⠗⠊⠎⠞⠑⠝⠙⠕⠍⠎⠤⠂ ⠗⠑⠇⠊⠛⠊⠕⠝⠎⠤ ⠕⠛ ⠇⠊⠧⠎⠎⠽⠝⠎⠅⠥⠝⠝⠎⠅⠁⠏ ⠦⠠⠠⠅⠗⠇⠴⠄
-    - {xfail: true}
+    - {xfail: "the nbsp comes out untranslated instead of being translated to a simple space"}
   -
     - • Det ble gjort mindre endringer i KRL-faget i 2001 og 2005, og det ble enklere å søke om fritak fra aktiviteter i faget.
     - ⠶ ⠠⠙⠑⠞ ⠃⠇⠑ ⠛⠚⠕⠗⠞ ⠍⠊⠝⠙⠗⠑ ⠑⠝⠙⠗⠊⠝⠛⠑⠗ ⠊ ⠠⠠⠅⠗⠇⠤⠋⠁⠛⠑⠞ ⠊ ⠼⠃⠚⠚⠁ ⠕⠛ ⠼⠃⠚⠚⠑⠂ ⠕⠛ ⠙⠑⠞ ⠃⠇⠑ ⠑⠝⠅⠇⠑⠗⠑ ⠡ ⠎⠪⠅⠑ ⠕⠍ ⠋⠗⠊⠞⠁⠅ ⠋⠗⠁ ⠁⠅⠞⠊⠧⠊⠞⠑⠞⠑⠗ ⠊ ⠋⠁⠛⠑⠞⠄
-    - {xfail: true}
+    - {xfail: "the nbsp comes out untranslated instead of being translated to a simple space"}
   # Footnotes and endnotes
   - ['Skolen ble åpnet i den franske hovedstaden i 1784,*', ⠠⠎⠅⠕⠇⠑⠝ ⠃⠇⠑ ⠡⠏⠝⠑⠞ ⠊ ⠙⠑⠝ ⠋⠗⠁⠝⠎⠅⠑ ⠓⠕⠧⠑⠙⠎⠞⠁⠙⠑⠝ ⠊ ⠼⠁⠛⠓⠙⠂⠔]
   -

--- a/tests/braille-specs/zh-tw.yaml
+++ b/tests/braille-specs/zh-tw.yaml
@@ -11,6 +11,9 @@
 # Currently maintained by Sponge Jhan <school510587@yahoo.com.tw>
 # Version: 2019-08
 
+# The display tables have been separated from the translation tables. But in
+# the case of this test some display relevant stuff is still defined in the
+# translation table. That is why we have to include it here.
 display: unicode.dis,zh_TW.tbl
 table:
   locale: cmn-TW

--- a/tests/braille-specs/zh-tw.yaml
+++ b/tests/braille-specs/zh-tw.yaml
@@ -11,7 +11,7 @@
 # Currently maintained by Sponge Jhan <school510587@yahoo.com.tw>
 # Version: 2019-08
 
-display: unicode.dis
+display: unicode.dis,zh_TW.tbl
 table:
   locale: cmn-TW
   __assert-match: zh_TW.tbl # zh-tw.ctb
@@ -22,6 +22,10 @@ tests:
   - ['\x000C', '⡘⠇']
   - ['\x0020', '⠀']
   - ['\x00A0', '\x00A0']
+display: unicode.dis
+table:
+  locale: cmn-TW
+  __assert-match: zh_TW.tbl # zh-tw.ctb
 flags: {testmode: forward}
 tests:
   - ['\x000D', '⠀']

--- a/tests/charToFallbackDots.c
+++ b/tests/charToFallbackDots.c
@@ -14,11 +14,11 @@
 
 // Test that the _lou_charToFallbackDots has the same behavior as the NABCC table for the ASCII range
 int main (int argc, char **argv) {
-	lou_getTable("tables/text_nabcc.dis");
+	const DisplayTableHeader* table = _lou_getDisplayTable("tables/text_nabcc.dis");
 	widechar c;
 	for (c = 0; c < 0x85; c++) {
 		widechar d1 = _lou_charToFallbackDots(c);
-		widechar d2 = _lou_getDotsForChar(c < 0x80 ? c : '?');
+		widechar d2 = _lou_getDotsForChar(c < 0x80 ? c : '?', table);
 		if (d1 != d2) {
 			fprintf(stderr, "_lou_charToFallbackDots(%s) expected to return %s but got %s\n",
 			        strdup(_lou_showString(&c, 1, 1)),

--- a/tests/getTable.c
+++ b/tests/getTable.c
@@ -17,7 +17,7 @@ main(int argc, char **argv)
 {
   const char* goodTable = "tables/en-us-g1.ctb";
   const char* badTable = "tests/tables/bad.ctb";
-  void* table = NULL;
+  const void* table = NULL;
   int result = 0;
 
   table = lou_getTable(goodTable);

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -41,6 +41,7 @@ EXTRA_DIST =					\
 	multipass.yaml				\
 	multipass-negation.yaml			\
 	multipass-vs-match.yaml			\
+	multipass-vs-match_common.uti		\
 	new_emph.yaml				\
 	noletsignafter.yaml			\
 	pass0_typebuf.yaml			\

--- a/tests/yaml/multipass-vs-match.yaml
+++ b/tests/yaml/multipass-vs-match.yaml
@@ -11,29 +11,30 @@
 # without any warranty.
 # ..............................................................................................
 
-# use "display" also to define common part for all tests
-# note that this is a hack and might break in the future
-display: |
-  include tables/unicode-without-blank.dis
-  include tables/braille-patterns.cti
-  include tables/latinLetterDef8Dots.uti
-  include tables/loweredDigits6Dots.uti
-  space \s 0
-  letter ç 4-14
-  punctuation ! 2346
-  punctuation . 46
-  punctuation - 36
-  sign % 146
-  sign _ 145
+display: tables/unicode-without-blank.dis
+
+# multipass-vs-match_common.uti:
+#   include tables/latinLetterDef8Dots.uti
+#   include tables/loweredDigits6Dots.uti
+#   space \s 0
+#   letter ç 4-14
+#   punctuation ! 2346
+#   punctuation . 46
+#   punctuation - 36
+#   sign % 146
+#   sign _ 145
 
 # ..............................................................................................
 
 # simple match replace
 table: |
+  include multipass-vs-match_common.uti
   noback context "abc" @123
 table : |
+  include multipass-vs-match_common.uti
   noback context ["abc"] @123
 table: |
+  include multipass-vs-match_common.uti
   match - abc - 123
 tests:
   - - "abc"
@@ -41,9 +42,11 @@ tests:
 
 # lookbehind
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   noback context _"x"["abc"] @123
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   match x abc - 123
 tests:
@@ -52,6 +55,7 @@ tests:
 
 # without the _ it is not a true lookbehind
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   noback context "x"["abc"] @123
 tests:
@@ -60,9 +64,11 @@ tests:
 
 # lookahead
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   noback context ["abc"]"x" @123
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   match - abc x 123
 tests:
@@ -74,6 +80,7 @@ tests:
 
 # with lookahead
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   noback context []"xx" @123
 tests:
@@ -82,6 +89,7 @@ tests:
 
 # with lookbehind
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   noback context "x"[] @123
 tests:
@@ -89,6 +97,7 @@ tests:
     - "⠭⠇⠭⠇⠭⠇"
     - xfail: got ⠇⠸⠇
 table: |
+  include multipass-vs-match_common.uti
   always x 456
   noback context "xx"[] @123
 tests:
@@ -98,6 +107,7 @@ tests:
 
 # error: characters, dots, attributes, or class swap not found in test part
 # table: |
+#  include multipass-vs-match_common.uti
 #   noback context _"x"[] @123
 # tests:
 #   - - "xxx"
@@ -105,12 +115,16 @@ tests:
 
 # beginning of string
 table: |
+  include multipass-vs-match_common.uti
   noback context `["abc"] @123
 table: |
+  include multipass-vs-match_common.uti
   noback context `"abc" @123
 table: |
+  include multipass-vs-match_common.uti
   match ^ abc - 123
 table: |
+  include multipass-vs-match_common.uti
   match $ abc - 123
 tests:
   - - "xabc"
@@ -120,12 +134,16 @@ tests:
 
 # end of string
 table: |
+  include multipass-vs-match_common.uti
   noback context ["abc"]~ @123
 table: |
+  include multipass-vs-match_common.uti
   noback context "abc"~ @123
 table: |
+  include multipass-vs-match_common.uti
   match - abc $ 123
 table: |
+  include multipass-vs-match_common.uti
   match - abc ^ 123
 tests:
   - - "abcx"
@@ -135,8 +153,10 @@ tests:
 
 # wildcard
 table: |
+  include multipass-vs-match_common.uti
   noback context ["abc"]$a"x" @123
 table: |
+  include multipass-vs-match_common.uti
   match - abc .x 123
 tests:
   - - "abcdx"
@@ -146,6 +166,7 @@ tests:
 
 # character classes
 table: |
+  include multipass-vs-match_common.uti
   noback context ["abc"]$U @123@1 # uppercase letter
   noback context ["abc"]$u @123@2 # lowercase letter
   noback context ["abc"]$l @123@3 # letter
@@ -155,6 +176,7 @@ table: |
   noback context ["abc"]$S @123@7 # sign
   noback context ["def"]$sp @456  # space or punctuation
 table: |
+  include multipass-vs-match_common.uti
   match - abc %u 123-1  # uppercase letter
   match - abc %l 123-2  # lowercase letter
   match - abc %a 123-3  # letter
@@ -187,21 +209,28 @@ tests:
 
 # character sets / custom character classes
 table: |
+  include multipass-vs-match_common.uti
   class xy xy
   noback context ["abc"]%xy @123
 table: |
+  include multipass-vs-match_common.uti
   class xy xy
   noback context ["abc"]$w @123
 table: |
+  include multipass-vs-match_common.uti
   match - abc [xy] 123
 table: |
+  include multipass-vs-match_common.uti
   match - abc x|y 123
 table: |
+  include multipass-vs-match_common.uti
   match - abc (x|y) 123
 table: |
+  include multipass-vs-match_common.uti
   attribute 0 xy
   match - abc %0 123
 table: |
+  include multipass-vs-match_common.uti
   class fo _
   class foo _
   class fooo _
@@ -218,8 +247,10 @@ tests:
 
 # alternation
 table: |
+  include multipass-vs-match_common.uti
   match - abc xy|z 123
 table: |
+  include multipass-vs-match_common.uti
   noback context ["abc"]"xy" @123
   noback context ["abc"]"z" @123
 tests:
@@ -234,8 +265,10 @@ tests:
 
 # single character
 table: |
+  include multipass-vs-match_common.uti
   match - abc x+y 123
 table: |
+  include multipass-vs-match_common.uti
   class x x
   noback context ["abc"]%x."y" @123
 tests:
@@ -248,10 +281,13 @@ tests:
 
 # character set/class
 table: |
+  include multipass-vs-match_common.uti
   match - abc [xy]+z 123
 table: |
+  include multipass-vs-match_common.uti
   match - abc (x|y)+z 123
 table: |
+  include multipass-vs-match_common.uti
   class xy xy
   noback context ["abc"]%xy."z" @123
 tests:
@@ -264,6 +300,7 @@ tests:
 
 # group of characters
 table: |
+  include multipass-vs-match_common.uti
   match - abc (xy)+z 123
 tests:
   - - "abcxyz"
@@ -275,8 +312,10 @@ tests:
 
 # zero or more
 table: |
+  include multipass-vs-match_common.uti
   match - abc x*y 123
 table: |
+  include multipass-vs-match_common.uti
   class x x
   noback context ["abc"]"y" @123
   noback context ["abc"]%x."y" @123
@@ -290,8 +329,10 @@ tests:
 
 # optional
 table: |
+  include multipass-vs-match_common.uti
   match - abc x?y 123
 table: |
+  include multipass-vs-match_common.uti
   noback context ["abc"]"y" @123
   noback context ["abc"]"xy" @123
 tests:
@@ -304,6 +345,7 @@ tests:
 
 # limiting repitition (not more than two)
 table: |
+  include multipass-vs-match_common.uti
   class x x
   noback context ["abc"]%x1-2"y" @123
 tests:
@@ -318,6 +360,7 @@ tests:
 
 # exact repitition
 table: |
+  include multipass-vs-match_common.uti
   class x x
   noback context ["abc"]%x2"y" @123
 tests:
@@ -330,6 +373,7 @@ tests:
 
 # three or more
 table: |
+  include multipass-vs-match_common.uti
   class x x
   noback context ["abc"]%x2%x."y" @123
 tests:
@@ -342,10 +386,13 @@ tests:
 
 # negation
 table: |
+  include multipass-vs-match_common.uti
   match - abc !x 123
 table: |
+  include multipass-vs-match_common.uti
   noback context ["abc"]!"x" @123
 table: |
+  include multipass-vs-match_common.uti
   class x x
   noback context ["abc"]!%x @123
 tests:
@@ -358,6 +405,7 @@ tests:
 
 # negated group
 table: |
+  include multipass-vs-match_common.uti
   match - abc !(xy) 123
 tests:
   - - "abcx"
@@ -367,6 +415,7 @@ tests:
 
 # replace with nothing
 table: |
+  include multipass-vs-match_common.uti
   noback context "abc" ?
 tests:
   - - "xabcx"
@@ -374,6 +423,7 @@ tests:
 
 # character classes in match
 table: |
+  include multipass-vs-match_common.uti
   class xy xy
   noback context $s  @1
   noback context $d. @3

--- a/tests/yaml/multipass-vs-match_common.uti
+++ b/tests/yaml/multipass-vs-match_common.uti
@@ -1,0 +1,9 @@
+include tables/latinLetterDef8Dots.uti
+include tables/loweredDigits6Dots.uti
+space \s 0
+letter ç 4-14
+punctuation ! 2346
+punctuation . 46
+punctuation - 36
+sign % 146
+sign _ 145

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -146,13 +146,13 @@ check_base(const char *tableList, const char *input, const char *expected,
 		// provided a too short output buffer.
 		for (int k = 1; k <= 3; k++) {
 			if (direction == 1) {
-				funcStatus = lou_backTranslate(tableList, inbuf, &actualInlen, outbuf,
-						&outlen, typeformbuf, NULL, outputPos, inputPos, &cursorPos,
-						in.mode);
+				funcStatus = _lou_backTranslate(tableList, in.display_table, inbuf,
+						&actualInlen, outbuf, &outlen, typeformbuf, NULL, outputPos,
+						inputPos, &cursorPos, in.mode, NULL, NULL);
 			} else {
-				funcStatus = lou_translate(tableList, inbuf, &actualInlen, outbuf,
-						&outlen, typeformbuf, NULL, outputPos, inputPos, &cursorPos,
-						in.mode);
+				funcStatus = _lou_translate(tableList, in.display_table, inbuf,
+						&actualInlen, outbuf, &outlen, typeformbuf, NULL, outputPos,
+						inputPos, &cursorPos, in.mode, NULL, NULL);
 			}
 			if (!funcStatus) {
 				fprintf(stderr, "Translation failed.\n");

--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -31,6 +31,7 @@
  * Used to define optional and named arguments for the check() macro
  */
 typedef struct {
+	const char *display_table;
 	const formtype *typeform;
 	const int cursorPos;
 	const int mode;
@@ -50,6 +51,8 @@ typedef struct {
  * @param tableList comma separated list of tables
  * @param input string to translate
  * @param expected expected output
+ * @param display_table (optional) the display table to use (comma separated list of
+ * files). If not specified the translation table is used.
  * @param typeform (optional) the typeform for this translation. If not specified it
  * defaults to NULL.
  * @param mode (optional) the translation mode. If not specified it defaults to 0.
@@ -80,18 +83,19 @@ typedef struct {
  *                .cursorPos = 5);
  * ~~~~~~~~~~~~~~~~~~~~~~
  */
-#define check(tables, input, expected, ...)           \
-	check_base(tables, input, expected,               \
-			(optional_test_params){ .typeform = NULL, \
-					.cursorPos = -1,                  \
-					.expected_cursorPos = -1,         \
-					.expected_inputPos = NULL,        \
-					.expected_outputPos = NULL,       \
-					.max_outlen = -1,                 \
-					.real_inlen = -1,                 \
-					.mode = 0,                        \
-					.direction = 0,                   \
-					.diagnostics = 1,                 \
+#define check(table, input, expected, ...)                 \
+	check_base(table, input, expected,                     \
+			(optional_test_params){ .display_table = NULL, \
+					.typeform = NULL,                      \
+					.cursorPos = -1,                       \
+					.expected_cursorPos = -1,              \
+					.expected_inputPos = NULL,             \
+					.expected_outputPos = NULL,            \
+					.max_outlen = -1,                      \
+					.real_inlen = -1,                      \
+					.mode = 0,                             \
+					.direction = 0,                        \
+					.diagnostics = 1,                      \
 					__VA_ARGS__ })
 
 int

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -74,7 +74,7 @@ completely interactive. \n\n",
 #define BUFSIZE 256
 
 static char inputBuffer[BUFSIZE];
-static void *validTable = NULL;
+static const void *validTable = NULL;
 static int forwardOnly = 0;
 static int backOnly = 0;
 static int showPositions = 0;

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -95,6 +95,7 @@ typedef struct {
 	const char *content;  // table content in case of an inline table; NULL means name is
 						  // a file
 	int location;		  // location in YAML file (line number) where table is defined
+	int is_display;		  // whether the table is a display table or a translation table
 } table_value;
 
 const char *event_names[] = { "YAML_NO_EVENT", "YAML_STREAM_START_EVENT",
@@ -112,8 +113,6 @@ int errors = 0;
 int count = 0;
 
 static char const **emph_classes = NULL;
-static table_value *display_table = NULL;
-static int new_table = 0;
 
 static void
 simple_error(const char *msg, yaml_parser_t *parser, yaml_event_t *event) {
@@ -177,16 +176,22 @@ read_table_query(yaml_parser_t *parser, const char **table_file_name_check) {
 }
 
 static void
-compile_inline_table(const char *table_name, const char *table_content, int location) {
-	char *p = (char *)table_content;
+compile_inline_table(const table_value *table) {
+	int location = table->location;
+	char *p = (char *)table->content;
 	char *line_start = p;
 	int line_len = 0;
 	while (*p) {
 		if (*p == 10 || *p == 13) {
 			char *line = strndup((const char *)line_start, line_len);
-			if (!lou_compileString(table_name, line))
+			int error = 0;
+			if (!table->is_display)
+				error = !_lou_compileTranslationRule(table->name, line);
+			else
+				error = !_lou_compileDisplayRule(table->name, line);
+			if (error)
 				error_at_line(EXIT_FAILURE, 0, file_name, location, "Error in table %s",
-						table_name);
+						table->name);
 			location++;
 			free(line);
 			line_start = p + 1;
@@ -198,31 +203,8 @@ compile_inline_table(const char *table_name, const char *table_content, int loca
 	}
 }
 
-static void
-compile_include(const char *table_name, const char *tableList, int location) {
-	char *p;
-	char *includeRule = malloc(sizeof(char) * MAXSTRING);
-	char *subTable;
-	subTable = strdup(tableList);
-	p = subTable;
-	while (*p != '\0') {
-		char *subTable = p;
-		while (*p != '\0' && *p != ',') p++;
-		if (*p == ',') {
-			*p = '\0';
-			p++;
-		}
-		sprintf(includeRule, "include %s", subTable);
-		if (!lou_compileString(table_name, includeRule))
-			error_at_line(EXIT_FAILURE, 0, file_name, location, "Error in table %s",
-					table_name);
-	}
-	free(includeRule);
-	free(subTable);
-}
-
 static table_value *
-read_table_value(yaml_parser_t *parser, int start_line) {
+read_table_value(yaml_parser_t *parser, int start_line, int is_display) {
 	table_value *table;
 	char *table_name = malloc(sizeof(char) * MAXSTRING);
 	char *table_content = NULL;
@@ -296,6 +278,7 @@ read_table_value(yaml_parser_t *parser, int start_line) {
 	table->name = table_name;
 	table->content = table_content;
 	table->location = start_line + 1;
+	table->is_display = is_display;
 	return table;
 }
 
@@ -309,45 +292,29 @@ free_table_value(table_value *table) {
 }
 
 static char *
-read_table(yaml_event_t *start_event, yaml_parser_t *parser) {
-	table_value *table = NULL;
+read_table(yaml_event_t *start_event, yaml_parser_t *parser, const char *display_table) {
+	table_value *v = NULL;
 	char *table_name = NULL;
 	if (start_event->type != YAML_SCALAR_EVENT ||
 			strcmp((const char *)start_event->data.scalar.value, "table"))
 		return 0;
-	table = read_table_value(parser, start_event->start_mark.line + 1);
-	table_name = strdup((char *)table->name);
-	if (display_table) {
-		char *t = table_name;
-		table_name = malloc(strlen(display_table->name) + 1 + strlen(t) + 1);
-		strcpy(table_name, display_table->name);
-		strcat(table_name, ",");
-		strcat(table_name, t);
-		free(t);
-	}
-	new_table = 0;
-	if (!lou_getTable(table_name))
+	v = read_table_value(parser, start_event->start_mark.line + 1, 0);
+	if (!_lou_getTranslationTable(v->name))
 		error_at_line(EXIT_FAILURE, 0, file_name, start_event->start_mark.line + 1,
-				"Table %s not valid", table_name);
-	// trick to find out whether it is the first time this table is compiled
-	if (new_table) {
-		if (table->content || (display_table && display_table->content)) {
-			if (display_table) {
-				if (display_table->content)
-					compile_inline_table(
-							table_name, display_table->content, display_table->location);
-				else
-					compile_include(
-							table_name, display_table->name, display_table->location);
-			}
-			if (table->content)
-				compile_inline_table(table_name, table->content, table->location);
-			else
-				compile_include(table_name, table->name, table->location);
+				"Table %s not valid", v->name);
+	if (v->content) compile_inline_table(v);
+	emph_classes = lou_getEmphClasses(v->name);  // get declared emphasis classes
+	table_name = strdup((char *)v->name);
+	if (!display_table) {
+		if (!_lou_getDisplayTable(v->name))
+			error_at_line(EXIT_FAILURE, 0, file_name, start_event->start_mark.line + 1,
+					"Table %s not valid", v->name);
+		if (v->content) {
+			v->is_display = 1;
+			compile_inline_table(v);
 		}
 	}
-	free_table_value(table);
-	emph_classes = lou_getEmphClasses(table_name);  // get declared emphasis classes
+	free_table_value(v);
 	return table_name;
 }
 
@@ -762,7 +729,8 @@ parsed_strlen(char *s) {
 }
 
 static void
-read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) {
+read_test(yaml_parser_t *parser, char **tables, const char *display_table, int direction,
+		int hyphenation) {
 	yaml_event_t event;
 	char *description = NULL;
 	char *word;
@@ -830,11 +798,12 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 			// means that if we are testing multiple tables at the same time
 			// they must have the same mapping (i.e. the emphasis classes
 			// must be defined in the same order).
-			r = check(*table, word, translation, .typeform = typeform, .mode = mode,
-					.expected_inputPos = inPos, .expected_outputPos = outPos,
-					.cursorPos = cursorPos, .expected_cursorPos = cursorOutPos,
-					.max_outlen = maxOutputLen, .real_inlen = realInputLen,
-					.direction = direction, .diagnostics = !xfail);
+			r = check(*table, word, translation, .display_table = display_table,
+					.typeform = typeform, .mode = mode, .expected_inputPos = inPos,
+					.expected_outputPos = outPos, .cursorPos = cursorPos,
+					.expected_cursorPos = cursorOutPos, .max_outlen = maxOutputLen,
+					.real_inlen = realInputLen, .direction = direction,
+					.diagnostics = !xfail);
 		}
 		if (xfail != r) {
 			// FAIL or XPASS
@@ -846,6 +815,7 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 			// which table we are testing. You can can define a test
 			// for multiple tables.
 			fprintf(stderr, "Table: %s\n", *table);
+			if (display_table) fprintf(stderr, "Display table: %s\n", display_table);
 			// add an empty line after each error
 			fprintf(stderr, "\n");
 		} else if (xfail && r && verbose) {
@@ -854,6 +824,7 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 			if (description) fprintf(stderr, "%s\n", description);
 			error_at_line(0, 0, file_name, event.start_mark.line + 1, "Expected Failure");
 			fprintf(stderr, "Table: %s\n", *table);
+			if (display_table) fprintf(stderr, "Display table: %s\n", display_table);
 			fprintf(stderr, "\n");
 		}
 		result |= r;
@@ -871,7 +842,8 @@ read_test(yaml_parser_t *parser, char **tables, int direction, int hyphenation) 
 }
 
 static void
-read_tests(yaml_parser_t *parser, char **tables, int direction, int hyphenation) {
+read_tests(yaml_parser_t *parser, char **tables, const char *display_table, int direction,
+		int hyphenation) {
 	yaml_event_t event;
 	if (!yaml_parser_parse(parser, &event) || (event.type != YAML_SEQUENCE_START_EVENT))
 		yaml_error(YAML_SEQUENCE_START_EVENT, &event);
@@ -888,7 +860,7 @@ read_tests(yaml_parser_t *parser, char **tables, int direction, int hyphenation)
 			yaml_event_delete(&event);
 		} else if (event.type == YAML_SEQUENCE_START_EVENT) {
 			yaml_event_delete(&event);
-			read_test(parser, tables, direction, hyphenation);
+			read_test(parser, tables, display_table, direction, hyphenation);
 		} else {
 			error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
 					"Expected %s or %s (actual %s)", event_names[YAML_SEQUENCE_END_EVENT],
@@ -905,7 +877,6 @@ static char **
 customTableResolver(const char *tableList, const char *base) {
 	static char *dummy_table[1];
 	char *p = (char *)tableList;
-	new_table = 1;
 	while (*p != '\0') {
 		if (strncmp(p, inline_table_prefix, strlen(inline_table_prefix)) == 0)
 			return dummy_table;
@@ -1028,16 +999,24 @@ main(int argc, char *argv[]) {
 
 	int MAXTABLES = 150;
 	char *tables[MAXTABLES + 1];
+	char *display_table = NULL;
 	while (1) {
 		if (event.type == YAML_SCALAR_EVENT &&
 				!strcmp((const char *)event.data.scalar.value, "display")) {
-			display_table = read_table_value(&parser, event.start_mark.line + 1);
+			table_value *v;
+			free(display_table);
+			v = read_table_value(&parser, event.start_mark.line + 1, 1);
+			display_table = strdup((char *)v->name);
+			if (!_lou_getDisplayTable(display_table))
+				error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
+						"Display table %s not valid", display_table);
+			if (v->content) compile_inline_table(v);
+			free_table_value(v);
 			yaml_event_delete(&event);
 			if (!yaml_parser_parse(&parser, &event))
 				simple_error("table expected", &parser, &event);
 		}
-
-		if (!(tables[0] = read_table(&event, &parser))) break;
+		if (!(tables[0] = read_table(&event, &parser, display_table))) break;
 		yaml_event_delete(&event);
 		int k = 1;
 		while (1) {
@@ -1045,7 +1024,7 @@ main(int argc, char *argv[]) {
 				error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
 						"Expected table or %s (actual %s)",
 						event_names[YAML_SCALAR_EVENT], event_names[event.type]);
-			if ((tables[k++] = read_table(&event, &parser))) {
+			if ((tables[k++] = read_table(&event, &parser, display_table))) {
 				if (k == MAXTABLES)
 					error_at_line(EXIT_FAILURE, 0, file_name, event.start_mark.line + 1,
 							"Only %d tables in one YAML test supported", MAXTABLES);
@@ -1070,12 +1049,12 @@ main(int argc, char *argv[]) {
 					simple_error("tests expected", &parser, &event);
 				}
 				yaml_event_delete(&event);
-				read_tests(&parser, tables, direction, hyphenation);
+				read_tests(&parser, tables, display_table, direction, hyphenation);
 				haveRunTests = 1;
 
 			} else if (!strcmp((const char *)event.data.scalar.value, "tests")) {
 				yaml_event_delete(&event);
-				read_tests(&parser, tables, direction, hyphenation);
+				read_tests(&parser, tables, display_table, direction, hyphenation);
 				haveRunTests = 1;
 			} else {
 				if (haveRunTests) {
@@ -1110,7 +1089,7 @@ main(int argc, char *argv[]) {
 	yaml_parser_delete(&parser);
 
 	free(emph_classes);
-	free_table_value(display_table);
+	free(display_table);
 	lou_free();
 
 	assert(!fclose(file));

--- a/tools/lou_debug.c
+++ b/tools/lou_debug.c
@@ -644,11 +644,11 @@ main(int argc, char **argv) {
 		exit(EXIT_FAILURE);
 	}
 
-	if (!(table = lou_getTable(argv[optind]))) {
+	_lou_getTable(argv[optind], argv[optind], &table, &displayTable);
+	if (!table) {
 		lou_free();
 		exit(EXIT_FAILURE);
 	}
-	displayTable = _lou_getCurrentDisplayTable();
 	getCommands();
 	lou_free();
 	exit(EXIT_SUCCESS);

--- a/tools/lou_maketable.d/utils.py
+++ b/tools/lou_maketable.d/utils.py
@@ -165,8 +165,8 @@ def translate(text):
     max_rules = 16
     c_rules = (c_void_p * max_rules)()
     c_rules_len = c_int(max_rules)
-    exit_if_not(liblouis._lou_translateWithTracing(table, c_text, byref(c_text_len), c_braille, byref(c_braille_len),
-                                                   None, None, None, None, None, 0, c_rules, byref(c_rules_len)))
+    exit_if_not(liblouis._lou_translate(table, c_text, byref(c_text_len), c_braille, byref(c_braille_len),
+                                        None, None, None, None, None, 0, c_rules, byref(c_rules_len)))
     return c_braille.value, c_rules[0:c_rules_len.value]
 
 def get_rule(c_rule_pointer):

--- a/tools/lou_trace.c
+++ b/tools/lou_trace.c
@@ -253,11 +253,11 @@ main_loop(int backward_translation, char *table, int mode) {
 		outlen = BUFSIZE;
 		ruleslen = RULESSIZE;
 		if (backward_translation) {
-			if (!_lou_backTranslate(table, inbuf, &inlen, outbuf, &outlen, NULL, NULL,
-						NULL, NULL, NULL, mode, rules, &ruleslen))
+			if (!_lou_backTranslate(table, table, inbuf, &inlen, outbuf, &outlen, NULL,
+						NULL, NULL, NULL, NULL, mode, rules, &ruleslen))
 				break;
-		} else if (!_lou_translate(table, inbuf, &inlen, outbuf, &outlen, NULL, NULL,
-						   NULL, NULL, NULL, mode, rules, &ruleslen))
+		} else if (!_lou_translate(table, table, inbuf, &inlen, outbuf, &outlen, NULL,
+						   NULL, NULL, NULL, NULL, mode, rules, &ruleslen))
 			break;
 		if ((mode & dotsIO) && !backward_translation)
 			printf("Dot patterns: %s\n", _lou_showDots(outbuf, outlen));

--- a/tools/lou_trace.c
+++ b/tools/lou_trace.c
@@ -253,11 +253,11 @@ main_loop(int backward_translation, char *table, int mode) {
 		outlen = BUFSIZE;
 		ruleslen = RULESSIZE;
 		if (backward_translation) {
-			if (!_lou_backTranslateWithTracing(table, inbuf, &inlen, outbuf, &outlen,
-						NULL, NULL, NULL, NULL, NULL, mode, rules, &ruleslen))
+			if (!_lou_backTranslate(table, inbuf, &inlen, outbuf, &outlen, NULL, NULL,
+						NULL, NULL, NULL, mode, rules, &ruleslen))
 				break;
-		} else if (!_lou_translateWithTracing(table, inbuf, &inlen, outbuf, &outlen, NULL,
-						   NULL, NULL, NULL, NULL, mode, rules, &ruleslen))
+		} else if (!_lou_translate(table, inbuf, &inlen, outbuf, &outlen, NULL, NULL,
+						   NULL, NULL, NULL, mode, rules, &ruleslen))
 			break;
 		if ((mode & dotsIO) && !backward_translation)
 			printf("Dot patterns: %s\n", _lou_showDots(outbuf, outlen));


### PR DESCRIPTION
This is the next step after #789.

There are two phases to a braille conversion:

1. **translation**: liblouis uses the rules in the translation table to convert characters to dots
2. **display**: display the dots as characters. Usually liblouis uses the characters defined in `display` rules (in display tables) but as a fallback it uses mappings defined in the translation table, e.g. `letter` rules

This PR aims to separate these two concepts at least internally