### PR TITLE
Update zh-tw.ctb version to 2020-02

### DIFF
--- a/tables/zh-tw.ctb
+++ b/tables/zh-tw.ctb
@@ -1,7 +1,7 @@
 # Bopomofo-based Chinese Braille Table
 #
 #  Copyright (C) 2008-2017 Coscell Kao <coscell@gmail.com>
-#  Copyright (C) 2017-2019 nvda-tw <https://groups.io/g/nvda-tw>
+#  Copyright (C) 2017-2020 nvda-tw <https://groups.io/g/nvda-tw>
 #
 #  This file is part of liblouis.
 #
@@ -20,7 +20,7 @@
 #  <http://www.gnu.org/licenses/>.
 
 # Currently maintained by Sponge Jhan <school510587@yahoo.com.tw>
-# Version: 2019-11
+# Version: 2020-02
 #
 # This table mainly conforms to the rules listed in the
 # following Wikipedia page to braille Han characters:
@@ -31201,6 +31201,7 @@ noback correct "\x3905" "\x611B"
 noback correct "\x3907" "\x61CA"
 noback correct "\x390A" "\x6054"
 noback correct "\x3913" "\x7B28"
+noback correct "\x3917" "\x6CF0"
 noback correct "\x3918" "\x396E"
 noback correct "\x3919" "\x6069"
 noback correct "\x391B" "\x6041"
@@ -32462,8 +32463,8 @@ noback correct "\x4EE7" "\x9577"
 noback correct "\x4EEA" "\x5100"
 noback correct "\x4EEC" "\x5011"
 noback correct _1"\x8D70"["\x4EF7"]"\x99B3\x66F8" "\x4EF7"
-noback correct _1"\x662D"["\x4EF7"] "\x4EF7"
 noback correct _1"\x7121"["\x4EF7"]"\x4E8B" "\x4EF7"
+noback correct _1"\x662D"["\x4EF7"] "\x4EF7"
 noback correct "\x4EF7" "\x50F9"
 noback correct "\x4EFA" "\x5009"
 noback correct "\x4EFE" "\x4F4E"
@@ -32616,9 +32617,9 @@ noback correct "\x51D2" "\x769A"
 noback correct "\x51D6" "\x6E96"
 noback correct "\x51DB" "\x51DC"
 noback correct "\x51DF" "\x7006"
-noback correct _1"\x8336"["\x51E0"] "\x51E0"
-noback correct _2"\x7A97\x660E"["\x51E0"]"\x6DE8" "\x51E0"
 noback correct _3"\x660E\x7A97\x6DE8"["\x51E0"] "\x51E0"
+noback correct _2"\x7A97\x660E"["\x51E0"]"\x6DE8" "\x51E0"
+noback correct _1"\x8336"["\x51E0"] "\x51E0"
 noback correct "\x51E0" "\x5E7E"
 noback correct "\x51E2" "\x51E1"
 noback correct "\x51E3" "\x51E1"
@@ -33145,8 +33146,8 @@ noback correct "\x5C2B" "\x5C2A"
 noback correct "\x5C32" "\x5C37"
 noback correct "\x5C34" "\x5C37"
 noback correct "\x5C36" "\x5C37"
-noback correct ["\x5C38"]"\x5B50" "\x5C38"
 noback correct _1"\x96DE"["\x5C38"]"\x725B\x5F9E" "\x5C38"
+noback correct ["\x5C38"]"\x5B50" "\x5C38"
 noback correct "\x5C38" "\x5C4D"
 noback correct "\x5C3D" "\x76E1"
 noback correct "\x5C42" "\x5C64"
@@ -33169,8 +33170,8 @@ noback correct "\x5C99" "\x5DB4"
 noback correct "\x5C9A" "\x5D50"
 noback correct "\x5C9B" "\x5CF6"
 noback correct "\x5C9E" "\x5C9D"
-noback correct ["\x5CAD"]"\x5DC6" "\x5CAD"
 noback correct ["\x5CAD"]"\x5D64" "\x5CAD"
+noback correct ["\x5CAD"]"\x5DC6" "\x5CAD"
 noback correct "\x5CAD" "\x5DBA"
 noback correct "\x5CB4" "\x5D87"
 noback correct "\x5CB9" "\x5CA7"
