### PR TITLE
Increase LETSIGNSIZE to 256

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3177,8 +3177,9 @@ doOpcode:
 		}
 		case CTO_NoLetsignBefore:
 			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-				if (((*table)->noLetsignBeforeCount + ruleChars.length) > LETSIGNSIZE) {
-					compileError(nested, "More than %d characters", LETSIGNSIZE);
+				if (((*table)->noLetsignBeforeCount + ruleChars.length) >
+						LETSIGNBEFORESIZE) {
+					compileError(nested, "More than %d characters", LETSIGNBEFORESIZE);
 					ok = 0;
 					break;
 				}
@@ -3200,8 +3201,9 @@ doOpcode:
 			break;
 		case CTO_NoLetsignAfter:
 			if (getRuleCharsText(nested, &ruleChars, &lastToken)) {
-				if (((*table)->noLetsignAfterCount + ruleChars.length) > LETSIGNSIZE) {
-					compileError(nested, "More than %d characters", LETSIGNSIZE);
+				if (((*table)->noLetsignAfterCount + ruleChars.length) >
+						LETSIGNAFTERSIZE) {
+					compileError(nested, "More than %d characters", LETSIGNAFTERSIZE);
 					ok = 0;
 					break;
 				}

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -53,7 +53,11 @@ extern "C" {
 
 #define NUMSWAPS 50
 #define NUMVAR 50
-#define LETSIGNSIZE 128
+#define LETSIGNSIZE 256
+// noletsignbefore and noletsignafter is hardly ever used and usually
+// only with very few chars, so it only needs a small array
+#define LETSIGNBEFORESIZE 64
+#define LETSIGNAFTERSIZE 64
 #define SEQPATTERNSIZE 128
 #define CHARSIZE sizeof(widechar)
 #define DEFAULTRULESIZE 50
@@ -538,11 +542,11 @@ typedef struct { /* translation table */
 	TranslationTableOffset compEndCaps;
 	TranslationTableOffset endComp;
 	TranslationTableOffset hyphenStatesArray;
-	widechar noLetsignBefore[LETSIGNSIZE];
+	widechar noLetsignBefore[LETSIGNBEFORESIZE];
 	int noLetsignBeforeCount;
 	widechar noLetsign[LETSIGNSIZE];
 	int noLetsignCount;
-	widechar noLetsignAfter[LETSIGNSIZE];
+	widechar noLetsignAfter[LETSIGNAFTERSIZE];
 	int noLetsignAfterCount;
 	TranslationTableOffset characters[HASHNUM]; /** Character definitions */
 	TranslationTableOffset dots[HASHNUM];		/** Dot definitions */


### PR DESCRIPTION
and at the same time decrease `LETSIGNSIZE` for `noletsignbefore` and
`noletsignafter` (by introducing two more constants `LETSIGNBEFORESIZE`
and `LETSIGNAFTERSIZE`.

This will allow for 256 letsign characters while keeping the size of
the table the same because we decrease the size of the `noLetsignBefore`
and `noLetsignAfter` array.

This fixes #529 in a simplistic but good enough way and helps with #921.