### PR TITLE
Python bindings: always use mbcs on windows to encode file path, `getTypeformForEmphClass` fix and clean up

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,14 +14,17 @@ issues]].
 
 ** Bug fixes
 - Fix a crash on sparc64 thanks to Samuel Thibault.
-- Fix a problem in the Python bindings when invoking ~compileString~
-  with Python3 thanks to André-Abush Clause.
 - Fixed a bug where the ~inputPos~ array was not monotonically
   increasing. This is a problem for language bindings that try to do
   hyphenation based on this information. Thanks to Bert Frees.
 - A couple of small Coverity fixes thanks to David King.
 - Fix an infinite loop involving multipass rules and backtranslation
   thanks to Bert Frees and Bue Vester-Andersen.
+- Fix several problems in the Python bindings thanks to Leonard de Ruijter,
+  Łukasz Golonka and André-Abush Clause:
+  - Rather than ~sys.getfilesystemencoding~, we use ~locale.getpreferredencoding~ to encode filename.
+  - ~getTypeformForEmphClass~ was passed a decoded string on Python 3 instead of an encoded one.
+  - The same applies to compileString. We encoded the input string, but never used that encoded one when passing it to liblouis.
 ** Braille table improvements
 - Improvements to Afrikaans thanks to Christo de Klerk
   - Fixed back translation of some lower words.

--- a/NEWS
+++ b/NEWS
@@ -22,9 +22,12 @@ issues]].
   thanks to Bert Frees and Bue Vester-Andersen.
 - Fix several problems in the Python bindings thanks to Leonard de Ruijter,
   Łukasz Golonka and André-Abush Clause:
-  - Rather than ~sys.getfilesystemencoding~, we use ~locale.getpreferredencoding~ to encode filename.
-  - ~getTypeformForEmphClass~ was passed a decoded string on Python 3 instead of an encoded one.
-  - The same applies to compileString. We encoded the input string, but never used that encoded one when passing it to liblouis.
+  - Ensure that the mbcs encoding is always used to encode file path on Windows,
+    especially when 'Unicode UTF-8' feature is enabled.
+  - ~getTypeformForEmphClass~ was passed a decoded string on Python 3
+    instead of an encoded one.
+  - The same applies to compileString. We encoded the input string,
+    but never used that encoded one when passing it to liblouis.
 ** Braille table improvements
 - Improvements to Afrikaans thanks to Christo de Klerk
   - Fixed back translation of some lower words.

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -3,20 +3,20 @@
 # Copyright (C) 2009, 2010 James Teh <jamie@jantrid.net>
 #
 # This file is part of liblouis.
-# 
+#
 # liblouis is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published
 # by the Free Software Foundation, either version 2.1 of the License, or
 # (at your option) any later version.
-# 
+#
 # liblouis is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 # Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
