### PR TITLE
Additional fixes to Polish grade 1

### DIFF
--- a/tables/Pl-Pl-g1.utb
+++ b/tables/Pl-Pl-g1.utb
@@ -3,6 +3,7 @@
 #  Copyright (C) 2004-2008 ViewPlus Technologies, Inc. www.viewplus.com
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
 #  Copyright (C) 2012 Mesar Hameed <mesar.hameed@gmail.com>
+#  Copyright (C) 2019 Łukasz Golonka <wulfryk1@gmail.com>
 #
 #  This file is part of liblouis.
 #

--- a/tables/Pl-Pl-g1.utb
+++ b/tables/Pl-Pl-g1.utb
@@ -31,18 +31,19 @@ include text_nabcc.dis
 punctuation ! 235			exclamation sign   						x0021
 punctuation " 356			double quote									x0022
 sign # 3456						number sign										x0023
-sign $ 256						dollar sign										x0024
-sign % 4-356					percent sign									x0025
+sign $ 4-145						dollar sign										x0024
+sign % 3456-245-356					percent sign									x0025
 sign & 456-12346			ampersand											z0026
-punctuation ' 3				apostrophe										x0027
+noback punctuation ' 3				apostrophe										x0027
+nofor punctuation ' 4				apostrophe										x0027
 punctuation ( 2356			left parenthesis						x0028
 punctuation ) 2356			right parenthesis						x0029
-sign * 35-35						asterisk										x002A
+sign * 35						asterisk										x002A
 math + 235							plus												002B
 punctuation , 2					coma												002C
 punctuation - 36				hyphen-minus								002D
 punctuation . 3					point												002E
-math / 456-34						solidus											002F
+math / 256						solidus											002F
 
 punctuation : 25				colon								x003A
 punctuation ; 23				semicolon						x003B
@@ -50,7 +51,7 @@ punctuation < 5-13			less-than sign			x003C
 math = 2356			equal sign					x003D
 math > 46-2			greater-than sign		x003E
 punctuation ? 26				question mark				x003F
-sign @ 4-1			commercial at				x0040
+sign @ 345			commercial at				x0040
 
 include latinLetterDef6Dots.uti
 
@@ -93,7 +94,7 @@ uplow \x017B\x017C 12346
 
 
 punctuation [ 12356		left square bracket						x005B
-sign \\ 2				reverse solidus								x005C
+sign \\ 34				reverse solidus								x005C
 punctuation ] 23456		right square bracket					x005D
 sign ^ 5				circumflex accent							x005E
 sign _ 46				low line											x005F
@@ -146,7 +147,7 @@ uplow \x00CF\x00EF 12456	i with diaeresis								x00CF / 00EF
 uplow \x00D4\x00F4 1456	o with circumflex													x00F4
 uplow \x00D5\x00F5 246		o with tilde														x00F5
 uplow Öö 246						O with diaeresis									x00D6 / 00F6
-math × 236				multiplication sign											x00D7
+math × 3				multiplication sign											x00D7
 uplow \x00D8\x00F8 246		o with stroke										x00D8 / 00F8
 
 math ÷ 256				division sign										x00F7
@@ -180,11 +181,6 @@ begcapsword 46-46			# a block of consecutive capital letters indicator
 numsign 3456		#	number sign, just one operand
 midnum , 2
 midnum . 3
-midnum + 235
-midnum - 36
-midnum / 256
-midnum : 25
-midnum = 2356
 
 endnum # 56-3456
 
@@ -209,7 +205,6 @@ repeated ___ 46-46-46
 repeated ::: 25-25-25
 repeated === 46-13-46-13-46-13
 repeated ~~~ 4-156-4-156-4-156
-always \s-\s 36-36
 always \s-\scom 36-36-14-135-134
 always ... 3-3-3
 always .\s.\s. 3-3-3 . . .
@@ -240,3 +235,65 @@ literal .wav
 
 literal .tar
 literal .zip
