### PR TITLE
Marked Current German g0 and g2 table correctly as forward only tables.

### DIFF
--- a/tables/de-g0.utb
+++ b/tables/de-g0.utb
@@ -17,7 +17,7 @@
 #+type:literary
 #+contraction:no
 #+grade:0
-#+translation:forward
+#+direction:forward
 # ------------
 #
 #  Copyright (C) 2018 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte

--- a/tables/de-g2.ctb
+++ b/tables/de-g2.ctb
@@ -5,7 +5,7 @@
 #+type:literary
 #+contraction:full
 #+grade:2
-#+translation:forward
+#+direction:forward
 #
 #-has-nocross: yes
 


### PR DESCRIPTION
Changed "translation" to "direction".