-# 
+#
 
 """Liblouis Python ctypes bindings
 These bindings allow you to use the liblouis braille translator and back-translator library from within Python.
@@ -44,20 +44,31 @@ import sys
 # Some general utility functions
 def _createTablesString(tablesList):
     """Creates a tables string for liblouis calls"""
-    return b",".join([x.encode(filesystemencoding) if isinstance(x, str) else bytes(x) for x in tablesList])
+    return b",".join(
+        [
+            x.encode(filesystemencoding) if isinstance(x, str) else bytes(x)
+            for x in tablesList
+        ]
+    )
+
 
 def _createTypeformbuf(length, typeform=None):
     """Creates a typeform buffer for liblouis calls"""
-    return (c_ushort*length)(*typeform) if typeform else (c_ushort*length)()
+    return (c_ushort * length)(*typeform) if typeform else (c_ushort * length)()
+
 
 ENCODING_ERROR_HANDLER = None
 createEncodedByteString = None
 if sys.version_info.major == 2:
     ENCODING_ERROR_HANDLER = "strict"
-    createEncodedByteString = lambda x: unicode(x).encode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
-else: # sys.version_info[0] == 3
+    createEncodedByteString = lambda x: unicode(x).encode(
+        conversionEncoding, errors=ENCODING_ERROR_HANDLER
+    )
+else:  # sys.version_info[0] == 3
     ENCODING_ERROR_HANDLER = "surrogatepass"
-    createEncodedByteString = lambda x: str(x).encode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
+    createEncodedByteString = lambda x: str(x).encode(
+        conversionEncoding, errors=ENCODING_ERROR_HANDLER
+    )
 
 try:
     # Native win32
@@ -76,25 +87,62 @@ liblouis.lou_version.restype = c_char_p
 liblouis.lou_charSize.restype = c_int
 
 liblouis.lou_translateString.argtypes = (
-    c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char), 
-         POINTER(c_int), POINTER(c_ushort), POINTER(c_char), c_int)
+    c_char_p,
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_ushort),
+    POINTER(c_char),
+    c_int,
+)
 
 liblouis.lou_translate.argtypes = (
-    c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char), 
-         POINTER(c_int), POINTER(c_ushort), POINTER(c_char), 
-         POINTER(c_int), POINTER(c_int), POINTER(c_int), c_int)
+    c_char_p,
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_ushort),
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_int),
+    POINTER(c_int),
+    c_int,
+)
 
 liblouis.lou_backTranslateString.argtypes = (
-         c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char),
-         POINTER(c_int), POINTER(c_ushort), POINTER(c_char), c_int)
+    c_char_p,
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_ushort),
+    POINTER(c_char),
+    c_int,
+)
 
 liblouis.lou_backTranslate.argtypes = (
-         c_char_p, POINTER(c_char), POINTER(c_int), POINTER(c_char), POINTER(c_int),
-         POINTER(c_ushort), POINTER(c_char), POINTER(c_int), POINTER(c_int),
-         POINTER(c_int), c_int)
+    c_char_p,
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_ushort),
+    POINTER(c_char),
+    POINTER(c_int),
+    POINTER(c_int),
+    POINTER(c_int),
+    c_int,
+)
 
 liblouis.lou_hyphenate.argtypes = (
-         c_char_p, POINTER(c_char), c_int, POINTER(c_char), c_int)
+    c_char_p,
+    POINTER(c_char),
+    c_int,
+    POINTER(c_char),
+    c_int,
+)
 
 liblouis.lou_checkTable.argtypes = (c_char_p,)
 
@@ -103,12 +151,20 @@ liblouis.lou_compileString.argtypes = (c_char_p, c_char_p)
 liblouis.lou_getTypeformForEmphClass.argtypes = (c_char_p, c_char_p)
 
 liblouis.lou_dotsToChar.argtypes = (
-    c_char_p, POINTER(c_char), POINTER(c_char), 
-         c_int, c_int)
+    c_char_p,
+    POINTER(c_char),
+    POINTER(c_char),
+    c_int,
+    c_int,
+)
 
 liblouis.lou_charToDots.argtypes = (
-    c_char_p, POINTER(c_char), POINTER(c_char), 
-         c_int, c_int)
+    c_char_p,
+    POINTER(c_char),
+    POINTER(c_char),
+    c_int,
+    c_int,
+)
 
 LogCallback = _functype(None, c_int, c_char_p)
 
@@ -117,7 +173,7 @@ liblouis.lou_registerLogCallback.restype = None
 liblouis.lou_setLogLevel.restype = None
 liblouis.lou_setLogLevel.argtypes = (c_int,)
 
-#{ Module Configuration
+# { Module Configuration
 #: Specifies the charSize (in bytes) used by liblouis.
 #: This is fetched once using L{liblouis.lou_charSize}.
 #: Call it directly, since L{charSize} is not yet defined.
@@ -135,7 +191,8 @@ filesystemencoding = sys.getfilesystemencoding()
 #: Specifies the encoding to use when converting from byte strings to unicode strings.
 #: @type: str
 conversionEncoding = "utf_%d_le" % (wideCharBytes * 8)
-#}
+# }
+
 
 def version():
     """Obtain version information for liblouis.
@@ -145,12 +202,14 @@ def version():
     """
     return liblouis.lou_version().decode("ASCII")
 
+
 def charSize():
     """Obtain charSize information for liblouis.
     @return: The size of the widechar with which liblouis was compiled.
     @rtype: int
     """
     return liblouis.lou_charSize()
+
 
 def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     """Translate a string of characters, providing position information.