+
+# Greek letters
+
+noback letter \x0391 456-1 # Α
+noback letter \x0392 456-12 # Β
+noback letter \x0393 456-1245 # Γ
+noback letter \x0394 456-145 # Δ
+noback letter \x0395 456-15 # Ε
+noback letter \x0396 456-1356 # Ζ
+noback letter \x0397 456-156 # Η
+noback letter \x0398 456-1456 # Θ
+noback letter \x0399 456-24 # Ι
+noback letter \x039A 456-13 # Κ
+noback letter \x039B 456-123 # Λ
+noback letter \x039C 456-134 # Μ
+noback letter \x039D 456-1345 # Ν
+noback letter \x039E 456-1346 # Ξ
+noback letter \x039F 456-135 # Ο
+noback letter \x03A0 456-1234 # Π
+noback letter \x03A1 456-1235 # Ρ
+noback letter \x03A3 456-234 # Σ
+noback letter \x03A4 456-2345 # Τ
+noback letter \x03A5 456-136 # Υ
+noback letter \x03A6 456-124 # Φ
+noback letter \x03A7 456-12346 # Χ
+noback letter \x03A8 456-13456 # Ψ
+noback letter \x03A9 456-2456 # Ω
+
+noback letter \x03B1 56-1 # α
+noback letter \x03B2 56-12 # β
+noback letter \x03B3 56-1245 # γ
+noback letter \x03B4 56-145 # δ
+noback letter \x03B5 56-15 # ε
+noback letter \x03B6 56-1356 # ζ
+noback letter \x03B7 56-156 # η
+noback letter \x03B8 56-1456 # θ
+noback letter \x03B9 56-24 # ι
+noback letter \x03BA 56-13 # κ
+noback letter \x03BB 56-123 # λ
+noback letter \x03BC 56-134 # μ
+noback letter \x03BD 56-1345 # ν
+noback letter \x03BE 56-1346 # ξ
+noback letter \x03BF 56-135 # ο
+noback letter \x03C0 56-1234 # π
+noback letter \x03C1 56-1235 # ρ
+noback letter \x03C2 56-234 # ς
+noback letter \x03C3 56-234
+noback letter \x03C4 56-2345 # τ
+noback letter \x03C5 56-136 # υ
+noback letter \x03C6 56-124 # φ
+noback letter \x03C7 56-12346 # χ
+noback letter \x03C8 56-13456 # ψ
+noback letter \x03C9 56-2456 # ω
+
+# Arrows:
+
+noback sign \x2192 25-135
+noback sign \x2190 246-25
+
+
+noback sign \x2264 246-2356 # Less than or equal to
+noback sign \x2265 135-2356 #  Greater than or equal to

--- a/tables/pl-pl-comp8.ctb
+++ b/tables/pl-pl-comp8.ctb
@@ -1,4 +1,5 @@
 #  Copyright (C) 2015 by Harpo Sp. z o. o. <info@harpo.com.pl>
+#  Copyright (C) 2019 Łukasz Golonka  <wulfryk1@gmail.com>
 #
 # -----------
 #-index-name: Polish, computer

--- a/tables/pl-pl-comp8.ctb
+++ b/tables/pl-pl-comp8.ctb
@@ -333,30 +333,30 @@ noback uppercase \x038C 24678
 noback uppercase \x038E 125678
 noback uppercase \x038F 24578
 noback lowercase \x0390 248
