### PR TITLE
Remove the second, undocumented argument to lou_translate

### DIFF
--- a/tools/lou_translate.c
+++ b/tools/lou_translate.c
@@ -131,8 +131,6 @@ main(int argc, char **argv) {
 	int forward_flag = 0;
 	int backward_flag = 0;
 
-	FILE *input;
-
 	const struct option longopts[] = {
 		{ "help", no_argument, NULL, 'h' },
 		{ "version", no_argument, NULL, 'v' },
@@ -173,30 +171,16 @@ main(int argc, char **argv) {
 		exit(EXIT_FAILURE);
 	}
 
-	// if (optind != argc - 1)
-	//   {
-	// 	// Print error message and exit.
-	// 	if (optind < argc - 1)
-	//   fprintf (stderr, "%s: extra operand: %s\n",
-	// 	   program_name, argv[optind + 1]);
-	// 	else
-	//   fprintf (stderr, "%s: no table specified\n",
-	// 	   program_name);
-	// 	fprintf (stderr, "Try `%s --help' for more information.\n",
-	// 			 program_name);
-	// 	exit (EXIT_FAILURE);
-	//   }
-	if (!argv[optind + 0]) {
-		fprintf(stderr, "%s: no table specified\n", program_name);
+	if (optind != argc - 1) {
+		// Print error message and exit.
+		if (optind < argc - 1)
+			fprintf(stderr, "%s: extra operand: %s\n", program_name, argv[optind + 1]);
+		else
+			fprintf(stderr, "%s: no table specified\n", program_name);
 		fprintf(stderr, "Try `%s --help' for more information.\n", program_name);
 		exit(EXIT_FAILURE);
 	}
-	if (argv[optind + 1]) {
-		input = fopen(argv[optind + 1], "r");
-	} else
-		input = stdin;
-
 	/* assume forward translation by default */
-	translate_input(!backward_flag, argv[optind], input);
+	translate_input(!backward_flag, argv[optind], stdin);
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
`lou_translate` has had an undocumented feature to directly specify a file to translate instead of piping it in via `stdin`. This code crashes if a non-existing file is passed in (see #849).

This PR takes a different approach at preventing this crash than the previous PR (#850).

In the spirit of _less is more_, instead of making the code more tamper-proof and documenting it, we simply remove this feature.

The behaviour can easily be had by using `lou_translate foo.tbl < bar.txt`

Fixes #849

Supercedes #850