@@ -176,21 +235,42 @@ def translate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
-    outlen = c_int(inlen.value*outlenMultiplier)
+    outlen = c_int(inlen.value * outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
     if typeform:
         typeformbuf = _createTypeformbuf(outlen.value, typeform)
-    inPos = (c_int*outlen.value)()
-    outPos = (c_int*inlen.value)()
+    inPos = (c_int * outlen.value)()
+    outPos = (c_int * inlen.value)()
     cursorPos = c_int(cursorPos)
-    if not liblouis.lou_translate(tablesString, inbuf, byref(inlen), 
-                                  outbuf, byref(outlen), typeformbuf, 
-                                  None, outPos, inPos, byref(cursorPos), mode):
-        raise RuntimeError("Can't translate: tables %s, inbuf %s, typeform %s, cursorPos %s, mode %s"%(tableList, inbuf, typeform, cursorPos, mode))
+    if not liblouis.lou_translate(
+        tablesString,
+        inbuf,
+        byref(inlen),
+        outbuf,
+        byref(outlen),
+        typeformbuf,
+        None,
+        outPos,
+        inPos,
+        byref(cursorPos),
+        mode,
+    ):
+        raise RuntimeError(
+            "Can't translate: tables %s, inbuf %s, typeform %s, cursorPos %s, mode %s"
+            % (tableList, inbuf, typeform, cursorPos, mode)
+        )
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
+    return (
+        outbuf.raw[: outlen.value * wideCharBytes].decode(
+            conversionEncoding, errors=ENCODING_ERROR_HANDLER
+        ),
+        inPos[: outlen.value],
+        outPos[: inlen.value],
+        cursorPos.value,
+    )
+
 
 def translateString(tableList, inbuf, typeform=None, mode=0):
     """Translate a string of characters.
@@ -211,18 +291,31 @@ def translateString(tableList, inbuf, typeform=None, mode=0):
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
-    outlen = c_int(inlen.value*outlenMultiplier)
+    outlen = c_int(inlen.value * outlenMultiplier)
     outbuf = create_string_buffer(outlen.value * wideCharBytes)
     typeformbuf = None
     if typeform:
         typeformbuf = _createTypeformbuf(outlen.value, typeform)
-    if not liblouis.lou_translateString(tablesString, inbuf, byref(inlen), 
-                                        outbuf, byref(outlen), typeformbuf, 
-                                        None, mode):
-        raise RuntimeError("Can't translate: tables %s, inbuf %s, typeform %s, mode %s"%(tableList, inbuf, typeform, mode))
+    if not liblouis.lou_translateString(
+        tablesString,
+        inbuf,
+        byref(inlen),
+        outbuf,
+        byref(outlen),
+        typeformbuf,
+        None,
+        mode,
+    ):
+        raise RuntimeError(
+            "Can't translate: tables %s, inbuf %s, typeform %s, mode %s"
+            % (tableList, inbuf, typeform, mode)
+        )
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
+    return outbuf.raw[: outlen.value * wideCharBytes].decode(
+        conversionEncoding, errors=ENCODING_ERROR_HANDLER
+    )
+
 
 def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     """Back translates a string of characters, providing position information.
@@ -252,16 +345,37 @@ def backTranslate(tableList, inbuf, typeform=None, cursorPos=0, mode=0):
     typeformbuf = None
     if isinstance(typeform, list):
         typeformbuf = _createTypeformbuf(outlen.value)
-    inPos = (c_int*outlen.value)()
-    outPos = (c_int*inlen.value)()
+    inPos = (c_int * outlen.value)()
+    outPos = (c_int * inlen.value)()
     cursorPos = c_int(cursorPos)
-    if not liblouis.lou_backTranslate(tablesString, inbuf, byref(inlen),
-                    outbuf, byref(outlen), typeformbuf, None,
-                    outPos, inPos, byref(cursorPos), mode):
-        raise RuntimeError("Can't back translate: tables %s, inbuf %s, typeform %s, cursorPos %d, mode %d"%(tableList, inbuf, typeform, cursorPos, mode))
+    if not liblouis.lou_backTranslate(
+        tablesString,
+        inbuf,
+        byref(inlen),
+        outbuf,
+        byref(outlen),
+        typeformbuf,
+        None,
+        outPos,
+        inPos,
+        byref(cursorPos),
+        mode,
+    ):
+        raise RuntimeError(
+            "Can't back translate: tables %s, inbuf %s, typeform %s, cursorPos %d, mode %d"
+            % (tableList, inbuf, typeform, cursorPos, mode)
+        )
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER), inPos[:outlen.value], outPos[:inlen.value], cursorPos.value
+    return (
+        outbuf.raw[: outlen.value * wideCharBytes].decode(
+            conversionEncoding, errors=ENCODING_ERROR_HANDLER
+        ),
+        inPos[: outlen.value],
+        outPos[: inlen.value],
+        cursorPos.value,
+    )
+
 
 def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     """Back translate from Braille.
@@ -287,12 +401,26 @@ def backTranslateString(tableList, inbuf, typeform=None, mode=0):
     typeformbuf = None
     if isinstance(typeform, list):
         typeformbuf = _createTypeformbuf(outlen.value)
-    if not liblouis.lou_backTranslateString(tablesString, inbuf, byref(inlen), outbuf,
-                    byref(outlen), typeformbuf, None, mode):
-        raise RuntimeError("Can't back translate: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
+    if not liblouis.lou_backTranslateString(
+        tablesString,
+        inbuf,
+        byref(inlen),
+        outbuf,
+        byref(outlen),
+        typeformbuf,
+        None,
+        mode,
+    ):
+        raise RuntimeError(
+            "Can't back translate: tables %s, inbuf %s, mode %d"
+            % (tableList, inbuf, mode)
+        )
     if isinstance(typeform, list):
         typeform[:] = list(typeformbuf)
-    return outbuf.raw[:outlen.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
+    return outbuf.raw[: outlen.value * wideCharBytes].decode(
+        conversionEncoding, errors=ENCODING_ERROR_HANDLER
+    )
+
 
 def hyphenate(tableList, inbuf, mode=0):
     """Get information for hyphenation.
