### PR TITLE
Fix endless loop in makeCorrections and translatePass (backTranslateString.c)

### DIFF
--- a/tests/yaml/multipass-backward.yaml
+++ b/tests/yaml/multipass-backward.yaml
@@ -174,3 +174,41 @@ tests:
   - ⠴
   - 5
 
+# Multipass rules should not go in endless loop when startMatch == endReplace
+table: |
+  include tables/unicode-without-blank.dis
+  include tables/en-us-comp8.ctb
+  nofor correct []"bar0" "foo"
+  nofor context []@12-1-1235-2 "foo"
+  nofor pass2 []@12-1-1235-23 @124-135-135
+flags: {testmode: backward}
+tests:
+  - - ⠃⠁⠗⠴
+    - foobar0
+  - - ⠃⠁⠗⠂
+    - foobar1
+    - xfail: context rule can still cause endless loop
+  - - ⠃⠁⠗⠆
+    - foobar2
+
+table: |
+  include tables/unicode.dis
+  include tables/loweredDigits6Dots.uti
+  include tables/latinLetterDef6Dots.uti
+  nofor context `[]$l "foo"
+flags: {testmode: backward}
+tests:
+  - - ⠃⠁⠗⠂
+    - foobar1
+    - xfail: context rule can still cause endless loop
+
+table: |
+  include tables/unicode.dis
+  include tables/loweredDigits6Dots.uti
+  include tables/latinLetterDef6Dots.uti
+  nofor pass2 `[]$l @124-135-135
+flags: {testmode: backward}
+tests:
+  - - ⠃⠁⠗⠆
+    - foobar2
+


### PR DESCRIPTION
This is the part of https://github.com/liblouis/liblouis/pull/860 that was not included yet and is OK to include.