### PR TITLE
Avoid a memory leak when several tables are specified with some of them that can't be resolved

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3950,6 +3950,7 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 	char *cp;
 	int last;
 	int k;
+	size_t sz = NULL;
 
 	/* Set up search path */
 	searchPath = _lou_getTablePath();
@@ -3958,7 +3959,10 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 	k = 0;
 	for (cp = (char *)tableList; *cp != '\0'; cp++)
 		if (*cp == ',') k++;
-	tableFiles = (char **)malloc((k + 2) * sizeof(char *));
+	sz = (k + 2);
+	tableFiles = (char **)malloc(sz * sizeof(char *));
+	if (!tableFiles) _lou_outOfMemory();
+	for (size_t i = 0; i < sz; ++i) tableFiles[i] = NULL;
 
 	/* Resolve subtables */
 	k = 0;
@@ -3976,6 +3980,7 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 				_lou_logMessage(LOU_LOG_ERROR, "LOUIS_TABLEPATH=%s", path);
 			free(searchPath);
 			free(tableList_copy);
+			for(unsigned int i = 0; i < sz; i++) free(*(tableFiles+i));
 			free(tableFiles);
 			return NULL;
 		}

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3980,7 +3980,7 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 				_lou_logMessage(LOU_LOG_ERROR, "LOUIS_TABLEPATH=%s", path);
 			free(searchPath);
 			free(tableList_copy);
-			for(unsigned int i = 0; i < sz; i++) free(*(tableFiles+i));
+			for (unsigned int i = 0; i < sz; i++) free(*(tableFiles + i));
 			free(tableFiles);
 			return NULL;
 		}

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3950,7 +3950,6 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 	char *cp;
 	int last;
 	int k;
-	size_t sz = NULL;
 
 	/* Set up search path */
 	searchPath = _lou_getTablePath();
@@ -3959,10 +3958,8 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 	k = 0;
 	for (cp = (char *)tableList; *cp != '\0'; cp++)
 		if (*cp == ',') k++;
-	sz = (k + 2);
-	tableFiles = (char **)malloc(sz * sizeof(char *));
+	tableFiles = (char **)calloc(k + 2, sizeof(char *));
 	if (!tableFiles) _lou_outOfMemory();
-	for (size_t i = 0; i < sz; ++i) tableFiles[i] = NULL;
 
 	/* Resolve subtables */
 	k = 0;
@@ -3980,8 +3977,7 @@ _lou_defaultTableResolver(const char *tableList, const char *base) {
 				_lou_logMessage(LOU_LOG_ERROR, "LOUIS_TABLEPATH=%s", path);
 			free(searchPath);
 			free(tableList_copy);
-			for (unsigned int i = 0; i < sz; i++) free(*(tableFiles + i));
-			free(tableFiles);
+			free_tablefiles(tableFiles);
 			return NULL;
 		}
 		if (k == 1) base = subTable;


### PR DESCRIPTION
Warning: I'm not totally confident for this patch, (I'm a beginner in C), so please review it carefully. :)

Fixes #854 

### Valgrind reports
* With current releases: see #854
* With this patch: see below