@@ -33262,9 +33263,9 @@ noback correct "\x5E5A" "\x5E6B"
 noback correct "\x5E5E" "\x8946"
 noback correct "\x5E77" "\x5E76"
 noback correct "\x5E7A" "\x4E48"
+noback correct _2"\x67B6\x5D16"["\x5E7F"] "\x5E7F"
 noback correct _1"\x8349"["\x5E7F"]"\x7A81\x5982\x5CD9" "\x5E7F"
 noback correct _2"\x8606\x96EA"["\x5E7F"] "\x5E7F"
-noback correct _2"\x67B6\x5D16"["\x5E7F"] "\x5E7F"
 noback correct "\x5E7F" "\x5EE3"
 noback correct "\x5E81" "\x5EF3"
 noback correct "\x5E83" "\x5EE3"
@@ -33685,8 +33686,8 @@ noback correct "\x66FD" "\x66FE"
 noback correct "\x670C" "\x9812"
 noback correct "\x6716" "\x6717"
 noback correct "\x6719" "\x660E"
-noback correct _1"\x84BC"["\x672F"] "\x672F"
 noback correct _1"\x767D"["\x672F"] "\x672F"
+noback correct _1"\x84BC"["\x672F"] "\x672F"
 noback correct "\x672F" "\x8853"
 noback correct "\x6736" "\x6735"
 noback correct "\x673A" "\x6A5F"
@@ -34483,8 +34484,8 @@ noback correct "\x79C3" "\x79BF"
 noback correct "\x79C6" "\x7A08"
 noback correct "\x79CA" "\x5E74"
 noback correct "\x79CC" "\x79CB"
-noback correct ["\x79CD"]"\x5E2B\x4E2D" "\x79CD"
 noback correct ["\x79CD"]"\x5E2B\x9053" "\x79CD"
+noback correct ["\x79CD"]"\x5E2B\x4E2D" "\x79CD"
 noback correct "\x79CD" "\x7A2E"
 noback correct "\x79D0" "\x8018"
 noback correct "\x79D4" "\x7CB3"
@@ -35174,8 +35175,8 @@ noback correct "\x8715" "\x86FB"
 noback correct "\x8716" "\x86D4"
 noback correct "\x8717" "\x8778"
 noback correct "\x871D" "\x871E"
-noback correct _2"\x5468\x66F0"["\x8721"] "\x8721"
 noback correct ["\x8721"]"\x796D" "\x8721"
+noback correct _2"\x5468\x66F0"["\x8721"] "\x8721"
 noback correct "\x8721" "\x881F"
 noback correct "\x872B" "\x45B5"
 noback correct "\x872F" "\x868C"
@@ -35227,11 +35228,11 @@ noback correct "\x8873" "\x5E52"
 noback correct "\x8884" "\x8956"
 noback correct "\x8885" "\x88CA"
 noback correct "\x8886" "\x8918"
-noback correct ["\x889C"]"\x8179" "\x889C"
-noback correct _1"\x5BF6"["\x889C"]"\x695A\x5BAE\x8170" "\x889C"
-noback correct ["\x889C"]"\x984D" "\x889C"
 noback correct ["\x889C"]"\x809A" "\x889C"
 noback correct ["\x889C"]"\x80F8" "\x889C"
+noback correct ["\x889C"]"\x984D" "\x889C"
+noback correct _1"\x5BF6"["\x889C"]"\x695A\x5BAE\x8170" "\x889C"
+noback correct ["\x889C"]"\x8179" "\x889C"
 noback correct "\x889C" "\x896A"
 noback correct "\x88A0" "\x889F"
 noback correct "\x88AD" "\x8972"
@@ -38203,6 +38204,9 @@ noback context ["\x597D"]"\x751F\x4E4B\x5FB7" @1235-146-5
 noback context ["\x597D"]"\x9AD8\x9A16\x9060" @1235-146-5
 noback context _3"\x597D\x9AD8\x9A16"["\x9060"] @45-4
 
