### PR TITLE
Check faulty attribute name

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3799,7 +3799,7 @@ doOpcode:
 					} else if (token.length > 1 || attrNumber > 7) {
 						compileError(nested,
 								"Invalid attribute name: must be a digit between 0 and 7 "
-								"or a word containing only letters and digits");
+								"or a word containing only letters");
 						ok = 0;
 						break;
 					}
@@ -3821,8 +3821,7 @@ doOpcode:
 								// expressions
 								compileWarning(nested,
 										"Invalid attribute name: must be a digit between "
-										"0 and 7 or a word containing only letters and "
-										"digits");
+										"0 and 7 or a word containing only letters");
 							}
 						}
 						// check that name is not reserved

--- a/tests/yaml/attribute.yaml
+++ b/tests/yaml/attribute.yaml
@@ -28,6 +28,19 @@ tests:
   - - aabaa
     - aabAa
 
+# attribute names cannot contain digits
+table: |
+  display A 17
+  sign a 1
+  sign b 12
+  attribute foo1 b
+  noback context _%foo1["a"] @17
+flags: {testmode: forward}
+tests:
+  - - aabaa
+    - aabAa
+    - xfail: This is expected to fail as the attribute name foo1 is not allowed
+
 # attribute name can be a predefined attribute, i.e. space, letter,
 # digit, punctuation, uppercase, lowercase, math, sign or litdigit
 # (and it will set that attribute, not a custom one)


### PR DESCRIPTION
This PR 

1. fixes the error message for an invalid attribute name and
2. adds a test containing an invalid attribute name

The test with the invalid attribute name isn't so nice as the error message is not properly caught by the test framework. It fails later on and adds some garbage to the `test-suite.log`. TBH I'm not sure if we should use this test as is.