-noback uppercase \x0391 178
-noback uppercase \x0392 1278
-noback uppercase \x0393 124578
-noback uppercase \x0394 14578
-noback uppercase \x0395 1578
-noback uppercase \x0396 135678
-noback uppercase \x0397 15678
-noback uppercase \x0398 145678
-noback uppercase \x0399 248
-noback uppercase \x039A 1378
-noback uppercase \x039B 12378
-noback uppercase \x039C 13478
-noback uppercase \x039D 134578
-noback uppercase \x039E 134678
-noback uppercase \x039F 13578
-noback uppercase \x03A0 123478
-noback uppercase \x03A1 123578
-noback uppercase \x03A3 23478
-noback uppercase \x03A4 234578
-noback uppercase \x03A5 13678
-noback uppercase \x03A6 12478
-noback uppercase \x03A7 1234678
-noback uppercase \x03A8 1345678
-noback uppercase \x03A9 245678
+noback uppercase \x0391 456-1 # Α
+noback uppercase \x0392 456-12 # Β
+noback uppercase \x0393 456-1245 # Γ
+noback uppercase \x0394 456-145 # Δ
+noback uppercase \x0395 456-15 # Ε
+noback uppercase \x0396 456-1356 # Ζ
+noback uppercase \x0397 456-156 # Η
+noback uppercase \x0398 456-1456 # Θ
+noback uppercase \x0399 456-24 # Ι
+noback uppercase \x039A 456-13 # Κ
+noback uppercase \x039B 456-123 # Λ
+noback uppercase \x039C 456-134 # Μ
+noback uppercase \x039D 456-1345 # Ν
+noback uppercase \x039E 456-1346 # Ξ
+noback uppercase \x039F 456-135 # Ο
+noback uppercase \x03A0 456-1234 # Π
+noback uppercase \x03A1 456-1235 # Ρ
+noback uppercase \x03A3 456-234 # Σ
+noback uppercase \x03A4 456-2345 # Τ
+noback uppercase \x03A5 456-136 # Υ
+noback uppercase \x03A6 456-124 # Φ
+noback uppercase \x03A7 456-12346 # Χ
+noback uppercase \x03A8 456-13456 # Ψ
+noback uppercase \x03A9 456-2456 # Ω
 noback uppercase \x03AA 2478
 noback uppercase \x03AB 1345678
 
@@ -365,31 +365,31 @@ noback lowercase \x03AD 12468
 noback lowercase \x03AE 1234568
 noback lowercase \x03AF 124568
 noback lowercase \x03B0 134568
-noback lowercase \x03B1 18
-noback lowercase \x03B2 128
-noback lowercase \x03B3 12458
-noback lowercase \x03B4 1458
-noback lowercase \x03B5 158
-noback lowercase \x03B6 13568
-noback lowercase \x03B7 1568
-noback lowercase \x03B8 14568
-noback lowercase \x03B9 248
-noback lowercase \x03BA 138
-noback lowercase \x03BB 1238
-noback lowercase \x03BC 1348
-noback lowercase \x03BD 13458
-noback lowercase \x03BE 13468
-noback lowercase \x03BF 1358
-noback lowercase \x03C0 12348
-noback lowercase \x03C1 12358
-noback lowercase \x03C2 2348
-noback lowercase \x03C3 2348
-noback lowercase \x03C4 23458
-noback lowercase \x03C5 1368
-noback lowercase \x03C6 1248
-noback lowercase \x03C7 123468
-noback lowercase \x03C8 13456
-noback lowercase \x03C9 24568
+noback lowercase \x03B1 56-1 # α
+noback lowercase \x03B2 56-12 # β
+noback lowercase \x03B3 56-1245 # γ
+noback lowercase \x03B4 56-145 # δ
+noback lowercase \x03B5 56-15 # ε
+noback lowercase \x03B6 56-1356 # ζ
+noback lowercase \x03B7 56-156 # η
+noback lowercase \x03B8 56-1456 # θ
+noback lowercase \x03B9 56-24 # ι
+noback lowercase \x03BA 56-13 # κ
+noback lowercase \x03BB 56-123 # λ
+noback lowercase \x03BC 56-134 # μ
+noback lowercase \x03BD 56-1345 # ν
+noback lowercase \x03BE 56-1346 # ξ
+noback lowercase \x03BF 56-135 # ο
+noback lowercase \x03C0 56-1234 # π
+noback lowercase \x03C1 56-1235 # ρ
+noback lowercase \x03C2 56-234 # ς
+noback lowercase \x03C3 56-234
+noback lowercase \x03C4 56-2345 # τ
+noback lowercase \x03C5 56-136 # υ
+noback lowercase \x03C6 56-124 # φ
+noback lowercase \x03C7 56-12346 # χ
+noback lowercase \x03C8 56-13456 # ψ
+noback lowercase \x03C9 56-2456 # ω
 noback lowercase \x03CA 348
 noback lowercase \x03CB 234568
 noback lowercase \x03CC 2468
@@ -585,8 +585,8 @@ noback sign \x221E 234678
 noback sign \x2229 578
 noback sign \x2248 3578
 noback sign \x2261 23568
-noback sign \x2264 568
-noback sign \x2265 458
+noback sign \x2264 246-2356 # Less than or equal to
+noback sign \x2265 135-2356 #  Grater than or equal to
 noback sign \x2310 14567
 noback sign \x2320 347
 noback sign \x2321 1567
