### PR TITLE
Add new opcode rependword

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ issues]].
   opcode but also with other translation opcodes such as ~begword~,
   e.g. ~nocross begword sh 146~ for example. The old usage of the
   opcode no longer works, see [[Backwards incompatible changes]].
+- Added a new opcode ~rependword~, needed to implement Malay
+  braille. Thanks to Bert Frees.
 
 ** Bug fixes
 - Fix a crash on sparc64 thanks to Samuel Thibault.

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -1239,14 +1239,29 @@ repeated --- 36-36-36 shorten separator lines made with hyphens
 @end example
 
 @opcode{repword, characters dots}
-When characters are encountered check to see if the word before this
-string matches the word after it. If so, replace characters with dots
-and eliminate the second word and any word following another
-occurrence of characters that is the same. This opcode is used in
-Malaysian braille. In this case the rule is:
+When characters are encountered check to see if the word before these
+characters matches the string after them. If so, replace the
+characters with dots and eliminate the repeated string and any string
+following another occurrence of characters that is the same. This
+opcode is used in Malaysian braille. In this case the rule is:
 
 @example
 repword - 123456
+@end example
+
+@opcode{rependword, characters dots,dots}
+Like @ref{repword,@code{repword}}, but for indicating a repetition of
+a string at the end of a word. When characters are encountered check
+to see if a part of the word before these characters (but not the
+whole word) matches the string after them. If so, insert the first dot
+pattern at the position where the part of the word started, replace
+characters with the second dot pattern and eliminate the repeated
+string and any string following another occurrence of characters that
+is the same. This opcode is used in Malaysian braille. In this case
+the rule is:
+
+@example
+rependword - 25,123456
 @end example
 
 @opcode{largesign, characters dots}

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -1239,21 +1239,32 @@ repeated --- 36-36-36 shorten separator lines made with hyphens
 @end example
 
 @opcode{repword, characters dots}
-When characters are encountered check to see if the word before these
-characters matches the string after them. If so, replace the
-characters with dots and eliminate the repeated string and any string
-following another occurrence of characters that is the same. This
-opcode is used in Malaysian braille. In this case the rule is:
+For some braille systems there is the requirement to remove repeated
+words which are connected by some character. In Malaysian braille for
+example you want to contract as follows:
+
+@table @asis
+@item Text:
+@samp{tasik-tasik}
+@item Grade 1:
+@samp{2345-1-234-24-13-36-2345-1-234-24-13}
+@item Grade 2:
+@samp{2345-1-234-24-13-123456}
+@end table
+
+The dash and the second occurrence of @samp{tasik} is replaced with
+dots @samp{123456}. To achieve this you can use the repword opcode as
+follows:
 
 @example
 repword - 123456
 @end example
 
-@opcode{rependword, characters dots,dots}
-Like @ref{repword,@code{repword}}, but for indicating a repetition of
-a string at the end of a word. When characters are encountered check
-to see if a part of the word before these characters (but not the
-whole word) matches the string after them. If so, insert the first dot
+@opcode{rependword, characters dots@comma{} dots}
+Like the @opcoderef{repword}, but for indicating a repetition of a
+string at the end of a word. When characters are encountered check to
+see if a part of the word before these characters (but not the whole
+word) matches the string after them. If so, insert the first dot
 pattern at the position where the part of the word started, replace
 characters with the second dot pattern and eliminate the repeated
 string and any string following another occurrence of characters that
@@ -1629,8 +1640,8 @@ by a comma.
 
 Let's say that you'd like to define the opening and closing
 parentheses via multipass rules, and that you'd like to use dots
-123478 for the opening parenthesis and dots 145678 for the closing
-parenthesis. One way to do so is like this:
+@samp{123478} for the opening parenthesis and dots @samp{145678} for
+the closing parenthesis. One way to do so is like this:
 
 @example
 grouping parentheses () 123478,145678
@@ -3835,6 +3846,6 @@ directory. Usage information is included in the Python module itself.
 @c  LocalWords:  dotsIO ucBrl noUndefined partialTrans capsletter
 @c  LocalWords:  abc doctest inString enum cp outbufbuf logcallback fprint
 @c  LocalWords:  lbu EOF heckTable fn ispell getTypeformForEmphClass
-@c  LocalWords:  indexTables begcapsword endcapsword typeforms
+@c  LocalWords:  indexTables begcapsword endcapsword typeforms tasik
 @c  LocalWords:  endemphphraseopcode emphClass BrailleSense HumanWare
 @c  LocalWords:  BrailleNote refreshable

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -290,6 +290,7 @@ typedef enum { /* Op codes */
 	CTO_Pass4,
 	CTO_Repeated,
 	CTO_RepWord,
+	CTO_RepEndWord,
 	CTO_CapsNoCont,
 	CTO_Always,
 	CTO_ExactDots,

--- a/tests/yaml/repword.yaml
+++ b/tests/yaml/repword.yaml
@@ -1,14 +1,64 @@
 # see issue https://github.com/liblouis/liblouis/issues/787
+
+table: |
+  include tables/latinLetterDef6Dots.uti
+  space \s 0
+  display ^ 46
+  capsletter 46
+  punctuation . 6
+  sign - 25
+  display = 123456
+  display : 456
+  repword - 123456
+  rependword - 456,123456
+  always aaa 1-1-1
+  always ccc 14-14-14
+
+tests:
+  - - abc-abc
+    - abc=
+  - - .abc-abc
+    - .abc=
+  - - .abc-.abc
+    - .abc-.abc
+  - - abc def-abc def
+    - abc def-abc def
+  - - abc abc-abc abc
+    - abc abc= abc
+  - - abc-abc-abc
+    - abc=
+  - - aaabc-aaabc
+    - aaabc=
+  - - abc-abcxxx
+    - abc=xxx
+  - - abc-abccc
+    - abc=cc
+  - - xxxabc-abc
+    - xxx:abc=
+  - - aaabc-abc
+    - aaabc-abc
+  - - xxxabc-abcxxx
+    - xxx:abc=xxx
+
+
+
+# ---------------------------------------------------------
+# FIXME: move the tests below to ms-my-g2.yaml when Malay table has been added
+
+# Copyright © 2019 Herbert Koh
+# Copyright © 2019 Bert Frees
 #
-# These examples refer to the Malay braille system so should probably
-# be moved to a "ms-g2.yaml" file in the future. Some more targeted
-# regression tests for repword should then be added to this file.
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
 
 display: tables/unicode.dis
 table: |
   include tables/spaces.uti
   include tables/latinLetterDef6Dots.uti
   repword - 123456
+  rependword - 25,123456
   always an 12456
   always ang 1-346
   always ber 23
@@ -39,7 +89,6 @@ tests:
   # between.
   - - berjalan-jalan
     - ⠆⠒⠚⠇⠝⠿
-    - xfail: "repword does not work with prefix (and dots 25 is missing)"
 
   # 3. Repeated word with suffix
   #
@@ -62,4 +111,3 @@ tests:
   # suffix "nya" will come immediately after the repeat sign.
   - - sekurang-kurangnya
     - ⠹⠒⠅⠥⠗⠁⠬⠿⠪⠁
-    - xfail: "repword does not work with prefix (and dots 25 is missing)"


### PR DESCRIPTION
With this opcode you can indicate that a part of a word between a start and end mark is repeated. With the existing repword opcode you could only repeat a whole word.

This fixes issue https://github.com/liblouis/liblouis/issues/787

Also fixed some small issue with the existing repword opcode.