### PR TITLE
Further separate display from translation

### DIFF
--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -195,7 +195,7 @@ typedef struct {
 	TranslationTableOffset next;
 	widechar lookFor;
 	widechar found;
-} CharOrDots;
+} CharDotsMapping;
 
 typedef struct {
 	TranslationTableOffset next;
@@ -660,7 +660,7 @@ _lou_getDotsForChar(widechar c, const DisplayTableHeader *table);
  * TODO: move to commonTranslationFunctions.c
  */
 widechar EXPORT_CALL
-_lou_getCharFromDots(widechar d, const DisplayTableHeader *table);
+_lou_getCharForDots(widechar d, const DisplayTableHeader *table);
 
 void EXPORT_CALL
 _lou_getTable(const char *tableList, const char *displayTableList,

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -108,24 +108,21 @@ typedef struct {
 } PassRuleMatch;
 
 static int
-backTranslateString(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, int currentPass,
+backTranslateString(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, char *spacebuf, int *posMapping,
 		int *realInlen, int *cursorPosition, int *cursorStatus,
 		const TranslationTableRule **appliedRules, int *appliedRulesCount,
 		int maxAppliedRules);
 static int
-makeCorrections(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, int currentPass,
+makeCorrections(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, int *realInlen,
 		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
 		int *appliedRulesCount, int maxAppliedRules);
 static int
-translatePass(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
-		int mode, int currentPass, const InString *input, OutString *output,
-		int *posMapping, int *realInlen, int *cursorPosition, int *cursorStatus,
-		const TranslationTableRule **appliedRules, int *appliedRulesCount,
-		int maxAppliedRules);
+translatePass(const TranslationTableHeader *table, int mode, int currentPass,
+		const InString *input, OutString *output, int *posMapping, int *realInlen,
+		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
+		int *appliedRulesCount, int maxAppliedRules);
 static void
 passSelectRule(const TranslationTableHeader *table, int pos, int currentPass,
 		const InString *input, TranslationTableOpcode *currentOpcode,
@@ -246,19 +243,18 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 		int realInlen;
 		switch (currentPass) {
 		case 1:
-			goodTrans = backTranslateString(table, displayTable, mode, currentPass,
-					&input, &output, spacebuf, passPosMapping, &realInlen,
-					&cursorPosition, &cursorStatus, appliedRules, &appliedRulesCount,
-					maxAppliedRules);
+			goodTrans = backTranslateString(table, mode, currentPass, &input, &output,
+					spacebuf, passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
+					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		case 0:
-			goodTrans = makeCorrections(table, displayTable, mode, currentPass, &input,
-					&output, passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
+			goodTrans = makeCorrections(table, mode, currentPass, &input, &output,
+					passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
 					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		default:
-			goodTrans = translatePass(table, displayTable, mode, currentPass, &input,
-					&output, passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
+			goodTrans = translatePass(table, mode, currentPass, &input, &output,
+					passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
 					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		}
@@ -572,10 +568,9 @@ back_passDoTest(const TranslationTableHeader *table, int pos, const InString *in
 		TranslationTableOpcode currentOpcode, const TranslationTableRule *currentRule,
 		const widechar **passInstructions, int *passIC, PassRuleMatch *match);
 static int
-back_passDoAction(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int *pos, int mode, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int *nextUpper, int allUpper, int allUpperPhrase,
+back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase,
 		TranslationTableOpcode currentOpcode, const TranslationTableRule *currentRule,
 		const widechar *passInstructions, int passIC, PassRuleMatch match);
 
@@ -928,38 +923,30 @@ undefinedDots(widechar dots, int mode, OutString *output, int pos, int *posMappi
 }
 
 static int
-putCharacter(widechar dots, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, int mode, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int *nextUpper, int allUpper, int allUpperPhrase) {
+putCharacter(widechar dots, const TranslationTableHeader *table, int pos, int mode,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase) {
 	/* Output character(s) corresponding to a Unicode braille Character */
 	TranslationTableOffset offset = (getDots(dots, table))->definitionRule;
 	if (offset) {
-		widechar c;
 		const TranslationTableRule *rule =
 				(TranslationTableRule *)&table->ruleArea[offset];
-		if (rule->charslen)
-			return back_updatePositions(&rule->charsdots[0], rule->dotslen,
-					rule->charslen, table, pos, input, output, posMapping, cursorPosition,
-					cursorStatus, nextUpper, allUpper, allUpperPhrase);
-		c = _lou_getCharForDots(dots, displayTable);
-		if (c == '\0') c = ' ';
-		return back_updatePositions(&c, 1, 1, table, pos, input, output, posMapping,
-				cursorPosition, cursorStatus, nextUpper, allUpper, allUpperPhrase);
+		return back_updatePositions(&rule->charsdots[0], rule->dotslen, rule->charslen,
+				table, pos, input, output, posMapping, cursorPosition, cursorStatus,
+				nextUpper, allUpper, allUpperPhrase);
 	}
 	return undefinedDots(dots, mode, output, pos, posMapping);
 }
 
 static int
 putCharacters(const widechar *characters, int count, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, int mode, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int *nextUpper, int allUpper, int allUpperPhrase) {
+		int pos, int mode, const InString *input, OutString *output, int *posMapping,
+		int *cursorPosition, int *cursorStatus, int *nextUpper, int allUpper,
+		int allUpperPhrase) {
 	int k;
 	for (k = 0; k < count; k++)
-		if (!putCharacter(characters[k], table, displayTable, pos, mode, input, output,
-					posMapping, cursorPosition, cursorStatus, nextUpper, allUpper,
-					allUpperPhrase))
+		if (!putCharacter(characters[k], table, pos, mode, input, output, posMapping,
+					cursorPosition, cursorStatus, nextUpper, allUpper, allUpperPhrase))
 			return 0;
 	return 1;
 }
@@ -989,8 +976,7 @@ compareChars(const widechar *address1, const widechar *address2, int count,
 }
 
 static int
-makeCorrections(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, int currentPass,
+makeCorrections(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, int *realInlen,
 		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
 		int *appliedRulesCount, int maxAppliedRules) {
@@ -1069,8 +1055,8 @@ makeCorrections(const TranslationTableHeader *table,
 		case CTO_Correct:
 			if (appliedRules != NULL && *appliedRulesCount < maxAppliedRules)
 				appliedRules[(*appliedRulesCount)++] = currentRule;
-			if (!back_passDoAction(table, displayTable, &pos, mode, input, output,
-						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
+			if (!back_passDoAction(table, &pos, mode, input, output, posMapping,
+						cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch))
 				goto failure;
@@ -1086,8 +1072,7 @@ failure:
 }
 
 static int
-backTranslateString(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, int currentPass,
+backTranslateString(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, char *spacebuf, int *posMapping,
 		int *realInlen, int *cursorPosition, int *cursorStatus,
 		const TranslationTableRule **appliedRules, int *appliedRulesCount,
@@ -1213,8 +1198,8 @@ backTranslateString(const TranslationTableHeader *table,
 		/* replacement processing */
 		switch (currentOpcode) {
 		case CTO_Context:
-			if (!back_passDoAction(table, displayTable, &pos, mode, input, output,
-						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
+			if (!back_passDoAction(table, &pos, mode, input, output, posMapping,
+						cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch))
 				return 0;
@@ -1222,9 +1207,8 @@ backTranslateString(const TranslationTableHeader *table,
 		case CTO_Replace:
 			while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			if (!putCharacters(&currentRule->charsdots[0], currentRule->charslen, table,
-						displayTable, pos, mode, input, output, posMapping,
-						cursorPosition, cursorStatus, &nextUpper, allUpper,
-						allUpperPhrase))
+						pos, mode, input, output, posMapping, cursorPosition,
+						cursorStatus, &nextUpper, allUpper, allUpperPhrase))
 				goto failure;
 			break;
 		case CTO_None:
@@ -1253,9 +1237,9 @@ backTranslateString(const TranslationTableHeader *table,
 			} else {
 				int srclim = pos + currentDotslen;
 				while (1) {
-					if (!putCharacter(input->chars[pos], table, displayTable, pos, mode,
-								input, output, posMapping, cursorPosition, cursorStatus,
-								&nextUpper, allUpper, allUpperPhrase))
+					if (!putCharacter(input->chars[pos], table, pos, mode, input, output,
+								posMapping, cursorPosition, cursorStatus, &nextUpper,
+								allUpper, allUpperPhrase))
 						goto failure;
 					if (++pos == srclim) break;
 				}
@@ -1275,8 +1259,8 @@ backTranslateString(const TranslationTableHeader *table,
 			passSelectRule(table, pos, currentPass, input, &currentOpcode, &currentRule,
 					&passInstructions, &passIC, &patternMatch);
 			if (currentOpcode == CTO_Context) {
-				back_passDoAction(table, displayTable, &pos, mode, input, output,
-						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
+				back_passDoAction(table, &pos, mode, input, output, posMapping,
+						cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch);
 			}
@@ -1511,16 +1495,15 @@ back_passDoTest(const TranslationTableHeader *table, int pos, const InString *in
 }
 
 static int
-copyCharacters(int from, int to, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int *nextUpper, int allUpper, int allUpperPhrase,
+copyCharacters(int from, int to, const TranslationTableHeader *table, int mode,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase,
 		TranslationTableOpcode currentOpcode) {
 	if (currentOpcode == CTO_Context) {
 		while (from < to) {
-			if (!putCharacter(input->chars[from], table, displayTable, from, mode, input,
-						output, posMapping, cursorPosition, cursorStatus, nextUpper,
-						allUpper, allUpperPhrase))
+			if (!putCharacter(input->chars[from], table, from, mode, input, output,
+						posMapping, cursorPosition, cursorStatus, nextUpper, allUpper,
+						allUpperPhrase))
 				return 0;
 			from++;
 		}
@@ -1540,10 +1523,9 @@ copyCharacters(int from, int to, const TranslationTableHeader *table,
 }
 
 static int
-back_passDoAction(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int *pos, int mode, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int *nextUpper, int allUpper, int allUpperPhrase,
+back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int *nextUpper, int allUpper, int allUpperPhrase,
 		TranslationTableOpcode currentOpcode, const TranslationTableRule *currentRule,
 		const widechar *passInstructions, int passIC, PassRuleMatch match) {
 	int k;
@@ -1551,9 +1533,9 @@ back_passDoAction(const TranslationTableHeader *table,
 	int destStartReplace;
 	int newPos = match.endReplace;
 
-	if (!copyCharacters(match.startMatch, match.startReplace, table, displayTable, mode,
-				input, output, posMapping, cursorPosition, cursorStatus, nextUpper,
-				allUpper, allUpperPhrase, currentOpcode))
+	if (!copyCharacters(match.startMatch, match.startReplace, table, mode, input, output,
+				posMapping, cursorPosition, cursorStatus, nextUpper, allUpper,
+				allUpperPhrase, currentOpcode))
 		return 0;
 	destStartReplace = output->length;
 
@@ -1588,9 +1570,9 @@ back_passDoAction(const TranslationTableHeader *table,
 			}
 		}
 
-			if (!copyCharacters(match.startReplace, match.endReplace, table, displayTable,
-						mode, input, output, posMapping, cursorPosition, cursorStatus,
-						nextUpper, allUpper, allUpperPhrase, currentOpcode))
+			if (!copyCharacters(match.startReplace, match.endReplace, table, mode, input,
+						output, posMapping, cursorPosition, cursorStatus, nextUpper,
+						allUpper, allUpperPhrase, currentOpcode))
 				return 0;
 			newPos = match.endMatch;
 			passIC++;
@@ -1615,11 +1597,10 @@ passSelectRule(const TranslationTableHeader *table, int pos, int currentPass,
 }
 
 static int
-translatePass(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
-		int mode, int currentPass, const InString *input, OutString *output,
-		int *posMapping, int *realInlen, int *cursorPosition, int *cursorStatus,
-		const TranslationTableRule **appliedRules, int *appliedRulesCount,
-		int maxAppliedRules) {
+translatePass(const TranslationTableHeader *table, int mode, int currentPass,
+		const InString *input, OutString *output, int *posMapping, int *realInlen,
+		int *cursorPosition, int *cursorStatus, const TranslationTableRule **appliedRules,
+		int *appliedRulesCount, int maxAppliedRules) {
 	int pos;
 	int posIncremented = 1;
 	int nextUpper = 0;
@@ -1645,8 +1626,8 @@ translatePass(const TranslationTableHeader *table, const DisplayTableHeader *dis
 		case CTO_Pass4:
 			if (appliedRules != NULL && *appliedRulesCount < maxAppliedRules)
 				appliedRules[(*appliedRulesCount)++] = currentRule;
-			if (!back_passDoAction(table, displayTable, &pos, mode, input, output,
-						posMapping, cursorPosition, cursorStatus, &nextUpper, allUpper,
+			if (!back_passDoAction(table, &pos, mode, input, output, posMapping,
+						cursorPosition, cursorStatus, &nextUpper, allUpper,
 						allUpperPhrase, currentOpcode, currentRule, passInstructions,
 						passIC, patternMatch))
 				goto failure;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -145,43 +145,53 @@ static int maxAppliedRules;
 static int appliedRulesCount;
 
 static TranslationTableCharacter *
-findCharOrDots(widechar c, int m, const TranslationTableHeader *table) {
-	/* Look up character or dot pattern in the appropriate
-	 * table. */
-	static TranslationTableCharacter noChar = { 0, 0, 0, CTC_Space, 32, 32, 32 };
-	static TranslationTableCharacter noDots = { 0, 0, 0, CTC_Space, LOU_DOTS, LOU_DOTS,
-		LOU_DOTS };
-	TranslationTableCharacter *notFound;
-	TranslationTableCharacter *character;
-	TranslationTableOffset bucket;
+getChar(widechar c, const TranslationTableHeader *table) {
+	static TranslationTableCharacter notFound = { 0, 0, 0, CTC_Space, 32, 32, 32 };
 	unsigned long int makeHash = _lou_charHash(c);
-	if (m == 0) {
-		bucket = table->characters[makeHash];
-		notFound = &noChar;
-	} else {
-		bucket = table->dots[makeHash];
-		notFound = &noDots;
-	}
+	TranslationTableOffset bucket = table->characters[makeHash];
 	while (bucket) {
-		character = (TranslationTableCharacter *)&table->ruleArea[bucket];
+		TranslationTableCharacter *character =
+				(TranslationTableCharacter *)&table->ruleArea[bucket];
 		if (character->realchar == c) return character;
 		bucket = character->next;
 	}
-	notFound->realchar = notFound->uppercase = notFound->lowercase = c;
-	return notFound;
+	notFound.realchar = notFound.uppercase = notFound.lowercase = c;
+	return &notFound;
+}
+
+static TranslationTableCharacter *
+getDots(widechar c, const TranslationTableHeader *table) {
+	static TranslationTableCharacter notFound = { 0, 0, 0, CTC_Space, LOU_DOTS, LOU_DOTS,
+		LOU_DOTS };
+	unsigned long int makeHash = _lou_charHash(c);
+	TranslationTableOffset bucket = table->dots[makeHash];
+	while (bucket) {
+		TranslationTableCharacter *character =
+				(TranslationTableCharacter *)&table->ruleArea[bucket];
+		if (character->realchar == c) return character;
+		bucket = character->next;
+	}
+	notFound.realchar = notFound.uppercase = notFound.lowercase = c;
+	return &notFound;
 }
 
 static int
-checkAttr(const widechar c, const TranslationTableCharacterAttributes a, int m,
+checkCharAttr(const widechar c, const TranslationTableCharacterAttributes a,
 		const TranslationTableHeader *table) {
-	return (((findCharOrDots(c, m, table))->attributes & a) ? 1 : 0);
+	return (((getChar(c, table))->attributes & a) ? 1 : 0);
 }
 
 static int
-checkAttr_safe(const InString *input, int pos,
-		const TranslationTableCharacterAttributes a, int m,
+checkDotsAttr(const widechar c, const TranslationTableCharacterAttributes a,
 		const TranslationTableHeader *table) {
-	return ((pos < input->length) ? checkAttr(input->chars[pos], a, m, table) : 0);
+	return (((getDots(c, table))->attributes & a) ? 1 : 0);
+}
+
+static int
+checkCharAttr_safe(const InString *input, int pos,
+		const TranslationTableCharacterAttributes a,
+		const TranslationTableHeader *table) {
+	return ((pos < input->length) ? checkCharAttr(input->chars[pos], a, table) : 0);
 }
 
 static int
@@ -211,13 +221,13 @@ findForPassRule(const TranslationTableHeader *table, int pos, int currentPass,
 }
 
 static int
-compareChars(const widechar *address1, const widechar *address2, int count, int m,
+compareChars(const widechar *address1, const widechar *address2, int count,
 		const TranslationTableHeader *table) {
 	int k;
 	if (!count) return 0;
 	for (k = 0; k < count; k++)
-		if ((findCharOrDots(address1[k], m, table))->lowercase !=
-				(findCharOrDots(address2[k], m, table))->lowercase)
+		if ((getChar(address1[k], table))->lowercase !=
+				(getChar(address2[k], table))->lowercase)
 			return 0;
 	return 1;
 }
@@ -262,7 +272,7 @@ makeCorrections(const TranslationTableHeader *table,
 				case 1:
 					if (!(length >= 1)) break;
 					length = 1;
-					ruleOffset = findCharOrDots(input->chars[pos], 0, table)->otherRules;
+					ruleOffset = getChar(input->chars[pos], table)->otherRules;
 					break;
 				case 2: /* No rule found */
 					transOpcode = CTO_Always;
@@ -276,8 +286,7 @@ makeCorrections(const TranslationTableHeader *table,
 					if (tryThis == 1 ||
 							(transCharslen <= length &&
 									compareChars(&transRule->charsdots[0],
-											&input->chars[pos], transCharslen, 0,
-											table))) {
+											&input->chars[pos], transCharslen, table))) {
 						if (posIncremented && transOpcode == CTO_Correct &&
 								passDoTest(table, pos, input, transOpcode, transRule,
 										&passCharDots, &passInstructions, &passIC,
@@ -617,12 +626,12 @@ doPassSearch(const TranslationTableHeader *table, const InString *input,
 					if (input->chars[*searchPos] == LOU_ENDSEGMENT)
 						itsTrue = 0;
 					else {
-						itsTrue = ((findCharOrDots(input->chars[(*searchPos)++],
-											passCharDots, table)
-												   ->attributes &
-										   attributes)
-										? 1
-										: 0);
+						itsTrue = (passCharDots ? getDots(input->chars[(*searchPos)++],
+														  table)
+												: getChar(input->chars[(*searchPos)++],
+														  table))
+										  ->attributes &
+								attributes;
 						if (not) itsTrue = !itsTrue;
 					}
 					if (!itsTrue) break;
@@ -634,8 +643,8 @@ doPassSearch(const TranslationTableHeader *table, const InString *input,
 							itsTrue = 0;
 							break;
 						}
-						if (!(findCharOrDots(
-									  input->chars[*searchPos], passCharDots, table)
+						if (!((passCharDots ? getDots(input->chars[*searchPos], table)
+											: getChar(input->chars[*searchPos], table))
 											->attributes &
 									attributes)) {
 							if (!not) break;
@@ -768,7 +777,8 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 					itsTrue = 0;
 					break;
 				}
-				if (!(findCharOrDots(input->chars[pos], *passCharDots, table)
+				if (!((*passCharDots ? getDots(input->chars[pos], table)
+									 : getChar(input->chars[pos], table))
 									->attributes &
 							attributes)) {
 					if (!not) {
@@ -789,7 +799,8 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 						itsTrue = 0;
 						break;
 					}
-					if (!(findCharOrDots(input->chars[pos], *passCharDots, table)
+					if (!((*passCharDots ? getDots(input->chars[pos], table)
+										 : getChar(input->chars[pos], table))
 										->attributes &
 								attributes)) {
 						if (!not) break;
@@ -1050,7 +1061,7 @@ translatePass(const TranslationTableHeader *table, const DisplayTableHeader *dis
 	}
 failure:
 	if (pos < input->length) {
-		while (checkAttr(input->chars[pos], CTC_Space, 1, table))
+		while (checkDotsAttr(input->chars[pos], CTC_Space, table))
 			if (++pos == input->length) break;
 	}
 	*realInlen = pos;
@@ -1174,17 +1185,17 @@ _lou_translate(const char *tableList, const char *displayTableList,
 		cursorPosition = *cursorPos;
 		if ((mode & (compbrlAtCursor | compbrlLeftCursor))) {
 			compbrlStart = cursorPosition;
-			if (checkAttr(input.chars[compbrlStart], CTC_Space, 0, table))
+			if (checkCharAttr(input.chars[compbrlStart], CTC_Space, table))
 				compbrlEnd = compbrlStart + 1;
 			else {
 				while (compbrlStart >= 0 &&
-						!checkAttr(input.chars[compbrlStart], CTC_Space, 0, table))
+						!checkCharAttr(input.chars[compbrlStart], CTC_Space, table))
 					compbrlStart--;
 				compbrlStart++;
 				compbrlEnd = cursorPosition;
 				if (!(mode & compbrlLeftCursor))
 					while (compbrlEnd < input.length &&
-							!checkAttr(input.chars[compbrlEnd], CTC_Space, 0, table))
+							!checkCharAttr(input.chars[compbrlEnd], CTC_Space, table))
 						compbrlEnd++;
 			}
 		}
@@ -1291,7 +1302,7 @@ _lou_translate(const char *tableList, const char *displayTableList,
 				else
 					outbuf[k] = output.chars[k];
 			} else {
-				outbuf[k] = _lou_getCharFromDots(output.chars[k], displayTable);
+				outbuf[k] = _lou_getCharForDots(output.chars[k], displayTable);
 				if (!outbuf[k]) {
 					// assume that if NUL character is returned, it's because the display
 					// table has no mapping for the dot pattern (not because it maps to
@@ -1406,7 +1417,7 @@ hyphenateWord(const widechar *word, int wordSize, char *hyphens,
 	 * hyphens is the length of the word "hello" "00000" */
 	prepWord[0] = '.';
 	for (i = 0; i < wordSize; i++) {
-		prepWord[i + 1] = (findCharOrDots(word[i], 0, table))->lowercase;
+		prepWord[i + 1] = (getChar(word[i], table))->lowercase;
 		hyphens[i] = '0';
 	}
 	prepWord[wordSize + 1] = '.';
@@ -1502,15 +1513,13 @@ syllableBreak(const TranslationTableHeader *table, int pos, const InString *inpu
 	int k = 0;
 	char *hyphens = NULL;
 	for (wordStart = pos; wordStart >= 0; wordStart--)
-		if (!((findCharOrDots(input->chars[wordStart], 0, table))->attributes &
-					CTC_Letter)) {
+		if (!((getChar(input->chars[wordStart], table))->attributes & CTC_Letter)) {
 			wordStart++;
 			break;
 		}
 	if (wordStart < 0) wordStart = 0;
 	for (wordEnd = pos; wordEnd < input->length; wordEnd++)
-		if (!((findCharOrDots(input->chars[wordEnd], 0, table))->attributes &
-					CTC_Letter)) {
+		if (!((getChar(input->chars[wordEnd], table))->attributes & CTC_Letter)) {
 			wordEnd--;
 			break;
 		}
@@ -1541,7 +1550,7 @@ setBefore(const TranslationTableHeader *table, int pos, const InString *input,
 		before = input->chars[pos - 2];
 	else
 		before = (pos == 0) ? ' ' : input->chars[pos - 1];
-	*beforeAttributes = (findCharOrDots(before, 0, table))->attributes;
+	*beforeAttributes = (getChar(before, table))->attributes;
 }
 
 static void
@@ -1552,7 +1561,7 @@ setAfter(int length, const TranslationTableHeader *table, int pos, const InStrin
 		after = input->chars[pos + 2];
 	else
 		after = (pos + length < input->length) ? input->chars[pos + length] : ' ';
-	*afterAttributes = (findCharOrDots(after, 0, table))->attributes;
+	*afterAttributes = (getChar(after, table))->attributes;
 }
 
 static int
@@ -1585,9 +1594,9 @@ validMatch(const TranslationTableHeader *table, int pos, const InString *input,
 			else
 				return 0;
 		}
-		inputChar = findCharOrDots(input->chars[k], 0, table);
+		inputChar = getChar(input->chars[k], table);
 		if (k == pos) prevAttr = inputChar->attributes;
-		ruleChar = findCharOrDots(transRule->charsdots[kk++], 0, table);
+		ruleChar = getChar(transRule->charsdots[kk++], table);
 		if ((inputChar->lowercase != ruleChar->lowercase)) return 0;
 		if (typebuf != NULL && (typebuf[pos] & CAPSEMPH) == 0 &&
 				(typebuf[k] | typebuf[pos]) != typebuf[pos])
@@ -1611,7 +1620,7 @@ insertNumberSign(const TranslationTableHeader *table, int pos, const InString *i
 		int *cursorStatus, TranslationTableCharacterAttributes beforeAttributes) {
 	const TranslationTableRule *numberSign;
 	if (brailleIndicatorDefined(table->numberSign, table, &numberSign) &&
-			checkAttr_safe(input, pos, CTC_Digit, 0, table) &&
+			checkCharAttr_safe(input, pos, CTC_Digit, table) &&
 			(prevTransOpcode == CTO_ExactDots ||
 					(!(beforeAttributes & CTC_Digit) && prevTransOpcode != CTO_MidNum))) {
 		if (!for_updatePositions(&numberSign->charsdots[0], 0, numberSign->dotslen, 0,
@@ -1631,9 +1640,9 @@ insertLetterSign(const TranslationTableHeader *table, int pos, const InString *i
 			if (!for_updatePositions(&letterSign->charsdots[0], 0, letterSign->dotslen, 0,
 						pos, input, output, posMapping, cursorPosition, cursorStatus))
 				return 0;
-		} else if ((checkAttr_safe(input, pos, CTC_Letter, 0, table) &&
+		} else if ((checkCharAttr_safe(input, pos, CTC_Letter, table) &&
 						   !(beforeAttributes & CTC_Letter)) &&
-				(!checkAttr_safe(input, pos + 1, CTC_Letter, 0, table) ||
+				(!checkCharAttr_safe(input, pos + 1, CTC_Letter, table) ||
 						(beforeAttributes & CTC_Digit))) {
 			int k;
 			if (pos > 0)
@@ -1660,7 +1669,7 @@ onlyLettersBehind(const TranslationTableHeader *table, int pos, const InString *
 	if (!(beforeAttributes & CTC_Space)) return 0;
 	for (k = pos - 2; k >= 0; k--) {
 		TranslationTableCharacterAttributes attr =
-				(findCharOrDots(input->chars[k], 0, table))->attributes;
+				(getChar(input->chars[k], table))->attributes;
 		if ((attr & CTC_Space)) continue;
 		if ((attr & CTC_Letter))
 			return 1;
@@ -1678,7 +1687,7 @@ onlyLettersAhead(const TranslationTableHeader *table, int pos, const InString *i
 	if (!(afterAttributes & CTC_Space)) return 0;
 	for (k = pos + transCharslen + 1; k < input->length; k++) {
 		TranslationTableCharacterAttributes attr =
-				(findCharOrDots(input->chars[k], 0, table))->attributes;
+				(getChar(input->chars[k], table))->attributes;
 		if ((attr & CTC_Space)) continue;
 		if ((attr & (CTC_Letter | CTC_LitDigit)))
 			return 1;
@@ -1695,15 +1704,15 @@ noCompbrlAhead(const TranslationTableHeader *table, int pos, int mode,
 	int end;
 	int p;
 	if (start >= input->length) return 1;
-	while (start < input->length && checkAttr(input->chars[start], CTC_Space, 0, table))
+	while (start < input->length && checkCharAttr(input->chars[start], CTC_Space, table))
 		start++;
 	if (start == input->length ||
 			(transOpcode == CTO_JoinableWord &&
-					(!checkAttr(input->chars[start], CTC_Letter | CTC_Digit, 0, table) ||
-							!checkAttr(input->chars[start - 1], CTC_Space, 0, table))))
+					(!checkCharAttr(input->chars[start], CTC_Letter | CTC_Digit, table) ||
+							!checkCharAttr(input->chars[start - 1], CTC_Space, table))))
 		return 1;
 	end = start;
-	while (end < input->length && !checkAttr(input->chars[end], CTC_Space, 0, table))
+	while (end < input->length && !checkCharAttr(input->chars[end], CTC_Space, table))
 		end++;
 	if ((mode & (compbrlAtCursor | compbrlLeftCursor)) && cursorPosition >= start &&
 			cursorPosition < end)
@@ -1724,7 +1733,7 @@ noCompbrlAhead(const TranslationTableHeader *table, int pos, int mode,
 			case 1:
 				if (!(length >= 1)) break;
 				length = 1;
-				ruleOffset = findCharOrDots(input->chars[p], 0, table)->otherRules;
+				ruleOffset = getChar(input->chars[p], table)->otherRules;
 				break;
 			}
 			while (ruleOffset) {
@@ -1732,8 +1741,8 @@ noCompbrlAhead(const TranslationTableHeader *table, int pos, int mode,
 				const TranslationTableCharacter *character2;
 				testRule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
 				for (k = 0; k < testRule->charslen; k++) {
-					character1 = findCharOrDots(testRule->charsdots[k], 0, table);
-					character2 = findCharOrDots(input->chars[p + k], 0, table);
+					character1 = getChar(testRule->charsdots[k], table);
+					character2 = getChar(input->chars[p + k], table);
 					if (character1->lowercase != character2->lowercase) break;
 				}
 				if (tryThis == 1 || k == testRule->charslen) {
@@ -1753,14 +1762,14 @@ isRepeatedWord(const TranslationTableHeader *table, int pos, const InString *inp
 		int outputLength, const int *posMapping, int transCharslen, int *repwordLength) {
 	int len;
 	for (len = 1; pos - len >= 0 && pos + transCharslen + len - 1 < input->length &&
-			checkAttr(input->chars[pos - len], CTC_Letter, 0, table) &&
-			checkAttr(input->chars[pos + transCharslen + len - 1], CTC_Letter, 0, table);
+			checkCharAttr(input->chars[pos - len], CTC_Letter, table) &&
+			checkCharAttr(input->chars[pos + transCharslen + len - 1], CTC_Letter, table);
 			len++)
 		;
 	len--;
 	while (len > 0) {
 		int start = pos - len;
-		if (compareChars(&input->chars[start], &input->chars[pos + transCharslen], len, 0,
+		if (compareChars(&input->chars[start], &input->chars[pos + transCharslen], len,
 					table)) {
 			// word must not start within a contraction
 			for (int k = outputLength - 1; k >= 0; k--)
@@ -1796,8 +1805,8 @@ inSequence(const TranslationTableHeader *table, int pos, const InString *input,
 
 	/* check before sequence */
 	for (i = pos - 1; i >= 0; i--) {
-		if (checkAttr(input->chars[i], CTC_SeqBefore, 0, table)) continue;
-		if (!(checkAttr(input->chars[i], CTC_Space | CTC_SeqDelimiter, 0, table)))
+		if (checkCharAttr(input->chars[i], CTC_SeqBefore, table)) continue;
+		if (!(checkCharAttr(input->chars[i], CTC_Space | CTC_SeqDelimiter, table)))
 			return 0;
 		break;
 	}
@@ -1852,8 +1861,8 @@ inSequence(const TranslationTableHeader *table, int pos, const InString *input,
 			}
 		}
 
-		if (checkAttr(input->chars[i], CTC_SeqAfter, 0, table)) continue;
-		if (!(checkAttr(input->chars[i], CTC_Space | CTC_SeqDelimiter, 0, table)))
+		if (checkCharAttr(input->chars[i], CTC_SeqAfter, table)) continue;
+		if (!(checkCharAttr(input->chars[i], CTC_Space | CTC_SeqDelimiter, table)))
 			return 0;
 		break;
 	}
@@ -1878,7 +1887,7 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output,
 	int tryThis;
 	int k;
 	TranslationTableOffset ruleOffset = 0;
-	*curCharDef = findCharOrDots(input->chars[pos], 0, table);
+	*curCharDef = getChar(input->chars[pos], table);
 	for (tryThis = 0; tryThis < 3; tryThis++) {
 		switch (tryThis) {
 		case 0:
@@ -1960,9 +1969,9 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output,
 							if (isRepeatedWord(table, pos, input, output.length,
 										posMapping, *transCharslen, repwordLength)) {
 								if ((pos > *repwordLength &&
-											checkAttr(input->chars[pos - *repwordLength -
-															  1],
-													CTC_Letter, 0, table)) ==
+											checkCharAttr(input->chars[pos -
+																  *repwordLength - 1],
+													CTC_Letter, table)) ==
 										(*transOpcode == CTO_RepEndWord)) {
 									return;
 								}
@@ -2028,10 +2037,10 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output,
 											output.maxlength)) {
 								int p = pos + *transCharslen + 1;
 								while (p < input->length) {
-									if (!checkAttr(
-												input->chars[p], CTC_Space, 0, table)) {
-										if (checkAttr(
-													input->chars[p], CTC_Digit, 0, table))
+									if (!checkCharAttr(
+												input->chars[p], CTC_Space, table)) {
+										if (checkCharAttr(
+													input->chars[p], CTC_Digit, table))
 											return;
 										break;
 									}
@@ -2122,32 +2131,32 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output,
 							if (beforeAttributes & CTC_Digit) *transOpcode = CTO_MidNum;
 							return;
 						case CTO_PrePunc:
-							if (!checkAttr(
-										input->chars[pos], CTC_Punctuation, 0, table) ||
+							if (!checkCharAttr(
+										input->chars[pos], CTC_Punctuation, table) ||
 									(pos > 0 &&
-											checkAttr(input->chars[pos - 1], CTC_Letter,
-													0, table)))
+											checkCharAttr(input->chars[pos - 1],
+													CTC_Letter, table)))
 								break;
 							for (k = pos + *transCharslen; k < input->length; k++) {
-								if (checkAttr(input->chars[k], (CTC_Letter | CTC_Digit),
-											0, table))
+								if (checkCharAttr(input->chars[k],
+											(CTC_Letter | CTC_Digit), table))
 									return;
-								if (checkAttr(input->chars[k], CTC_Space, 0, table))
+								if (checkCharAttr(input->chars[k], CTC_Space, table))
 									break;
 							}
 							break;
 						case CTO_PostPunc:
-							if (!checkAttr(
-										input->chars[pos], CTC_Punctuation, 0, table) ||
+							if (!checkCharAttr(
+										input->chars[pos], CTC_Punctuation, table) ||
 									(pos < (input->length - 1) &&
-											checkAttr(input->chars[pos + 1], CTC_Letter,
-													0, table)))
+											checkCharAttr(input->chars[pos + 1],
+													CTC_Letter, table)))
 								break;
 							for (k = pos; k >= 0; k--) {
-								if (checkAttr(input->chars[k], (CTC_Letter | CTC_Digit),
-											0, table))
+								if (checkCharAttr(input->chars[k],
+											(CTC_Letter | CTC_Digit), table))
 									return;
-								if (checkAttr(input->chars[k], CTC_Space, 0, table))
+								if (checkCharAttr(input->chars[k], CTC_Space, table))
 									break;
 							}
 							break;
@@ -2231,12 +2240,12 @@ putCharacter(widechar character, const TranslationTableHeader *table,
 	TranslationTableCharacter *chardef = NULL;
 	TranslationTableOffset offset;
 	widechar d;
-	chardef = findCharOrDots(character, 0, table);
+	chardef = getChar(character, table);
 	// If capsletter is defined, replace uppercase with lowercase letters. If capsletter
 	// is not defined, uppercase letters should be preserved because otherwise case info
 	// is lost.
 	if ((chardef->attributes & CTC_UpperCase) && capsletterDefined(table))
-		chardef = findCharOrDots(chardef->lowercase, 0, table);
+		chardef = getChar(chardef->lowercase, table);
 	offset = chardef->definitionRule;
 	if (offset) {
 		rule = (TranslationTableRule *)&table->ruleArea[offset];
@@ -2283,7 +2292,7 @@ doCompbrl(const TranslationTableHeader *table, const DisplayTableHeader *display
 		int *insertEmphasesFrom, int mode) {
 	/* Handle strings containing substrings defined by the compbrl opcode */
 	int stringStart, stringEnd;
-	if (checkAttr(input->chars[*pos], CTC_Space, 0, table)) return 1;
+	if (checkCharAttr(input->chars[*pos], CTC_Space, table)) return 1;
 	if (lastWord->outPos) {
 		*pos = lastWord->inPos;
 		output->length = lastWord->outPos;
@@ -2293,10 +2302,10 @@ doCompbrl(const TranslationTableHeader *table, const DisplayTableHeader *display
 	}
 	*insertEmphasesFrom = lastWord->emphasisInPos;
 	for (stringStart = *pos; stringStart >= 0; stringStart--)
-		if (checkAttr(input->chars[stringStart], CTC_Space, 0, table)) break;
+		if (checkCharAttr(input->chars[stringStart], CTC_Space, table)) break;
 	stringStart++;
 	for (stringEnd = *pos; stringEnd < input->length; stringEnd++)
-		if (checkAttr(input->chars[stringEnd], CTC_Space, 0, table)) break;
+		if (checkCharAttr(input->chars[stringEnd], CTC_Space, table)) break;
 	return doCompTrans(stringStart, stringEnd, table, displayTable, pos, input, output,
 			posMapping, emphasisBuffer, transRule, cursorPosition, cursorStatus, mode);
 }
@@ -2308,7 +2317,7 @@ putCompChar(widechar character, const TranslationTableHeader *table,
 		int mode) {
 	/* Insert the dots equivalent of a character into the output buffer */
 	widechar d;
-	TranslationTableOffset offset = (findCharOrDots(character, 0, table))->definitionRule;
+	TranslationTableOffset offset = (getChar(character, table))->definitionRule;
 	if (offset) {
 		const TranslationTableRule *rule =
 				(TranslationTableRule *)&table->ruleArea[offset];
@@ -2377,7 +2386,7 @@ doNocont(const TranslationTableHeader *table, int *pos, OutString *output, int m
 		const InString *input, const LastWord *lastWord, int *dontContract,
 		int *insertEmphasesFrom) {
 	/* Handle strings containing substrings defined by the nocont opcode */
-	if (checkAttr(input->chars[*pos], CTC_Space, 0, table) || *dontContract ||
+	if (checkCharAttr(input->chars[*pos], CTC_Space, table) || *dontContract ||
 			(mode & noContractions))
 		return 1;
 	if (lastWord->outPos) {
@@ -2421,7 +2430,7 @@ markSyllables(
 			case 1:
 				if (!(length >= 1)) break;
 				length = 1;
-				ruleOffset = findCharOrDots(input->chars[pos], 0, table)->otherRules;
+				ruleOffset = getChar(input->chars[pos], table)->otherRules;
 				break;
 			case 2: /* No rule found */
 				transOpcode = CTO_Always;
@@ -2435,7 +2444,7 @@ markSyllables(
 				if (tryThis == 1 ||
 						(transCharslen <= length &&
 								compareChars(&transRule->charsdots[0], &input->chars[pos],
-										transCharslen, 0, table))) {
+										transCharslen, table))) {
 					if (transOpcode == CTO_Syllable) {
 						tryThis = 4;
 						break;
@@ -2825,7 +2834,7 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 					if (buffer[i].word & class) {
 						/* deal with case when reset was at beginning of word */
 						if (wordBuffer[i] & WORD_RESET ||
-								!checkAttr(input->chars[i], CTC_Letter, 0, table)) {
+								!checkCharAttr(input->chars[i], CTC_Letter, table)) {
 							/* if the reset is a letter and emphletter is not defined, use
 							 * the word indicator */
 							/* also use the word indicator if the reset is a letter and
@@ -2833,8 +2842,8 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 							 * least one word reset on a letter because a passage can not
 							 * end on a word without uppercase letters) */
 							if (!((!letter_defined || pass_end == i) &&
-										checkAttr(
-												input->chars[i], CTC_Letter, 0, table))) {
+										checkCharAttr(
+												input->chars[i], CTC_Letter, table))) {
 
 								/* move the word marker to the next character or remove it
 								 * altogether if the next character is a space */
@@ -2848,7 +2857,7 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 								wordBuffer[i] &= ~WORD_WHOLE;
 
 								/* if reset is a letter, make it a symbol */
-								if (checkAttr(input->chars[i], CTC_Letter, 0, table))
+								if (checkCharAttr(input->chars[i], CTC_Letter, table))
 									buffer[i].symbol |= class;
 
 								continue;
@@ -2865,7 +2874,7 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 					 * marked as a symbol when it should not be one */
 					else if (buffer[i].symbol & class) {
 						if (wordBuffer[i] & WORD_RESET ||
-								!checkAttr(input->chars[i], CTC_Letter, 0, table))
+								!checkCharAttr(input->chars[i], CTC_Letter, table))
 							buffer[i].symbol &= ~class;
 					}
 				}
@@ -2889,7 +2898,7 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 						/* if word ended on a reset or last char was a reset,
 						 * get rid of end bits */
 						if (word_reset || wordBuffer[i] & WORD_RESET ||
-								!checkAttr(input->chars[i], CTC_Letter, 0, table)) {
+								!checkCharAttr(input->chars[i], CTC_Letter, table)) {
 							buffer[i].end &= ~class;
 							buffer[i].word &= ~class;
 						}
@@ -2903,13 +2912,13 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 					} else {
 						/* hit reset */
 						if (wordBuffer[i] & WORD_RESET ||
-								!checkAttr(input->chars[i], CTC_Letter, 0, table)) {
+								!checkCharAttr(input->chars[i], CTC_Letter, table)) {
 							/* characters that are not letters are resetting */
-							if (!checkAttr(input->chars[i], CTC_Letter, 0, table)) {
+							if (!checkCharAttr(input->chars[i], CTC_Letter, table)) {
 								/* ... unless they are marked as not resetting
 								 * (capsmodechars / emphmodechars) */
-								if (checkAttr(
-											input->chars[i], emphModeCharsAttr, 0, table))
+								if (checkCharAttr(
+											input->chars[i], emphModeCharsAttr, table))
 									continue;
 							}
 
@@ -2922,7 +2931,7 @@ resolveEmphasisResets(EmphasisInfo *buffer, const EmphRuleNumber emphRule,
 							}
 
 							/* if reset is a letter, make it the new word_start */
-							if (checkAttr(input->chars[i], CTC_Letter, 0, table)) {
+							if (checkCharAttr(input->chars[i], CTC_Letter, table)) {
 								if (word_start == pass_end)
 									/* move the word marker that ends the passage to the
 									 * current position */
@@ -3001,7 +3010,7 @@ markEmphases(const TranslationTableHeader *table, const InString *input,
 
 	for (i = 0; i < input->length; i++) {
 		/* WORD_CHAR means character is not a space */
-		if (!checkAttr(input->chars[i], CTC_Space, 0, table)) {
+		if (!checkCharAttr(input->chars[i], CTC_Space, table)) {
 			wordBuffer[i] |= WORD_CHAR;
 		} else {
 			last_space = i;
@@ -3012,7 +3021,7 @@ markEmphases(const TranslationTableHeader *table, const InString *input,
 		}
 
 		/* if character is uppercase, caps begins or continues */
-		if (checkAttr(input->chars[i], CTC_UpperCase, 0, table)) {
+		if (checkCharAttr(input->chars[i], CTC_UpperCase, table)) {
 			if (caps_start < 0) caps_start = i;
 			caps = 1;
 			/* handle capsnocont */
@@ -3031,8 +3040,8 @@ markEmphases(const TranslationTableHeader *table, const InString *input,
 				/* characters that cancel caps mode are handled later in
 				 * resolveEmphasisResets (note that letters that are neither uppercase nor
 				 * lowercase do not cancel caps mode) */
-				if (checkAttr(input->chars[i], CTC_Letter, 0, table) &&
-						checkAttr(input->chars[i], CTC_LowerCase, 0, table)) {
+				if (checkCharAttr(input->chars[i], CTC_Letter, table) &&
+						checkCharAttr(input->chars[i], CTC_LowerCase, table)) {
 					emphasisBuffer[caps_start].begin |= capsEmphClass;
 					if (caps) {
 						/* a passage can not end on a word without uppercase letters, so
@@ -3237,7 +3246,7 @@ beginCount(const EmphasisInfo *buffer, const int at, const EmphasisClass class,
 		for (i = at + 1; i < input->length; i++)
 			if (buffer[i].end & class) break;
 			// TODO: WORD_RESET?
-			else if (checkAttr(input->chars[i], CTC_SeqDelimiter | CTC_Space, 0, table))
+			else if (checkCharAttr(input->chars[i], CTC_SeqDelimiter | CTC_Space, table))
 				break;
 			else
 				cnt++;
@@ -3338,20 +3347,20 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 
 	/* not in numeric mode */
 	if (!*numericMode) {
-		if (checkAttr(input->chars[pos], CTC_Digit | CTC_LitDigit, 0, table)) {
+		if (checkCharAttr(input->chars[pos], CTC_Digit | CTC_LitDigit, table)) {
 			*numericMode = 1;
 			*dontContract = 1;
 			for_updatePositions(&indicRule->charsdots[0], 0, indicRule->dotslen, 0, pos,
 					input, output, posMapping, cursorPosition, cursorStatus);
-		} else if (checkAttr(input->chars[pos], CTC_NumericMode, 0, table)) {
+		} else if (checkCharAttr(input->chars[pos], CTC_NumericMode, table)) {
 			for (i = pos + 1; i < input->length; i++) {
-				if (checkAttr(input->chars[i], CTC_Digit | CTC_LitDigit, 0, table)) {
+				if (checkCharAttr(input->chars[i], CTC_Digit | CTC_LitDigit, table)) {
 					*numericMode = 1;
 					for_updatePositions(&indicRule->charsdots[0], 0, indicRule->dotslen,
 							0, pos, input, output, posMapping, cursorPosition,
 							cursorStatus);
 					break;
-				} else if (!checkAttr(input->chars[i], CTC_NumericMode, 0, table))
+				} else if (!checkCharAttr(input->chars[i], CTC_NumericMode, table))
 					break;
 			}
 		}
@@ -3359,12 +3368,12 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 
 	/* in numeric mode */
 	else {
-		if (!checkAttr(input->chars[pos],
-					CTC_Digit | CTC_LitDigit | CTC_NumericMode | CTC_MidEndNumericMode, 0,
+		if (!checkCharAttr(input->chars[pos],
+					CTC_Digit | CTC_LitDigit | CTC_NumericMode | CTC_MidEndNumericMode,
 					table)) {
 			*numericMode = 0;
 			if (brailleIndicatorDefined(table->noContractSign, table, &indicRule))
-				if (checkAttr(input->chars[pos], CTC_NumericNoContract, 0, table))
+				if (checkCharAttr(input->chars[pos], CTC_NumericNoContract, table))
 					for_updatePositions(&indicRule->charsdots[0], 0, indicRule->dotslen,
 							0, pos, input, output, posMapping, cursorPosition,
 							cursorStatus);
@@ -3412,7 +3421,7 @@ translateString(const TranslationTableHeader *table,
 	_lou_resetPassVariables();
 	if (typebuf && capsletterDefined(table))
 		for (k = 0; k < input->length; k++)
-			if (checkAttr(input->chars[k], CTC_UpperCase, 0, table))
+			if (checkCharAttr(input->chars[k], CTC_UpperCase, table))
 				typebuf[k] |= CAPSEMPH;
 
 	markEmphases(table, input, typebuf, wordBuffer, emphasisBuffer, haveEmphasis);
@@ -3541,12 +3550,12 @@ translateString(const TranslationTableHeader *table,
 		/* Processing before replacement */
 
 		/* check if leaving no contraction (grade 1) mode */
-		if (checkAttr(input->chars[pos], CTC_SeqDelimiter | CTC_Space, 0, table))
+		if (checkCharAttr(input->chars[pos], CTC_SeqDelimiter | CTC_Space, table))
 			dontContract = 0;
 
 		switch (transOpcode) {
 		case CTO_EndNum:
-			if (table->letterSign && checkAttr(input->chars[pos], CTC_Letter, 0, table))
+			if (table->letterSign && checkCharAttr(input->chars[pos], CTC_Letter, table))
 				output->length--;
 			break;
 		case CTO_Repeated:
@@ -3557,8 +3566,8 @@ translateString(const TranslationTableHeader *table,
 			if (prevTransOpcode == CTO_LargeSign) {
 				int hasEndSegment = 0;
 				while (output->length > 0 &&
-						checkAttr(
-								output->chars[output->length - 1], CTC_Space, 1, table)) {
+						checkDotsAttr(
+								output->chars[output->length - 1], CTC_Space, table)) {
 					if (output->chars[output->length - 1] == LOU_ENDSEGMENT) {
 						hasEndSegment = 1;
 					}
@@ -3658,7 +3667,7 @@ translateString(const TranslationTableHeader *table,
 				srclim = compbrlStart - 1;
 			while ((pos <= srclim) &&
 					compareChars(&transRule->charsdots[0], &input->chars[pos],
-							transCharslen, 0, table)) {
+							transCharslen, table)) {
 				if (!*cursorStatus && pos <= *cursorPosition &&
 						*cursorPosition < pos + transCharslen) {
 					*cursorStatus = 1;
@@ -3696,7 +3705,7 @@ translateString(const TranslationTableHeader *table,
 				srclim = compbrlStart;
 			while (pos + repwordLength <= srclim &&
 					compareChars(&input->chars[repwordStart], &input->chars[pos],
-							repwordLength, 0, table)) {
+							repwordLength, table)) {
 				if (!*cursorStatus && *cursorPosition >= pos - transCharslen &&
 						*cursorPosition < pos + repwordLength) {
 					*cursorStatus = 1;
@@ -3718,14 +3727,14 @@ translateString(const TranslationTableHeader *table,
 		case CTO_JoinNum:
 		case CTO_JoinableWord:
 			while (pos < input->length &&
-					checkAttr(input->chars[pos], CTC_Space, 0, table) &&
+					checkCharAttr(input->chars[pos], CTC_Space, table) &&
 					input->chars[pos] != LOU_ENDSEGMENT)
 				pos++;
 			break;
 		default:
 			break;
 		}
-		if (((pos > 0) && checkAttr(input->chars[pos - 1], CTC_Space, 0, table) &&
+		if (((pos > 0) && checkCharAttr(input->chars[pos - 1], CTC_Space, table) &&
 					(transOpcode != CTO_JoinableWord))) {
 			lastWord = (LastWord){ pos, output->length, insertEmphasesFrom };
 		}
@@ -3755,12 +3764,12 @@ translateString(const TranslationTableHeader *table,
 
 failure:
 	if (lastWord.outPos != 0 && pos < input->length &&
-			!checkAttr(input->chars[pos], CTC_Space, 0, table)) {
+			!checkCharAttr(input->chars[pos], CTC_Space, table)) {
 		pos = lastWord.inPos;
 		output->length = lastWord.outPos;
 	}
 	if (pos < input->length) {
-		while (checkAttr(input->chars[pos], CTC_Space, 0, table))
+		while (checkCharAttr(input->chars[pos], CTC_Space, table))
 			if (++pos == input->length) break;
 	}
 	*realInlen = pos;
@@ -3772,7 +3781,7 @@ failure:
 static int
 isHyphen(const TranslationTableHeader *table, widechar c) {
 	TranslationTableRule *rule;
-	TranslationTableOffset offset = findCharOrDots(c, 0, table)->otherRules;
+	TranslationTableOffset offset = getChar(c, table)->otherRules;
 	while (offset) {
 		rule = (TranslationTableRule *)&table->ruleArea[offset];
 		if (rule->opcode == CTO_Hyphen) return 1;
@@ -3830,23 +3839,18 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 		int wordEnd;
 		// find start of word
 		for (; wordStart < textLen; wordStart++)
-			if ((findCharOrDots(textBuffer[wordStart], 0, table))->attributes &
-					CTC_Letter)
-				break;
+			if ((getChar(textBuffer[wordStart], table))->attributes & CTC_Letter) break;
 		if (wordStart == textLen) break;
 		// find end of word
 		for (wordEnd = wordStart + 1; wordEnd < textLen; wordEnd++)
-			if (!((findCharOrDots(textBuffer[wordEnd], 0, table))->attributes &
-						CTC_Letter))
-				break;
+			if (!((getChar(textBuffer[wordEnd], table))->attributes & CTC_Letter)) break;
 		// hyphenate
 		if (!hyphenateWord(&textBuffer[wordStart], wordEnd - wordStart,
 					&textHyphens[wordStart], table))
 			return 0;
 		// normalize to '0', '1' or '2'
 		if (wordStart >= 2 && isHyphen(table, textBuffer[wordStart - 1]) &&
-				((findCharOrDots(textBuffer[wordStart - 2], 0, table))->attributes &
-						CTC_Letter))
+				((getChar(textBuffer[wordStart - 2], table))->attributes & CTC_Letter))
 			textHyphens[wordStart] = '2';
 		else
 			textHyphens[wordStart] = '0';
@@ -3894,7 +3898,7 @@ lou_dotsToChar(
 		if (!(dots & LOU_DOTS) &&
 				(dots & 0xff00) == LOU_ROW_BRAILLE) /* Unicode braille */
 			dots = (dots & 0x00ff) | LOU_DOTS;
-		outbuf[k] = _lou_getCharFromDots(dots, table);
+		outbuf[k] = _lou_getCharForDots(dots, table);
 		// assume that if NUL character is returned, it's because the display table has no
 		// mapping for the dot pattern (not because it maps to NUL)
 		if (outbuf[k] == '\0') outbuf[k] = ' ';

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -123,18 +123,17 @@ typedef struct {
 } PassRuleMatch;
 
 static int
-putCharacter(widechar c, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int mode);
+putCharacter(widechar c, const TranslationTableHeader *table, int pos,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int mode);
 static int
 passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 		int transOpcode, const TranslationTableRule *transRule, int *passCharDots,
 		const widechar **passInstructions, int *passIC, PassRuleMatch *match,
 		TranslationTableRule **groupingRule, widechar *groupingOp);
 static int
-passDoAction(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
-		const InString **input, OutString *output, int *posMapping, int transOpcode,
+passDoAction(const TranslationTableHeader *table, const InString **input,
+		OutString *output, int *posMapping, int transOpcode,
 		const TranslationTableRule **transRule, int passCharDots,
 		const widechar *passInstructions, int passIC, int *pos, PassRuleMatch match,
 		int *cursorPosition, int *cursorStatus, TranslationTableRule *groupingRule,
@@ -233,10 +232,9 @@ compareChars(const widechar *address1, const widechar *address2, int count,
 }
 
 static int
-makeCorrections(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, const InString *input, OutString *output,
-		int *posMapping, formtype *typebuf, int *realInlen, int *cursorPosition,
-		int *cursorStatus, int mode) {
+makeCorrections(const TranslationTableHeader *table, const InString *input,
+		OutString *output, int *posMapping, formtype *typebuf, int *realInlen,
+		int *cursorPosition, int *cursorStatus, int mode) {
 	int pos;
 	int transOpcode;
 	const TranslationTableRule *transRule;
@@ -312,10 +310,9 @@ makeCorrections(const TranslationTableHeader *table,
 			int posBefore = pos;
 			if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 				appliedRules[appliedRulesCount++] = transRule;
-			if (!passDoAction(table, displayTable, &input, output, posMapping,
-						transOpcode, &transRule, passCharDots, passInstructions, passIC,
-						&pos, patternMatch, cursorPosition, cursorStatus, groupingRule,
-						groupingOp, mode))
+			if (!passDoAction(table, &input, output, posMapping, transOpcode, &transRule,
+						passCharDots, passInstructions, passIC, &pos, patternMatch,
+						cursorPosition, cursorStatus, groupingRule, groupingOp, mode))
 				goto failure;
 			if (input->bufferIndex != inputBefore->bufferIndex &&
 					inputBefore->bufferIndex != origInput->bufferIndex)
@@ -873,13 +870,12 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 
 static int
 copyCharacters(int from, int to, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, const InString *input, OutString *output,
-		int *posMapping, int transOpcode, int *cursorPosition, int *cursorStatus,
-		int mode) {
+		const InString *input, OutString *output, int *posMapping, int transOpcode,
+		int *cursorPosition, int *cursorStatus, int mode) {
 	if (transOpcode == CTO_Context) {
 		while (from < to) {
-			if (!putCharacter(input->chars[from], table, displayTable, from, input,
-						output, posMapping, cursorPosition, cursorStatus, mode))
+			if (!putCharacter(input->chars[from], table, from, input, output, posMapping,
+						cursorPosition, cursorStatus, mode))
 				return 0;
 			from++;
 		}
@@ -899,8 +895,8 @@ copyCharacters(int from, int to, const TranslationTableHeader *table,
 }
 
 static int
-passDoAction(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
-		const InString **input, OutString *output, int *posMapping, int transOpcode,
+passDoAction(const TranslationTableHeader *table, const InString **input,
+		OutString *output, int *posMapping, int transOpcode,
 		const TranslationTableRule **transRule, int passCharDots,
 		const widechar *passInstructions, int passIC, int *pos, PassRuleMatch match,
 		int *cursorPosition, int *cursorStatus, TranslationTableRule *groupingRule,
@@ -912,8 +908,8 @@ passDoAction(const TranslationTableHeader *table, const DisplayTableHeader *disp
 	int destStartReplace;
 	int newPos = match.endReplace;
 
-	if (!copyCharacters(match.startMatch, match.startReplace, table, displayTable, *input,
-				output, posMapping, transOpcode, cursorPosition, cursorStatus, mode))
+	if (!copyCharacters(match.startMatch, match.startReplace, table, *input, output,
+				posMapping, transOpcode, cursorPosition, cursorStatus, mode))
 		return 0;
 	destStartReplace = output->length;
 
@@ -975,9 +971,9 @@ passDoAction(const TranslationTableHeader *table, const DisplayTableHeader *disp
 			}
 		}
 
-			if (!copyCharacters(match.startReplace, match.endReplace, table, displayTable,
-						*input, output, posMapping, transOpcode, cursorPosition,
-						cursorStatus, mode))
+			if (!copyCharacters(match.startReplace, match.endReplace, table, *input,
+						output, posMapping, transOpcode, cursorPosition, cursorStatus,
+						mode))
 				return 0;
 			newPos = match.endMatch;
 			passIC++;
@@ -1004,9 +1000,9 @@ passSelectRule(const TranslationTableHeader *table, int pos, int currentPass,
 }
 
 static int
-translatePass(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
-		int currentPass, const InString *input, OutString *output, int *posMapping,
-		int *realInlen, int *cursorPosition, int *cursorStatus, int mode) {
+translatePass(const TranslationTableHeader *table, int currentPass, const InString *input,
+		OutString *output, int *posMapping, int *realInlen, int *cursorPosition,
+		int *cursorStatus, int mode) {
 	int pos;
 	int transOpcode;
 	const TranslationTableRule *transRule;
@@ -1039,10 +1035,9 @@ translatePass(const TranslationTableHeader *table, const DisplayTableHeader *dis
 			int posBefore = pos;
 			if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 				appliedRules[appliedRulesCount++] = transRule;
-			if (!passDoAction(table, displayTable, &input, output, posMapping,
-						transOpcode, &transRule, passCharDots, passInstructions, passIC,
-						&pos, patternMatch, cursorPosition, cursorStatus, groupingRule,
-						groupingOp, mode))
+			if (!passDoAction(table, &input, output, posMapping, transOpcode, &transRule,
+						passCharDots, passInstructions, passIC, &pos, patternMatch,
+						cursorPosition, cursorStatus, groupingRule, groupingOp, mode))
 				goto failure;
 			if (input->bufferIndex != inputBefore->bufferIndex &&
 					inputBefore->bufferIndex != origInput->bufferIndex)
@@ -1073,8 +1068,7 @@ failure:
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 static int
-translateString(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, int currentPass,
+translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, formtype *typebuf,
 		unsigned char *srcSpacing, unsigned char *destSpacing, unsigned int *wordBuffer,
 		EmphasisInfo *emphasisBuffer, int haveEmphasis, int *realInlen,
@@ -1244,20 +1238,19 @@ _lou_translate(const char *tableList, const char *displayTableList,
 		int realInlen;
 		switch (currentPass) {
 		case 0:
-			goodTrans =
-					makeCorrections(table, displayTable, &input, &output, passPosMapping,
-							typebuf, &realInlen, &cursorPosition, &cursorStatus, mode);
+			goodTrans = makeCorrections(table, &input, &output, passPosMapping, typebuf,
+					&realInlen, &cursorPosition, &cursorStatus, mode);
 			break;
 		case 1: {
-			goodTrans = translateString(table, displayTable, mode, currentPass, &input,
-					&output, passPosMapping, typebuf, srcSpacing, destSpacing, wordBuffer,
+			goodTrans = translateString(table, mode, currentPass, &input, &output,
+					passPosMapping, typebuf, srcSpacing, destSpacing, wordBuffer,
 					emphasisBuffer, haveEmphasis, &realInlen, &cursorPosition,
 					&cursorStatus, compbrlStart, compbrlEnd);
 			break;
 		}
 		default:
-			goodTrans = translatePass(table, displayTable, currentPass, &input, &output,
-					passPosMapping, &realInlen, &cursorPosition, &cursorStatus, mode);
+			goodTrans = translatePass(table, currentPass, &input, &output, passPosMapping,
+					&realInlen, &cursorPosition, &cursorStatus, mode);
 			break;
 		}
 		passPosMapping[output.length] = realInlen;
@@ -1469,11 +1462,10 @@ hyphenateWord(const widechar *word, int wordSize, char *hyphens,
 }
 
 static int
-doCompTrans(int start, int end, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int *pos, const InString *input,
-		OutString *output, int *posMapping, EmphasisInfo *emphasisBuffer,
-		const TranslationTableRule **transRule, int *cursorPosition, int *cursorStatus,
-		int mode);
+doCompTrans(int start, int end, const TranslationTableHeader *table, int *pos,
+		const InString *input, OutString *output, int *posMapping,
+		EmphasisInfo *emphasisBuffer, const TranslationTableRule **transRule,
+		int *cursorPosition, int *cursorStatus, int mode);
 
 // The `shift' argument should be used with care because it can mess up the positions
 // array which is supposed to be monotonically increasing. It is set to -1 in order to
@@ -2199,10 +2191,9 @@ for_selectRule(const TranslationTableHeader *table, int pos, OutString output,
 }
 
 static int
-undefinedCharacter(widechar c, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int mode) {
+undefinedCharacter(widechar c, const TranslationTableHeader *table, int pos,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int mode) {
 	/* Display an undefined character in the output buffer */
 	if (table->undefined) {
 		TranslationTableRule *rule =
@@ -2218,12 +2209,21 @@ undefinedCharacter(widechar c, const TranslationTableHeader *table,
 	widechar dots[length];
 
 	for (unsigned int k = 0; k < length; k += 1) {
-		widechar c = text[k];
-		widechar d = _lou_getDotsForChar(c, displayTable);
-		// assume that if d is blank, it's because the display table does not have a
-		// mapping to c (not because blank maps to c)
-		if (d == LOU_DOTS) d = _lou_charToFallbackDots(c);
-		dots[k] = d;
+		dots[k] = 0;
+		// looking in otherRules and not definitionRule because definitionRule gives us
+		// the last occurence of a character definition rule and we are interested in
+		// the first
+		TranslationTableOffset offset = getChar(text[k], table)->otherRules;
+		while (offset) {
+			const TranslationTableRule *r =
+					(TranslationTableRule *)&table->ruleArea[offset];
+			if (r->opcode >= CTO_Space && r->opcode < CTO_UpLow && r->dotslen == 1) {
+				dots[k] = r->charsdots[1];
+				break;
+			}
+			offset = r->charsnext;
+		}
+		if (!dots[k]) dots[k] = _lou_charToFallbackDots(text[k]);
 	}
 
 	return for_updatePositions(dots, 1, length, 0, pos, input, output, posMapping,
@@ -2231,16 +2231,12 @@ undefinedCharacter(widechar c, const TranslationTableHeader *table,
 }
 
 static int
-putCharacter(widechar character, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int mode) {
+putCharacter(widechar character, const TranslationTableHeader *table, int pos,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int mode) {
 	/* Insert the dots equivalent of a character into the output buffer */
-	const TranslationTableRule *rule = NULL;
-	TranslationTableCharacter *chardef = NULL;
 	TranslationTableOffset offset;
-	widechar d;
-	chardef = getChar(character, table);
+	TranslationTableCharacter *chardef = getChar(character, table);
 	// If capsletter is defined, replace uppercase with lowercase letters. If capsletter
 	// is not defined, uppercase letters should be preserved because otherwise case info
 	// is lost.
@@ -2248,29 +2244,25 @@ putCharacter(widechar character, const TranslationTableHeader *table,
 		chardef = getChar(chardef->lowercase, table);
 	offset = chardef->definitionRule;
 	if (offset) {
-		rule = (TranslationTableRule *)&table->ruleArea[offset];
-		if (rule->dotslen)
-			return for_updatePositions(&rule->charsdots[1], 1, rule->dotslen, 0, pos,
-					input, output, posMapping, cursorPosition, cursorStatus);
-		d = _lou_getDotsForChar(character, displayTable);
-		return for_updatePositions(&d, 1, 1, 0, pos, input, output, posMapping,
-				cursorPosition, cursorStatus);
+		const TranslationTableRule *rule =
+				(TranslationTableRule *)&table->ruleArea[offset];
+		return for_updatePositions(&rule->charsdots[1], 1, rule->dotslen, 0, pos, input,
+				output, posMapping, cursorPosition, cursorStatus);
 	}
-	return undefinedCharacter(character, table, displayTable, pos, input, output,
-			posMapping, cursorPosition, cursorStatus, mode);
+	return undefinedCharacter(character, table, pos, input, output, posMapping,
+			cursorPosition, cursorStatus, mode);
 }
 
 static int
 putCharacters(const widechar *characters, int count, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int mode) {
+		int pos, const InString *input, OutString *output, int *posMapping,
+		int *cursorPosition, int *cursorStatus, int mode) {
 	/* Insert the dot equivalents of a series of characters in the output
 	 * buffer */
 	int k;
 	for (k = 0; k < count; k++)
-		if (!putCharacter(characters[k], table, displayTable, pos, input, output,
-					posMapping, cursorPosition, cursorStatus, mode))
+		if (!putCharacter(characters[k], table, pos, input, output, posMapping,
+					cursorPosition, cursorStatus, mode))
 			return 0;
 	return 1;
 }
@@ -2285,11 +2277,10 @@ typedef struct {
 } LastWord;
 
 static int
-doCompbrl(const TranslationTableHeader *table, const DisplayTableHeader *displayTable,
-		int *pos, const InString *input, OutString *output, int *posMapping,
-		EmphasisInfo *emphasisBuffer, const TranslationTableRule **transRule,
-		int *cursorPosition, int *cursorStatus, const LastWord *lastWord,
-		int *insertEmphasesFrom, int mode) {
+doCompbrl(const TranslationTableHeader *table, int *pos, const InString *input,
+		OutString *output, int *posMapping, EmphasisInfo *emphasisBuffer,
+		const TranslationTableRule **transRule, int *cursorPosition, int *cursorStatus,
+		const LastWord *lastWord, int *insertEmphasesFrom, int mode) {
 	/* Handle strings containing substrings defined by the compbrl opcode */
 	int stringStart, stringEnd;
 	if (checkCharAttr(input->chars[*pos], CTC_Space, table)) return 1;
@@ -2306,38 +2297,31 @@ doCompbrl(const TranslationTableHeader *table, const DisplayTableHeader *display
 	stringStart++;
 	for (stringEnd = *pos; stringEnd < input->length; stringEnd++)
 		if (checkCharAttr(input->chars[stringEnd], CTC_Space, table)) break;
-	return doCompTrans(stringStart, stringEnd, table, displayTable, pos, input, output,
-			posMapping, emphasisBuffer, transRule, cursorPosition, cursorStatus, mode);
+	return doCompTrans(stringStart, stringEnd, table, pos, input, output, posMapping,
+			emphasisBuffer, transRule, cursorPosition, cursorStatus, mode);
 }
 
 static int
-putCompChar(widechar character, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int pos, const InString *input,
-		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
-		int mode) {
+putCompChar(widechar character, const TranslationTableHeader *table, int pos,
+		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
+		int *cursorStatus, int mode) {
 	/* Insert the dots equivalent of a character into the output buffer */
-	widechar d;
 	TranslationTableOffset offset = (getChar(character, table))->definitionRule;
 	if (offset) {
 		const TranslationTableRule *rule =
 				(TranslationTableRule *)&table->ruleArea[offset];
-		if (rule->dotslen)
-			return for_updatePositions(&rule->charsdots[1], 1, rule->dotslen, 0, pos,
-					input, output, posMapping, cursorPosition, cursorStatus);
-		d = _lou_getDotsForChar(character, displayTable);
-		return for_updatePositions(&d, 1, 1, 0, pos, input, output, posMapping,
-				cursorPosition, cursorStatus);
+		return for_updatePositions(&rule->charsdots[1], 1, rule->dotslen, 0, pos, input,
+				output, posMapping, cursorPosition, cursorStatus);
 	}
-	return undefinedCharacter(character, table, displayTable, pos, input, output,
-			posMapping, cursorPosition, cursorStatus, mode);
+	return undefinedCharacter(character, table, pos, input, output, posMapping,
+			cursorPosition, cursorStatus, mode);
 }
 
 static int
-doCompTrans(int start, int end, const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int *pos, const InString *input,
-		OutString *output, int *posMapping, EmphasisInfo *emphasisBuffer,
-		const TranslationTableRule **transRule, int *cursorPosition, int *cursorStatus,
-		int mode) {
+doCompTrans(int start, int end, const TranslationTableHeader *table, int *pos,
+		const InString *input, OutString *output, int *posMapping,
+		EmphasisInfo *emphasisBuffer, const TranslationTableRule **transRule,
+		int *cursorPosition, int *cursorStatus, int mode) {
 	const TranslationTableRule *indicRule;
 	int k;
 	int haveEndsegment = 0;
@@ -2363,8 +2347,8 @@ doCompTrans(int start, int end, const TranslationTableHeader *table,
 						(*transRule)->charslen, (*transRule)->dotslen, 0, *pos, input,
 						output, posMapping, cursorPosition, cursorStatus))
 				return 0;
-		} else if (!putCompChar(input->chars[k], table, displayTable, *pos, input, output,
-						   posMapping, cursorPosition, cursorStatus, mode))
+		} else if (!putCompChar(input->chars[k], table, *pos, input, output, posMapping,
+						   cursorPosition, cursorStatus, mode))
 			return 0;
 	}
 	if (*cursorStatus != 2 && brailleIndicatorDefined(table->endComp, table, &indicRule))
@@ -3382,8 +3366,7 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 }
 
 static int
-translateString(const TranslationTableHeader *table,
-		const DisplayTableHeader *displayTable, int mode, int currentPass,
+translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, formtype *typebuf,
 		unsigned char *srcSpacing, unsigned char *destSpacing, unsigned int *wordBuffer,
 		EmphasisInfo *emphasisBuffer, int haveEmphasis, int *realInlen,
@@ -3429,9 +3412,8 @@ translateString(const TranslationTableHeader *table,
 	while (pos < input->length) { /* the main translation loop */
 		if ((pos >= compbrlStart) && (pos < compbrlEnd)) {
 			int cs = 2;  // cursor status for this call
-			if (!doCompTrans(pos, compbrlEnd, table, displayTable, &pos, input, output,
-						posMapping, emphasisBuffer, &transRule, cursorPosition, &cs,
-						mode))
+			if (!doCompTrans(pos, compbrlEnd, table, &pos, input, output, posMapping,
+						emphasisBuffer, &transRule, cursorPosition, &cs, mode))
 				goto failure;
 			continue;
 		}
@@ -3441,9 +3423,19 @@ translateString(const TranslationTableHeader *table,
 
 		if (!dontContract) dontContract = typebuf[pos] & no_contract;
 		if (typebuf[pos] & no_translate) {
-			widechar c = _lou_getDotsForChar(input->chars[pos], displayTable);
 			if (input->chars[pos] < 32 || input->chars[pos] > 126) goto failure;
-			if (!for_updatePositions(&c, 1, 1, 0, pos, input, output, posMapping,
+			widechar d = LOU_DOTS;
+			TranslationTableOffset offset = getChar(input->chars[pos], table)->otherRules;
+			while (offset) {
+				const TranslationTableRule *r =
+						(TranslationTableRule *)&table->ruleArea[offset];
+				if (r->opcode >= CTO_Space && r->opcode < CTO_UpLow && r->dotslen == 1) {
+					d = r->charsdots[1];
+					break;
+				}
+				offset = r->charsnext;
+			}
+			if (!for_updatePositions(&d, 1, 1, 0, pos, input, output, posMapping,
 						cursorPosition, cursorStatus))
 				goto failure;
 			pos++;
@@ -3464,9 +3456,9 @@ translateString(const TranslationTableHeader *table,
 		{
 		case CTO_CompBrl:
 		case CTO_Literal:
-			if (!doCompbrl(table, displayTable, &pos, input, output, posMapping,
-						emphasisBuffer, &transRule, cursorPosition, cursorStatus,
-						&lastWord, &insertEmphasesFrom, mode))
+			if (!doCompbrl(table, &pos, input, output, posMapping, emphasisBuffer,
+						&transRule, cursorPosition, cursorStatus, &lastWord,
+						&insertEmphasesFrom, mode))
 				goto failure;
 			continue;
 		default:
@@ -3530,10 +3522,10 @@ translateString(const TranslationTableHeader *table,
 				int posBefore = pos;
 				if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
 					appliedRules[appliedRulesCount++] = transRule;
-				if (!passDoAction(table, displayTable, &input, output, posMapping,
-							transOpcode, &transRule, passCharDots, passInstructions,
-							passIC, &pos, patternMatch, cursorPosition, cursorStatus,
-							groupingRule, groupingOp, mode))
+				if (!passDoAction(table, &input, output, posMapping, transOpcode,
+							&transRule, passCharDots, passInstructions, passIC, &pos,
+							patternMatch, cursorPosition, cursorStatus, groupingRule,
+							groupingOp, mode))
 					goto failure;
 				if (input->bufferIndex != inputBefore->bufferIndex &&
 						inputBefore->bufferIndex != origInput->bufferIndex)
@@ -3608,13 +3600,13 @@ translateString(const TranslationTableHeader *table,
 		case CTO_Replace:
 			pos += transCharslen;
 			if (!putCharacters(&transRule->charsdots[transCharslen], transRule->dotslen,
-						table, displayTable, pos, input, output, posMapping,
-						cursorPosition, cursorStatus, mode))
+						table, pos, input, output, posMapping, cursorPosition,
+						cursorStatus, mode))
 				goto failure;
 			break;
 		case CTO_None:
-			if (!undefinedCharacter(input->chars[pos], table, displayTable, pos, input,
-						output, posMapping, cursorPosition, cursorStatus, mode))
+			if (!undefinedCharacter(input->chars[pos], table, pos, input, output,
+						posMapping, cursorPosition, cursorStatus, mode))
 				goto failure;
 			pos++;
 			break;
@@ -3623,8 +3615,8 @@ translateString(const TranslationTableHeader *table,
 			 * the table defines a capital sign. */
 			if (!(mode & (compbrlAtCursor | compbrlLeftCursor)) &&
 					(transRule->dotslen == 1 && capsletterDefined(table))) {
-				if (!putCharacter(curCharDef->lowercase, table, displayTable, pos, input,
-							output, posMapping, cursorPosition, cursorStatus, mode))
+				if (!putCharacter(curCharDef->lowercase, table, pos, input, output,
+							posMapping, cursorPosition, cursorStatus, mode))
 					goto failure;
 				pos++;
 				break;
@@ -3647,8 +3639,8 @@ translateString(const TranslationTableHeader *table,
 				pos += transCharslen;
 			} else {
 				for (k = 0; k < transCharslen; k++) {
-					if (!putCharacter(input->chars[pos], table, displayTable, pos, input,
-								output, posMapping, cursorPosition, cursorStatus, mode))
+					if (!putCharacter(input->chars[pos], table, pos, input, output,
+								posMapping, cursorPosition, cursorStatus, mode))
 						goto failure;
 					pos++;
 				}

--- a/liblouis/maketable.c
+++ b/liblouis/maketable.c
@@ -98,7 +98,7 @@ printRule(TranslationTableRule *rule, widechar *rule_string) {
 		for (int k = 0; k < rule->charslen; k++) rule_string[l++] = rule->charsdots[k];
 		rule_string[l++] = '\t';
 		for (int k = 0; k < rule->dotslen; k++) {
-			rule_string[l] = _lou_getCharFromDots(
+			rule_string[l] = _lou_getCharForDots(
 					rule->charsdots[rule->charslen + k], displayTable);
 			if (rule_string[l] == '\0') {
 				// if a dot pattern can not be displayed, print an error message
@@ -247,7 +247,7 @@ find_matching_rules(widechar *text, int text_len, widechar *braille, int braille
 					(rule->dotslen == braille_len && rule->charslen < text_len))
 				goto inhibit;
 			for (k = 0; k < rule->dotslen; k++)
-				if (_lou_getCharFromDots(rule->charsdots[rule->charslen + k],
+				if (_lou_getCharForDots(rule->charsdots[rule->charslen + k],
 							displayTable) != braille[k])
 					goto inhibit;
 

--- a/tests/yaml/computer_braille.yaml
+++ b/tests/yaml/computer_braille.yaml
@@ -12,7 +12,7 @@ table: |
   comp6 c 25
   begcomp 456-346
   endcomp 456-156
-
+flags: {testmode: forward}
 tests:
   # no computer braille
   - - abc
@@ -35,9 +35,36 @@ tests:
 
 # Test comp6 in back-translation
 # see issue https://github.com/liblouis/liblouis/issues/715
-
 flags: {testmode: backward}
 tests:
   - - ⠁⠃⠉ ⠸⠬⠂⠆⠒⠸⠱ ⠁⠃⠉
     - abc abc abc
     - xfail: begcompbrl and endcompbrl are apparently consumed but not processed
+
+# no_translate typeform can not be used instead of computer_braille:
+# - it ignores comp6 rules
+# - it does not insert begcomp and endcomp
+# - it ignores character definition rules that map to more than one cell
+# - it takes the first character definition rule rather than the last
+# - it fails on characters outside of the range \x0020-\x007E
+table: |
+  include tables/unicode-without-blank.dis
+  space \s 0
+  letter a 1-1
+  letter a 1
+  letter a 2
+  letter b 12
+  letter c 14
+  comp6 a 2
+  comp6 b 23
+  comp6 c 25
+  begcomp 456-346
+  endcomp 456-156
+  always abc 123456
+  include tables/braille-patterns.cti
+flags: {testmode: forward}
+tests:
+  - - abc abc abc
+    - ⠿ ⠁⠃⠉ ⠿
+    - typeform:
+        no_translate: '    +++    '

--- a/tests/yaml/precedence.yaml
+++ b/tests/yaml/precedence.yaml
@@ -82,7 +82,7 @@ tests:
 
 # for printing escape sequences for undefined characters, only
 # character definitions that map to a single dot are used and the
-# first definition wins
+# first definition wins. display rules are ignored.
 table: |
   include tables/unicode-without-blank.dis
   digit 0 356
@@ -91,23 +91,8 @@ table: |
   letter x 1346
   sign \\ 16
   sign ' 3-3
+  display ' 6
   sign ' 3
-  sign ' 6
-flags: {testmode: forward}
-tests:
-  - - "\u2026"
-    - ⠄⠡⠭⠆⠴⠆⠖⠄
-
-# ... and display rules are also taken into account
-table: |
-  include tables/unicode-without-blank.dis
-  digit 0 356
-  digit 2 23
-  digit 6 235
-  letter x 1346
-  sign \\ 16
-  sign ' 3-3
-  display ' 3
   sign ' 6
 flags: {testmode: forward}
 tests:

--- a/tests/yaml/precedence.yaml
+++ b/tests/yaml/precedence.yaml
@@ -79,3 +79,37 @@ table: |
 tests:
   - - Aa Bb Cc Dd Ee Ff Gg Hh
     - ⠠⠁⠁ ⠠⠁⠃ ⠠⠉⠉ ⠠⠉⠙ ⠠⠑⠑ ⠠⠑⠋ ⠠⠛⠛ ⠠⠛⠓
+
+# for printing escape sequences for undefined characters, only
+# character definitions that map to a single dot are used and the
+# first definition wins
+table: |
+  include tables/unicode-without-blank.dis
+  digit 0 356
+  digit 2 23
+  digit 6 235
+  letter x 1346
+  sign \\ 16
+  sign ' 3-3
+  sign ' 3
+  sign ' 6
+flags: {testmode: forward}
+tests:
+  - - "\u2026"
+    - ⠄⠡⠭⠆⠴⠆⠖⠄
+
+# ... and display rules are also taken into account
+table: |
+  include tables/unicode-without-blank.dis
+  digit 0 356
+  digit 2 23
+  digit 6 235
+  letter x 1346
+  sign \\ 16
+  sign ' 3-3
+  display ' 3
+  sign ' 6
+flags: {testmode: forward}
+tests:
+  - - "\u2026"
+    - ⠄⠡⠭⠆⠴⠆⠖⠄

--- a/tools/lou_debug.c
+++ b/tools/lou_debug.c
@@ -355,7 +355,7 @@ show_misc(void) {
 static int
 show_charMap(int startHash) {
 	int k;
-	CharOrDots *thisChar;
+	CharDotsMapping *thisChar;
 	TranslationTableOffset nextChar;
 	printf("Press enter for next or (e)xit, next-(h)ash, then enter\n");
 	if (startHash < 0)
@@ -367,7 +367,7 @@ show_charMap(int startHash) {
 			printf("Hash=%d\n", k);
 			nextChar = displayTable->charToDots[k];
 			while (nextChar) {
-				thisChar = (CharOrDots *)&displayTable->ruleArea[nextChar];
+				thisChar = (CharDotsMapping *)&displayTable->ruleArea[nextChar];
 				printf("Char: %s ", print_chars(&thisChar->lookFor, 1));
 				printf("dots=%s\n", _lou_showDots(&thisChar->found, 1));
 				printf("=> ");
@@ -383,7 +383,7 @@ show_charMap(int startHash) {
 static int
 show_dotsMap(int startHash) {
 	int k;
-	CharOrDots *thisDots;
+	CharDotsMapping *thisDots;
 	TranslationTableOffset nextDots;
 	printf("Press enter for next or (e)xit, next-(h)ash, then enter\n");
 	if (startHash < 0)
@@ -395,7 +395,7 @@ show_dotsMap(int startHash) {
 			printf("Hash=%d\n", k);
 			nextDots = displayTable->dotsToChar[k];
 			while (nextDots) {
-				thisDots = (CharOrDots *)&displayTable->ruleArea[nextDots];
+				thisDots = (CharDotsMapping *)&displayTable->ruleArea[nextDots];
 				printf("Dots: %s ", _lou_showDots(&thisDots->lookFor, 1));
 				printf("char=%s\n", print_chars(&thisDots->found, 1));
 				printf("=> ");


### PR DESCRIPTION
Don't take into account any display rules during translation.

- In three cases I just removed some dead code because for character definition rules `dotslen` is always > 0.
- In two cases, namely for printing escape sequences for undefined characters and for handling the "no_translate" typeform, display rules are now ignored. Only character definitions (that map to a single dot) are taken into account.

See https://github.com/liblouis/liblouis/issues/307.