### PR TITLE
Major overhaul of the Dockerfile to create a mingw binary distribution

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,14 +7,23 @@ RUN apt-get update && apt-get install -y \
     autoconf \
     automake \
     curl \
+    libc6-dev-i386 \
     libtool \
     make \
     mingw-w64 \
     pkg-config \
     texinfo \
-    wine64 \
     zip \
    && rm -rf /var/lib/apt/lists/*
+
+# install wine for both 64-bit and 32-bit architecture
+RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
+    wine \
+    wine32-development \
+    wine64 \
+    libwine \
+    libwine:i386 \
+    fonts-wine
 
 ARG LIBYAML_VERSION=0.2.2
 ARG HOST=x86_64-w64-mingw32
@@ -28,6 +37,8 @@ RUN ./bootstrap && \
     make && \
     make install
 
+ARG WINE=wine64
+
 # Build release artifact, i.e. liblouis zip
 ADD . /usr/src/liblouis
 WORKDIR /usr/src/liblouis
@@ -36,7 +47,7 @@ RUN ./autogen.sh && \
         --prefix=/usr/build/liblouis \
         CPPFLAGS='-I/usr/build/libyaml/include/' LDFLAGS='-L/usr/build/libyaml/lib/' && \
     make LDFLAGS="-L/usr/build/libyaml/lib/ -avoid-version -Xcompiler -static-libgcc" && \
-    make check WINE=wine64 || cat tests/test-suite.log && \
+    make check WINE=${WINE} || cat tests/test-suite.log && \
     make install && \
     cd /usr/build/liblouis && \
     zip -r /usr/src/liblouis/liblouis.zip *

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,24 +17,26 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.2.2
+ARG HOST=x86_64-w64-mingw32
 
 # Build and install libyaml
 WORKDIR /usr/src/
 RUN curl -L https://github.com/yaml/libyaml/archive/${LIBYAML_VERSION}.tar.gz | tar zx
 WORKDIR /usr/src/libyaml-${LIBYAML_VERSION}
 RUN ./bootstrap && \
-    ./configure --host x86_64-w64-mingw32 --prefix=/usr/build/libyaml && \
+    ./configure --host ${HOST} --prefix=/usr/build/libyaml && \
     make && \
     make install
 
 # Build release artifact, i.e. liblouis zip
+ADD . /usr/src/liblouis
 WORKDIR /usr/src/liblouis
-CMD ./autogen.sh && \
-    ./configure  --host x86_64-w64-mingw32 --enable-ucs4 \
-        --prefix=/usr/build/liblouis-win64 \
+RUN ./autogen.sh && \
+    ./configure  --host ${HOST} --enable-ucs4 \
+        --prefix=/usr/build/liblouis \
         CPPFLAGS='-I/usr/build/libyaml/include/' LDFLAGS='-L/usr/build/libyaml/lib/' && \
     make LDFLAGS="-L/usr/build/libyaml/lib/ -avoid-version -Xcompiler -static-libgcc" && \
     make check WINE=wine64 || cat tests/test-suite.log && \
     make install && \
-    cd /usr/build/liblouis-win64 && \
-    zip -r /usr/src/liblouis/liblouis-win64.zip *
+    cd /usr/build/liblouis && \
+    zip -r /usr/src/liblouis/liblouis.zip *

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,29 +1,40 @@
-FROM debian:jessie
+FROM debian:latest
 
-MAINTAINER Liblouis Maintainers "liblouis-liblouisxml@freelists.org"
+LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
-# developer environment
-RUN apt-get update
-RUN apt-get install -y make autoconf automake libtool pkg-config curl
+# Fetch build dependencies
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    curl \
+    libtool \
+    make \
+    mingw-w64 \
+    pkg-config \
+    texinfo \
+    wine64 \
+    zip \
+   && rm -rf /var/lib/apt/lists/*
 
-# for cross-compiling
-RUN apt-get install -y mingw32 mingw-w64 libc6-dev-i386
+ARG LIBYAML_VERSION=0.2.2
 
-# for running cross-compiled tests
-RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y wine32 wine64
+# Build and install libyaml
+WORKDIR /usr/src/
+RUN curl -L https://github.com/yaml/libyaml/archive/${LIBYAML_VERSION}.tar.gz | tar zx
+WORKDIR /usr/src/libyaml-${LIBYAML_VERSION}
+RUN ./bootstrap && \
+    ./configure --host x86_64-w64-mingw32 --prefix=/usr/build/libyaml && \
+    make && \
+    make install
 
-# for check_yaml
-WORKDIR /root/src/
-RUN curl -L https://github.com/yaml/libyaml/archive/0.2.2.tar.gz | tar zx
-WORKDIR /root/src/libyaml-0.2.2
-RUN ./bootstrap
-RUN ./configure --host i586-mingw32msvc --prefix=/root/build/win32/libyaml
-RUN make
-RUN make install
-
-ADD . /root/src/liblouis
-WORKDIR /root/src/liblouis
-
-# create Makefile
-RUN ./autogen.sh
-RUN ./configure
+# Build release artifact, i.e. liblouis zip
+WORKDIR /usr/src/liblouis
+CMD ./autogen.sh && \
+    ./configure  --host x86_64-w64-mingw32 --enable-ucs4 \
+        --prefix=/usr/build/liblouis-win64 \
+        CPPFLAGS='-I/usr/build/libyaml/include/' LDFLAGS='-L/usr/build/libyaml/lib/' && \
+    make LDFLAGS="-L/usr/build/libyaml/lib/ -avoid-version -Xcompiler -static-libgcc" && \
+    make check WINE=wine64 || cat tests/test-suite.log && \
+    make install && \
+    cd /usr/build/liblouis-win64 && \
+    zip -r /usr/src/liblouis/liblouis-win64.zip *

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -244,5 +244,6 @@ AM_TESTS_ENVIRONMENT =								\
 	UEB_TEST_DATA_PATH=$(top_srcdir)/tests/ueb_test_data			\
 	LD_LIBRARY_PATH=$(top_builddir)/liblouis/.libs:$$LD_LIBRARY_PATH	\
 	PATH=$(top_builddir)/tools:$$PATH					\
+	WINEPATH=$(top_builddir)/tools						\
 	WINE=$(WINE)								\
 	EXEEXT=$(EXEEXT)


### PR DESCRIPTION
- base on newest Debian
- use best practices to create fewer layers, etc
- the image now basically just provides a mingw build environment with libyaml pre-installed
- the CMD which is executed when running the image will build, test and zip up liblouis

Mount the liblouis source directory when running the image as follows:

``` console
cd ~/src/liblouis
docker build -f Dockerfile.dev -t liblouis/mingw64 .
docker run -v `pwd`:/usr/src/liblouis liblouis/mingw64
```

This has the potential to simplify the mingw travis build quite a bit. We could push the image to docker hub and then use it in the travis build.

For win32 I imagine we could create a separate slightly different image that provides a build environment for 32 bit.