+# \x5982\x6578\x5BB6\x73CD 1245-34-2-24-34-4-13-23456-3-1-136-3
+noback context _1"\x5982"["\x6578"]"\x5BB6\x73CD" @24-34-4
+
 # \x5A01\x5100\x902E\x902E 1246-3-16-2-145-16-5-145-16-5
 noback context _2"\x5A01\x5100"["\x902E"]"\x902E" @145-16-5
 noback context _3"\x5A01\x5100\x902E"["\x902E"] @145-16-5
@@ -39905,6 +39909,11 @@ noback context ["\x4E0D"]"\x53AD\x53AD" @135-34-5
 noback context _1"\x4E0D"["\x53AD"]"\x53AD" @2345-5
 noback context _2"\x4E0D\x53AD"["\x53AD"] @2345-5
 
+# \x4E0D\x5C11\x5973 135-34-5-24-146-4-1345-1256-4
+noback context ["\x4E0D"]"\x5C11\x5973" @135-34-5
+noback context _1"\x4E0D"["\x5C11"]"\x5973" @24-146-4
+noback context _2"\x4E0D\x5C11"["\x5973"] @1345-1256-4
+
 # \x4E0D\x5F97\x4E86 135-34-5-145-2346-2-14-246-4
 noback context ["\x4E0D"]"\x5F97\x4E86" @135-34-5
 noback context _2"\x4E0D\x5F97"["\x4E86"] @14-246-4
@@ -40567,6 +40576,10 @@ noback context ["\x5953"]"\x96C4\x8C54" @12-156-4
 # \x5954\x5C3C\x6492 135-136-3-1345-16-2-15-345-3
 noback context _2"\x5954\x5C3C"["\x6492"] @15-345-3
 
+# \x597D\x4E00\x6703 1235-146-4-16-3-1235-1246-4
+noback context ["\x597D"]"\x4E00\x6703" @1235-146-4
+noback context _2"\x597D\x4E00"["\x6703"] @1235-1246-4
+
 # \x597D\x5584\x60E1 1235-146-5-24-1236-5-34-5
 noback context ["\x597D"]"\x5584\x60E1" @1235-146-5
 noback context _2"\x597D\x5584"["\x60E1"] @34-5
@@ -40922,6 +40935,10 @@ noback context ["\x6384"]"\x4E0D\x5230" @14-123456-2
 # \x6392\x5B50\x8ECA 1234-2456-4-125-156-1-12-2346-3
 noback context ["\x6392"]"\x5B50\x8ECA" @1234-2456-4
 noback context _2"\x6392\x5B50"["\x8ECA"] @12-2346-3
+
+# \x6392\x884C\x7A0B 1234-2456-2-15-13456-2-12-1356-2
+noback context ["\x6392"]"\x884C\x7A0B" @1234-2456-2
+noback context _1"\x6392"["\x884C"]"\x7A0B" @15-13456-2
 
 # \x63A8\x8457\x624B 124-1246-3-1-2346-1-24-12356-4
 noback context _1"\x63A8"["\x8457"]"\x624B" @1-2346-1
@@ -41525,6 +41542,9 @@ noback context _2"\x773C\x93E1"["\x884C"] @1235-1346-2
 
 # \x7761\x4E00\x89BA 24-1246-5-16-3-13-246-5
 noback context _2"\x7761\x4E00"["\x89BA"] @13-246-5
+
+# \x7761\x500B\x89BA 24-1246-5-13-2346-5-13-246-5
+noback context _2"\x7761\x500B"["\x89BA"] @13-246-5
 
 # \x7761\x61F6\x89BA 24-1246-5-14-1236-4-13-246-5
 noback context _2"\x7761\x61F6"["\x89BA"] @13-246-5
@@ -43322,6 +43342,9 @@ noback context _1"\x514B"["\x96E3"] @1345-1236-5
 # \x515C\x7387 145-12356-3-24-2356-5
 noback context _1"\x515C"["\x7387"] @24-2356-5
 
+# \x5167\x5B50 1345-356-5-125-156-4
+noback context _1"\x5167"["\x5B50"] @125-156-4
+
 # \x5167\x61C9 1345-356-5-13456-5
 noback context _1"\x5167"["\x61C9"] @13456-5
 
@@ -44239,6 +44262,9 @@ noback context _1"\x559C"["\x597D"] @1235-146-5
 
 # \x559D\x6B62 1235-2346-5-1-156-4
 noback context ["\x559D"]"\x6B62" @1235-2346-5