@@ -639,3 +639,6 @@ noback sign \x2592 3678
 noback sign \x2593 235678
 noback sign \x25A0 1234567
 noback sign \x25CF 35
+# Arrows:
+noback sign \x2192 25-135
+noback sign \x2190 246-25

--- a/tests/braille-specs/Pl-Pl-g1_harness.yaml
+++ b/tests/braille-specs/Pl-Pl-g1_harness.yaml
@@ -24,3 +24,23 @@ tests:
   - ["22,333", ⠼⠃⠃⠂⠉⠉⠉]
 # For digits with dot between them
   - [22.333, ⠼⠃⠃⠄⠉⠉⠉]
+# For minus sign with white spaces on both sides
+  - [" - "," ⠤ "]
+# Dollar sign
+  - ["22$","⠼⠃⠃⠈⠙"]
+# Percent sign
+  - ["22%","⠼⠃⠃⠼⠚⠴"]
+# Apostrophe when translating forward.
+  - ["Tomorrow is John's birthday","⠨⠞⠕⠍⠕⠗⠗⠕⠺ ⠊⠎ ⠨⠚⠕⠓⠝⠄⠎ ⠃⠊⠗⠞⠓⠙⠁⠽"]
+# Mathematical operators, and signs between numbers
+  - ["2+2=4","⠼⠃⠖⠼⠃⠶⠼⠙"]
+  - ["2*2=4","⠼⠃⠔⠼⠃⠶⠼⠙"]
+  - ["2-2=0","⠼⠃⠤⠼⠃⠶⠼⠚"]
+  - ["1/2+1/2=1","⠼⠁⠲⠼⠃⠖⠼⠁⠲⠼⠃⠶⠼⠁"]
+  - ["2:22","⠼⠃⠒⠼⠃⠃"]
+# Unicode multiplication symbol.
+  - ["2×2=4","⠼⠃⠄⠼⠃⠶⠼⠙"]
+# Backslash
+  - [\\,"⠌"]
+# At sign
+  - ["aa@a.com","⠁⠁⠜⠁⠄⠉⠕⠍"]

--- a/tests/braille-specs/pl-pl-comp8_harness.yaml
+++ b/tests/braille-specs/pl-pl-comp8_harness.yaml
@@ -1,3 +1,10 @@
+# Copyright © 2019 by Łukasz Golonka <wulfryk1@gmail.com>
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
 display: unicode-without-blank.dis
 table:
   locale: pl
@@ -17,3 +24,8 @@ tests:
   - ['+44,0123456789', ⠖⢙⢙⠂⢚⢁⢃⢉⢙⢑⢋⢛⢓⢊]
   - [●, ⠔]
   - [–, ⠤]
+# Greek letters and some matematical operators. As there is no official computer braile standard for Polish literary symbols are used for these to make them recognizable.
+  - [ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ, ⠸⠁⠸⠃⠸⠛⠸⠙⠸⠑⠸⠵⠸⠱⠸⠹⠸⠊⠸⠅⠸⠇⠸⠍⠸⠝⠸⠭⠸⠕⠸⠏⠸⠗⠸⠎⠸⠞⠸⠥⠸⠋⠸⠯⠸⠽⠸⠺]
+  - [αβγδεζηθικλμνξοπρςτυφχψω, ⠰⠁⠰⠃⠰⠛⠰⠙⠰⠑⠰⠵⠰⠱⠰⠹⠰⠊⠰⠅⠰⠇⠰⠍⠰⠝⠰⠭⠰⠕⠰⠏⠰⠗⠰⠎⠰⠞⠰⠥⠰⠋⠰⠯⠰⠽⠰⠺]
+  - [≤, ⠪⠶]
+  - [≥, ⠕⠶]


### PR DESCRIPTION
This PR implements the following:
 - Closes #804
- Removes some unneeded mitnum symbols from the Polish Grade 1.
- Fixes some symbols which weren't defined according to the specification.
- Makes it possible to type dot from a braille keyboard.
 - Adds Greek letters  and some commonly used math operators to both Grade 1 and computer braille table,

I've added tests for the first wave of changes - creating them for simple characters such as Greek letters makes no sense in my opinion.