```
$ echo "test"|valgrind --track-origins=yes --leak-check=full --show-leak-kinds=all -v ~/app/liblouis_test/bin/lou_translate en-ueb-g1.ctb,foobar.ctb
==112557== Memcheck, a memory error detector
==112557== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==112557== Using Valgrind-3.14.0-3a3000290b-20181009X and LibVEX; rerun with -h for copyright info
==112557== Command: /home/andreabush/app/liblouis_test/bin/lou_translate en-ueb-g1.ctb,foobar.ctb
==112557== 
--112557-- Valgrind options:
--112557--    --track-origins=yes
--112557--    --leak-check=full
--112557--    --show-leak-kinds=all
--112557--    -v
--112557-- Contents of /proc/version:
--112557--   Linux version 5.2.13-arch1-1-ARCH (builduser@heftig-49962) (gcc version 9.1.0 (GCC)) #1 SMP PREEMPT Fri Sep 6 17:52:33 UTC 2019
--112557-- 
--112557-- Arch and hwcaps: AMD64, LittleEndian, amd64-cx16-lzcnt-rdtscp-sse3-avx-avx2-bmi
--112557-- Page sizes: currently 4096, max supported 4096
--112557-- Valgrind library directory: /usr/lib/valgrind
--112557-- Reading syms from /home/andreabush/app/liblouis_test/bin/lou_translate
--112557-- Reading syms from /usr/lib/ld-2.29.so
--112557-- Reading syms from /usr/lib/valgrind/memcheck-amd64-linux
--112557--    object doesn't have a dynamic symbol table
--112557-- Scheduler: using generic scheduler lock implementation.
--112557-- Reading suppressions file: /usr/lib/valgrind/default.supp
==112557== embedded gdbserver: reading from /tmp/vgdb-pipe-from-vgdb-to-112557-by-andreabush-on-???
==112557== embedded gdbserver: writing to   /tmp/vgdb-pipe-to-vgdb-from-112557-by-andreabush-on-???
==112557== embedded gdbserver: shared mem   /tmp/vgdb-pipe-shared-mem-vgdb-112557-by-andreabush-on-???
==112557== 
==112557== TO CONTROL THIS PROCESS USING vgdb (which you probably
==112557== don't want to do, unless you know exactly what you're doing,
==112557== or are doing some strange experiment):
==112557==   /usr/lib/valgrind/../../bin/vgdb --pid=112557 ...command...
==112557== 
==112557== TO DEBUG THIS PROCESS USING GDB: start GDB like this
==112557==   /path/to/gdb /home/andreabush/app/liblouis_test/bin/lou_translate
==112557== and then give GDB the following command
==112557==   target remote | /usr/lib/valgrind/../../bin/vgdb --pid=112557
==112557== --pid is optional if only one valgrind process is running
==112557== 
--112557-- REDIR: 0x4020400 (ld-linux-x86-64.so.2:strlen) redirected to 0x580c9742 (vgPlain_amd64_linux_REDIR_FOR_strlen)
--112557-- REDIR: 0x40201d0 (ld-linux-x86-64.so.2:index) redirected to 0x580c975c (vgPlain_amd64_linux_REDIR_FOR_index)
--112557-- Reading syms from /usr/lib/valgrind/vgpreload_core-amd64-linux.so
--112557-- Reading syms from /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so
==112557== WARNING: new redirection conflicts with existing -- ignoring it
--112557--     old: 0x04020400 (strlen              ) R-> (0000.0) 0x580c9742 vgPlain_amd64_linux_REDIR_FOR_strlen
--112557--     new: 0x04020400 (strlen              ) R-> (2007.0) 0x0483bd80 strlen
--112557-- REDIR: 0x401cbe0 (ld-linux-x86-64.so.2:strcmp) redirected to 0x483ce40 (strcmp)
--112557-- REDIR: 0x4020960 (ld-linux-x86-64.so.2:mempcpy) redirected to 0x4840860 (mempcpy)
--112557-- Reading syms from /home/andreabush/app/liblouis_test/lib/liblouis.so.19.0.0
--112557-- Reading syms from /usr/lib/libyaml-0.so.2.0.6
--112557--    object doesn't have a symbol table
--112557-- Reading syms from /usr/lib/libc-2.29.so
--112557-- REDIR: 0x49534e0 (libc.so.6:memmove) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952760 (libc.so.6:strncpy) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953810 (libc.so.6:strcasecmp) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952080 (libc.so.6:strcat) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49527c0 (libc.so.6:rindex) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4954c70 (libc.so.6:rawmemchr) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x496d330 (libc.so.6:wmemchr) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x496cda0 (libc.so.6:wcscmp) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953640 (libc.so.6:mempcpy) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953470 (libc.so.6:bcmp) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49526f0 (libc.so.6:strncmp) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952130 (libc.so.6:strcmp) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49535a0 (libc.so.6:memset) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x496cd60 (libc.so.6:wcschr) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952650 (libc.so.6:strnlen) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952210 (libc.so.6:strcspn) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953860 (libc.so.6:strncasecmp) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49521b0 (libc.so.6:strcpy) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49539b0 (libc.so.6:memcpy@@GLIBC_2.14) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x496e610 (libc.so.6:wcsnlen) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952800 (libc.so.6:strpbrk) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49520e0 (libc.so.6:index) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952610 (libc.so.6:strlen) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49591b0 (libc.so.6:memrchr) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49538b0 (libc.so.6:strcasecmp_l) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953430 (libc.so.6:memchr) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x496ceb0 (libc.so.6:wcslen) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4952ac0 (libc.so.6:strspn) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x49537b0 (libc.so.6:stpncpy) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953750 (libc.so.6:stpcpy) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4954cb0 (libc.so.6:strchrnul) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4953900 (libc.so.6:strncasecmp_l) redirected to 0x482e1c0 (_vgnU_ifunc_wrapper)
--112557-- REDIR: 0x4a25a70 (libc.so.6:__strrchr_avx2) redirected to 0x483b790 (rindex)
--112557-- REDIR: 0x4a21580 (libc.so.6:__strncmp_avx2) redirected to 0x483c410 (strncmp)
--112557-- REDIR: 0x4a25c40 (libc.so.6:__strlen_avx2) redirected to 0x483bc60 (strlen)
--112557-- REDIR: 0x494e5d0 (libc.so.6:malloc) redirected to 0x4838710 (malloc)
--112557-- REDIR: 0x4a25880 (libc.so.6:__strchrnul_avx2) redirected to 0x4840390 (strchrnul)
--112557-- REDIR: 0x494ec70 (libc.so.6:free) redirected to 0x4839940 (free)
--112557-- REDIR: 0x4a290d0 (libc.so.6:__memset_avx2_unaligned_erms) redirected to 0x483f790 (memset)
--112557-- REDIR: 0x4a28c50 (libc.so.6:__memcpy_avx_unaligned_erms) redirected to 0x483f8a0 (memmove)
--112557-- REDIR: 0x4a28c30 (libc.so.6:__mempcpy_avx_unaligned_erms) redirected to 0x48404a0 (mempcpy)
--112557-- REDIR: 0x4a27180 (libc.so.6:__strcpy_avx2) redirected to 0x483bdb0 (strcpy)
--112557-- REDIR: 0x4a26100 (libc.so.6:__strcat_avx2) redirected to 0x483b940 (strcat)
Cannot resolve table 'foobar.ctb'
1 errors found.
en-ueb-g1.ctb,foobar.ctb could not be compiled
==112557== 
==112557== HEAP SUMMARY:
==112557==     in use at exit: 0 bytes in 0 blocks
==112557==   total heap usage: 15 allocs, 15 frees, 73,450 bytes allocated
==112557== 
==112557== All heap blocks were freed -- no leaks are possible
==112557== 
==112557== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==112557== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```