+
+# \x559D\x7F75 1235-2346-5-134-345-5
+noback context ["\x559D"]"\x7F75" @1235-2346-5
 
 # \x559D\x91C7 1235-2346-5-245-2456-4
 noback context ["\x559D"]"\x91C7" @1235-2346-5
@@ -45581,6 +45607,9 @@ noback context ["\x5F8D"]"\x5FA5" @35-3
 # \x5F97\x5B50 145-2346-2-125-156-4
 noback context _1"\x5F97"["\x5B50"] @125-156-4
 
+# \x5F9E\x5B50 245-12346-2-125-156-4
+noback context _1"\x5F9E"["\x5B50"] @125-156-4
+
 # \x5F9E\x8005 125-12346-5-1-2346-4
 noback context ["\x5F9E"]"\x8005" @125-12346-5
 
@@ -46816,6 +46845,9 @@ noback context _1"\x660E"["\x9419"] @145-1356-3
 
 # \x6613\x50B3 16-5-1-12456-5
 noback context _1"\x6613"["\x50B3"] @1-12456-5
+
+# \x6613\x5B50 16-5-125-156-4
+noback context _1"\x6613"["\x5B50"] @125-156-4
 
 # \x6614\x902E 15-16-2-145-2456-5
 noback context _1"\x6614"["\x902E"] @145-2456-5
@@ -49795,6 +49827,9 @@ noback context _1"\x81EA"["\x8655"] @12-34-4
 
 # \x81F7\x570B 1-156-5-13-25-2
 noback context ["\x81F7"]"\x570B" @1-156-5
+
+# \x8207\x5B50 1256-4-125-156-4
+noback context _1"\x8207"["\x5B50"] @125-156-4
 
 # \x8208\x5473 15-13456-5-1246-5
 noback context ["\x8208"]"\x5473" @15-13456-5

--- a/tests/braille-specs/zh-tw.yaml
+++ b/tests/braille-specs/zh-tw.yaml
@@ -1,5 +1,5 @@
 # Copyright © 2018 Bo-Cheng Jhan <school510587@yahoo.com.tw>
-# Copyright © 2019 nvda-tw <https://groups.io/g/nvda-tw>
+# Copyright © 2019-2020 nvda-tw <https://groups.io/g/nvda-tw>
 #
 # This file is part of liblouis.
 #
@@ -9,7 +9,7 @@
 # without any warranty.
 #
 # Currently maintained by Sponge Jhan <school510587@yahoo.com.tw>
-# Version: 2019-11
+# Version: 2020-02
 
 # The display tables have been separated from the translation tables. But in
 # the case of this test some display relevant stuff is still defined in the
@@ -922,6 +922,10 @@ tests:
     - "⠕⠌⠐⠑⠦⠂⠌⠂⠊⠌⠐"
     - outputPos: [0, 3, 6, 8]
       inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 3, 3, 3]
+  - - "不少女"
+    - "⠕⠌⠐⠊⠩⠈⠝⠳⠈"
+    - outputPos: [0, 3, 6]
+      inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2]
   - - "不幬"
     - "⠕⠌⠐⠙⠩⠐"
     - outputPos: [0, 3]
@@ -2414,6 +2418,10 @@ tests:
     - "⠛⠌⠐⠑⠾⠄⠅⠌⠈"
     - outputPos: [0, 3, 6]
       inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2]
+  - - "內子"
+    - "⠝⠴⠐⠓⠱⠈"
+    - outputPos: [0, 3]
+      inputPos: [0, 0, 0, 1, 1, 1]
   - - "內應"
     - "⠝⠴⠐⠽⠐"
     - outputPos: [0, 3]
@@ -4066,6 +4074,10 @@ tests:
     - "⠗⠮⠐⠁⠱⠈"
     - outputPos: [0, 3]
       inputPos: [0, 0, 0, 1, 1, 1]
+  - - "喝罵"
+    - "⠗⠮⠐⠍⠜⠐"
+    - outputPos: [0, 3]
+      inputPos: [0, 0, 0, 1, 1, 1]
   - - "喝茅成劍"
     - "⠗⠮⠐⠍⠩⠂⠃⠵⠂⠅⠞⠐"
     - outputPos: [0, 3, 6, 9]