@@ -315,10 +443,13 @@ def hyphenate(tableList, inbuf, mode=0):
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByteString(inbuf)
     inlen = c_int(len(inbuf) // wideCharBytes)
-    hyphen_string = create_string_buffer(inlen.value + 1) 
+    hyphen_string = create_string_buffer(inlen.value + 1)
     if not liblouis.lou_hyphenate(tablesString, inbuf, inlen, hyphen_string, mode):
-        raise RuntimeError("Can't hyphenate: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
+        raise RuntimeError(
+            "Can't hyphenate: tables %s, inbuf %s, mode %d" % (tableList, inbuf, mode)
+        )
     return hyphen_string.value.decode("ASCII")
+
 
 def checkTable(tableList):
     """Check if the specified tables can be found and compiled.
@@ -332,7 +463,8 @@ def checkTable(tableList):
     """
     tablesString = _createTablesString(tableList)
     if not liblouis.lou_checkTable(tablesString):
-        raise RuntimeError("Can't compile: tables %s"%tableList)
+        raise RuntimeError("Can't compile: tables %s" % tableList)
+
 
 def compileString(tableList, inString):
     """Compile a table entry on the fly at run-time.
@@ -346,7 +478,10 @@ def compileString(tableList, inString):
     tablesString = _createTablesString(tableList)
     inBytes = inString.encode("ASCII") if isinstance(inString, str) else bytes(inString)
     if not liblouis.lou_compileString(tablesString, inBytes):
-        raise RuntimeError("Can't compile entry: tables %s, inString %s"%(tableList, inString))
+        raise RuntimeError(
+            "Can't compile entry: tables %s, inString %s" % (tableList, inString)
+        )
+
 
 def getTypeformForEmphClass(tableList, emphClass):
     """Get the typeform bit for the named emphasis class.
@@ -358,6 +493,7 @@ def getTypeformForEmphClass(tableList, emphClass):
     """
     tablesString = _createTablesString(tableList)
     return liblouis.lou_getTypeformForEmphClass(tablesString, emphClass)
+
 
 def dotsToChar(tableList, inbuf):
     """"Convert a string of dot patterns to a string of characters according to the specifications in tableList.
@@ -373,8 +509,13 @@ def dotsToChar(tableList, inbuf):
     length = c_int(len(inbuf) // wideCharBytes)
     outbuf = create_string_buffer(length.value * wideCharBytes)
     if not liblouis.lou_dotsToChar(tablesString, inbuf, outbuf, length, 0):
-        raise RuntimeError("Can't convert dots to char: tables %s, inbuf %s"%(tableList, inbuf))
-    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
+        raise RuntimeError(
+            "Can't convert dots to char: tables %s, inbuf %s" % (tableList, inbuf)
+        )
+    return outbuf.raw[: length.value * wideCharBytes].decode(
+        conversionEncoding, errors=ENCODING_ERROR_HANDLER
+    )
+
 
 def charToDots(tableList, inbuf, mode=0):
     """"Convert a string of characterss to a string of dot patterns according to the specifications in tableList.
@@ -392,8 +533,14 @@ def charToDots(tableList, inbuf, mode=0):
     length = c_int(len(inbuf) // wideCharBytes)
     outbuf = create_string_buffer(length.value * wideCharBytes)
     if not liblouis.lou_charToDots(tablesString, inbuf, outbuf, length, mode):
-        raise RuntimeError("Can't convert char to dots: tables %s, inbuf %s, mode %d"%(tableList, inbuf, mode))
-    return outbuf.raw[:length.value * wideCharBytes].decode(conversionEncoding, errors=ENCODING_ERROR_HANDLER)
+        raise RuntimeError(
+            "Can't convert char to dots: tables %s, inbuf %s, mode %d"
+            % (tableList, inbuf, mode)
+        )
+    return outbuf.raw[: length.value * wideCharBytes].decode(
+        conversionEncoding, errors=ENCODING_ERROR_HANDLER
+    )
+
 
 def registerLogCallback(logCallback):
     """Register logging callbacks.
@@ -415,20 +562,24 @@ def registerLogCallback(logCallback):
     @type logCallback: L{LogCallback}
     """
     if logCallback is not None and not isinstance(logCallback, LogCallback):
-        raise TypeError("logCallback should be of type {} or NoneType".format(LogCallback.__name__))
+        raise TypeError(
+            "logCallback should be of type {} or NoneType".format(LogCallback.__name__)
+        )
     return liblouis.lou_registerLogCallback(logCallback)
 
+
 def setLogLevel(level):
-	"""Set the level for logging callback to be called at.
+    """Set the level for logging callback to be called at.
 	@param level: one of the C{LOG_*} constants.
 	@type level: int
 	@raise ValueError: If an invalid log level is provided.
 	"""
-	if level not in logLevels:
-		raise ValueError("Level %d is an invalid log level"%level)
-	return liblouis.lou_setLogLevel(level)
+    if level not in logLevels:
+        raise ValueError("Level %d is an invalid log level" % level)
+    return liblouis.lou_setLogLevel(level)
 
-#{ Typeforms
+
+# { Typeforms
 plain_text = 0x0000
 emph_1 = comp_emph_1 = italic = 0x0001
 emph_2 = comp_emph_2 = underline = 0x0002
@@ -443,20 +594,20 @@ emph_10 = 0x0200
 computer_braille = 0x0400
 no_translate = 0x0800
 no_contract = 0x1000
-#}
+# }
 
-#{ Translation modes
+# { Translation modes
 noContractions = 1
 compbrlAtCursor = 2
 dotsIO = 4
 compbrlLeftCursor = 32
 ucBrl = 64
 noUndefined = 128
-noUndefinedDots = noUndefined # alias for backward compatiblity
+noUndefinedDots = noUndefined  # alias for backward compatiblity
 partialTrans = 256
-#}
+# }
 
-#{ logLevels
+# { logLevels
 LOG_ALL = 0
 LOG_DEBUG = 10000
 LOG_INFO = 20000
@@ -464,11 +615,11 @@ LOG_WARN = 30000
 LOG_ERROR = 40000
 LOG_FATAL = 50000
 LOG_OFF = 60000
-#}
+# }
 
 logLevels = (LOG_ALL, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL, LOG_OFF)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Just some common tests.
     print(version())
-    print(translate([b'../tables/en-us-g2.ctb'], 'Hello world!', cursorPos=5))
+    print(translate([b"../tables/en-us-g2.ctb"], "Hello world!", cursorPos=5))

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -78,6 +78,8 @@ outlenMultiplier = 4 + wideCharBytes * 2
 #: Specifies the encoding to use when encode/decode file/dir name
 #: @type: str
 fileSystemEncoding = locale.getpreferredencoding()
+if fileSystemEncoding.lower() == "cp65001":
+    fileSystemEncoding = "UTF-8"
 #: Specifies the encoding to use when converting from byte strings to unicode strings.
 #: @type: str
 conversionEncoding = "utf_%d_le" % (wideCharBytes * 8)

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -38,8 +38,7 @@ function for information about how liblouis searches for these tables.
 """
 
 from __future__ import unicode_literals
-import locale
-import sys
+from sys import getfilesystemencoding, platform, version_info
 from atexit import register
 from ctypes import (
     c_ushort,
@@ -60,7 +59,8 @@ try:  # Native win32
 except ImportError:  # Unix/Cygwin
     _loader, _functype = cdll, CFUNCTYPE
 liblouis = _loader["###LIBLOUIS_SONAME###"]
-_is_py3 = sys.version_info[0] == 3
+_is_py3 = version_info[0] == 3
+_is_windows = platform == "win32"
 _unicode_type = str if _is_py3 else unicode
 
 # { Module Configuration
@@ -77,9 +77,7 @@ wideCharBytes = liblouis.lou_charSize()
 outlenMultiplier = 4 + wideCharBytes * 2
 #: Specifies the encoding to use when encode/decode file/dir name
 #: @type: str
-fileSystemEncoding = locale.getpreferredencoding()
-if fileSystemEncoding.lower() == "cp65001":
-    fileSystemEncoding = "UTF-8"
+fileSystemEncoding = "mbcs" if _is_windows else getfilesystemencoding()
 #: Specifies the encoding to use when converting from byte strings to unicode strings.
 #: @type: str
 conversionEncoding = "utf_%d_le" % (wideCharBytes * 8)

--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -34,19 +34,61 @@ function for information about how liblouis searches for these tables.
 @author: Michael Whapples <mwhapples@aim.com>
 @author: Davy Kager <mail@davykager.nl>
 @author: Leonard de Ruijter (Babbage B.V.) <alderuijter@gmail.com>
+@author: Andre-Abush Clause <dev@andreabc.net>
 """
 
 from __future__ import unicode_literals
-from ctypes import *
-import atexit
+import locale
 import sys
+from atexit import register
+from ctypes import (
+    c_ushort,
+    CFUNCTYPE,
+    cdll,
+    c_char_p,
+    c_char,
+    c_int,
+    POINTER,
+    byref,
+    create_string_buffer,
+)
+
+try:  # Native win32
+    from ctypes import WINFUNCTYPE, windll
+
+    _loader, _functype = windll, WINFUNCTYPE
+except ImportError:  # Unix/Cygwin
+    _loader, _functype = cdll, CFUNCTYPE
+liblouis = _loader["###LIBLOUIS_SONAME###"]
+_is_py3 = sys.version_info[0] == 3
+_unicode_type = str if _is_py3 else unicode
+
+# { Module Configuration
+#: Specifies the charSize (in bytes) used by liblouis.
+#: This is fetched once using L{liblouis.lou_charSize}.
+#: Call it directly, since L{charSize} is not yet defined.
+#: @type: int
+wideCharBytes = liblouis.lou_charSize()
+#: Specifies the number by which the input length should be multiplied
+#: to calculate the maximum output length.
+#: @type: int
+# This default will handle the case where every input character is
+# undefined in the translation table.
+outlenMultiplier = 4 + wideCharBytes * 2
+#: Specifies the encoding to use when encode/decode file/dir name
+#: @type: str
+fileSystemEncoding = locale.getpreferredencoding()
+#: Specifies the encoding to use when converting from byte strings to unicode strings.
+#: @type: str
+conversionEncoding = "utf_%d_le" % (wideCharBytes * 8)
+# }
 
 # Some general utility functions
 def _createTablesString(tablesList):
     """Creates a tables string for liblouis calls"""
     return b",".join(
         [
-            x.encode(filesystemencoding) if isinstance(x, str) else bytes(x)
+            x.encode(fileSystemEncoding) if isinstance(x, str) else bytes(x)
             for x in tablesList
         ]
     )
@@ -57,30 +99,16 @@ def _createTypeformbuf(length, typeform=None):
     return (c_ushort * length)(*typeform) if typeform else (c_ushort * length)()
 
 
-ENCODING_ERROR_HANDLER = None
-createEncodedByteString = None
-if sys.version_info.major == 2:
-    ENCODING_ERROR_HANDLER = "strict"
-    createEncodedByteString = lambda x: unicode(x).encode(
-        conversionEncoding, errors=ENCODING_ERROR_HANDLER
-    )
-else:  # sys.version_info[0] == 3
-    ENCODING_ERROR_HANDLER = "surrogatepass"
-    createEncodedByteString = lambda x: str(x).encode(
-        conversionEncoding, errors=ENCODING_ERROR_HANDLER
-    )
+ENCODING_ERROR_HANDLER = "surrogatepass" if _is_py3 else "strict"
 
-try:
-    # Native win32
-    _loader = windll
-    _functype = WINFUNCTYPE
-except NameError:
-    # Unix/Cygwin
-    _loader = cdll
-    _functype = CFUNCTYPE
-liblouis = _loader["###LIBLOUIS_SONAME###"]
 
-atexit.register(liblouis.lou_free)
+def createEncodedByteString(
+    x, encoding=conversionEncoding, errors=ENCODING_ERROR_HANDLER
+):
+    return _unicode_type(x).encode(encoding, errors)
+
+
+register(liblouis.lou_free)
 
 liblouis.lou_version.restype = c_char_p
 
@@ -172,26 +200,6 @@ liblouis.lou_registerLogCallback.restype = None
 
 liblouis.lou_setLogLevel.restype = None
 liblouis.lou_setLogLevel.argtypes = (c_int,)
-
-# { Module Configuration
-#: Specifies the charSize (in bytes) used by liblouis.
-#: This is fetched once using L{liblouis.lou_charSize}.
-#: Call it directly, since L{charSize} is not yet defined.
-#: @type: int
-wideCharBytes = liblouis.lou_charSize()
-#: Specifies the number by which the input length should be multiplied
-#: to calculate the maximum output length.
-#: @type: int
-# This default will handle the case where every input character is
-# undefined in the translation table.
-outlenMultiplier = 4 + wideCharBytes * 2
-#: Specifies the encoding to use when encode/decode filenames
-#: @type: str
-filesystemencoding = sys.getfilesystemencoding()
-#: Specifies the encoding to use when converting from byte strings to unicode strings.
-#: @type: str
-conversionEncoding = "utf_%d_le" % (wideCharBytes * 8)
-# }
 
 
 def version():
@@ -492,6 +500,8 @@ def getTypeformForEmphClass(tableList, emphClass):
     @see: lou_getTypeformForEmphClass in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
+    if _is_py3:
+        emphClass = emphClass.encode("ASCII")
     return liblouis.lou_getTypeformForEmphClass(tablesString, emphClass)
 
 
@@ -526,7 +536,7 @@ def charToDots(tableList, inbuf, mode=0):
     @param mode: The translation mode; add multiple values for a combined mode.
     @type mode: int
     @raise RuntimeError: If a complete conversion could not be done.
-    @see: lou_charToDOts in the liblouis documentation
+    @see: lou_charToDots in the liblouis documentation
     """
     tablesString = _createTablesString(tableList)
     inbuf = createEncodedByteString(inbuf)
@@ -570,10 +580,10 @@ def registerLogCallback(logCallback):
 
 def setLogLevel(level):
     """Set the level for logging callback to be called at.
-	@param level: one of the C{LOG_*} constants.
-	@type level: int
-	@raise ValueError: If an invalid log level is provided.
-	"""
+    @param level: one of the C{LOG_*} constants.
+    @type level: int
+    @raise ValueError: If an invalid log level is provided.
+    """
     if level not in logLevels:
         raise ValueError("Level %d is an invalid log level" % level)
     return liblouis.lou_setLogLevel(level)


### PR DESCRIPTION
This PR fixes #895: rather than sys.getfilesystemencoding(), we use locale.getpreferredencoding as advertised by @lukaszgo1.
Also, fixes another bug, thanks to @leonardder: `getTypeformForEmphClass` was passed a decoded string on Python 3 instead of an encoded one.