### PR TITLE
Enable sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: bertfrees # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
I've added Liblouis to IssueHunt: https://issuehunt.io/r/liblouis/liblouis. This enables us or anyone else to put bounties on specific issues. I haven't installed the IssueHunt app on the repo yet. This is needed in order to enjoy all of the features such as bounty requests, bot commenting, automatic PR submission and automatic rewarding, but I'll wait a bit with that.

If we add this YAML file it should create a sponsor button. Later we can add more stuff to it, e.g. I'm planning to sign up with GitHub Sponsors.