@@ -5222,6 +5234,10 @@ tests:
     - "⠝⠺⠈⠏⠭⠄"
     - outputPos: [0, 3]
       inputPos: [0, 0, 0, 1, 1, 1]
+  - - "好一會"
+    - "⠗⠩⠈⠡⠄⠗⠫⠈"
+    - outputPos: [0, 3, 5]
+      inputPos: [0, 0, 0, 1, 1, 2, 2, 2]
   - - "好勇斗狠"
     - "⠗⠩⠐⠖⠈⠙⠷⠐⠗⠥⠈"
     - outputPos: [0, 3, 5, 8]
@@ -5322,6 +5338,10 @@ tests:
     - "⠗⠩⠐⠙⠷⠐"
     - outputPos: [0, 3]
       inputPos: [0, 0, 0, 1, 1, 1]
+  - - "如數家珍"
+    - "⠛⠌⠂⠊⠌⠈⠅⠾⠄⠁⠥⠄"
+    - outputPos: [0, 3, 6, 9]
+      inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
   - - "妥當"
     - "⠋⠒⠈⠙⠭⠐"
     - outputPos: [0, 3]
@@ -6686,6 +6706,10 @@ tests:
     - "⠙⠮⠂⠱⠂⠁⠱⠄⠉⠮⠁"
     - outputPos: [0, 3, 5, 8]
       inputPos: [0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3]
+  - - "從子"
+    - "⠚⠯⠂⠓⠱⠈"
+    - outputPos: [0, 3]
+      inputPos: [0, 0, 0, 1, 1, 1]
   - - "從容不"
     - "⠚⠯⠄⠛⠯⠂⠕⠌⠐"
     - outputPos: [0, 3, 6]
@@ -7990,6 +8014,10 @@ tests:
     - "⠏⠺⠂⠗⠭⠂"
     - outputPos: [0, 3]
       inputPos: [0, 0, 0, 1, 1, 1]
+  - - "排行程"
+    - "⠏⠺⠂⠑⠽⠂⠃⠵⠂"
+    - outputPos: [0, 3, 6]
+      inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2]
   - - "排長"
     - "⠏⠺⠂⠁⠭⠈"
     - outputPos: [0, 3]
@@ -9080,6 +9108,10 @@ tests:
       inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
   - - "易傳"
     - "⠡⠐⠁⠻⠐"
+    - outputPos: [0, 2]
+      inputPos: [0, 0, 1, 1, 1]
+  - - "易子"
+    - "⠡⠐⠓⠱⠈"
     - outputPos: [0, 2]
       inputPos: [0, 0, 1, 1, 1]
   - - "昔逮"
@@ -12842,6 +12874,10 @@ tests:
     - "⠊⠫⠐⠕⠌⠐⠁⠩⠂⠅⠪⠐"
     - outputPos: [0, 3, 6, 9]
       inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
+  - - "睡個覺"
+    - "⠊⠫⠐⠅⠮⠐⠅⠪⠐"
+    - outputPos: [0, 3, 6]
+      inputPos: [0, 0, 0, 1, 1, 1, 2, 2, 2]
   - - "睡懶覺"
     - "⠊⠫⠐⠉⠧⠈⠅⠪⠐"
     - outputPos: [0, 3, 6]
@@ -14450,6 +14486,10 @@ tests:
     - "⠁⠱⠐⠅⠒⠂"
     - outputPos: [0, 3]
       inputPos: [0, 0, 0, 1, 1, 1]
+  - - "與子"
+    - "⠳⠈⠓⠱⠈"
+    - outputPos: [0, 2]
+      inputPos: [0, 0, 1, 1, 1]
   - - "興味"
     - "⠑⠽⠐⠫⠐"
     - outputPos: [0, 3]


### PR DESCRIPTION
It is a minor update of this table. Except the issue of adding emoticons, other rules are stable in principle. That is, if no change is made, zh-tw.ctb update may be absent from some future releases of liblouis.

Summary of changes:
* Add some more Chinese translation exception rules.
* Update copyright declarations.

Reviewers:
* Coscell Kao &lt;coscell@gmail.com&gt;
* Victor Cai &lt;surfer0627@gmail.com&gt;
