### PR TITLE
Add "unicode-form" metadata field to Norwegian tables

### DIFF
--- a/tables/no-no-8dot-fallback-6dot-g0.utb
+++ b/tables/no-no-8dot-fallback-6dot-g0.utb
@@ -33,6 +33,9 @@
 # The 8 dot table is based on the document "Punkttabell for JAWS".
 # The 6 dot table is based on the document "Håndbok i litterær punktskrift".
 #
+# Input is expected to be normalized to NFC (fully composed)
+#-unicode-form:nfc
+#
 #  This file is part of liblouis.
 #
 #  liblouis is free software: you can redistribute it and/or modify it

--- a/tables/no-no-8dot.utb
+++ b/tables/no-no-8dot.utb
@@ -27,6 +27,9 @@
 # http://liblouis.org/braille-specs/norwegian
 # This specific table is based on the document "Punkttabell for JAWS".
 #
+# Input is expected to be normalized to NFC (fully composed)
+#-unicode-form:nfc
+#
 #  Copyright (C) 2015 NLB Norwegian library of talking books and braille, http://www.nlb.no/
 #
 #  This file is part of liblouis.

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -45,6 +45,9 @@
 # http://liblouis.org/braille-specs/norwegian
 # This specific table is based on the document "Håndbok i litterær punktskrift".
 #
+# Input is expected to be normalized to NFC (fully composed)
+#-unicode-form:nfc
+#
 #  This file is part of liblouis.
 #
 #  liblouis is free software: you can redistribute it and/or modify it

--- a/tables/no-no-g1.ctb
+++ b/tables/no-no-g1.ctb
@@ -35,6 +35,9 @@
 # http://liblouis.org/braille-specs/norwegian
 # This specific table is based on the document "Kortskrift i norsk punktskrift - KS04".
 #
+# Input is expected to be normalized to NFC (fully composed)
+#-unicode-form:nfc
+#
 #  This file is part of liblouis.
 #
 #  liblouis is free software: you can redistribute it and/or modify it

--- a/tables/no-no-g2.ctb
+++ b/tables/no-no-g2.ctb
@@ -35,6 +35,9 @@
 # http://liblouis.org/braille-specs/norwegian
 # This specific table is based on the document "Kortskrift i norsk punktskrift - KS04".
 #
+# Input is expected to be normalized to NFC (fully composed)
+#-unicode-form:nfc
+#
 #  This file is part of liblouis.
 #
 #  liblouis is free software: you can redistribute it and/or modify it

--- a/tables/no-no-g3.ctb
+++ b/tables/no-no-g3.ctb
@@ -25,6 +25,8 @@
 # http://liblouis.org/braille-specs/norwegian
 # This specific table is based on the document "Kortskrift i norsk punktskrift - KS04".
 #
+# Input is expected to be normalized to NFC (fully composed)
+#
 #  This file is part of liblouis.
 #
 #  liblouis is free software: you can redistribute it and/or modify it

--- a/tables/no.tbl
+++ b/tables/no.tbl
@@ -8,6 +8,8 @@
 #+dots:6
 #+contraction:full
 #+grade:3
+#
+#-unicode-form:nfc
 
 include no-no-g3.ctb
 include braille-patterns.cti


### PR DESCRIPTION
Input of Norwegian tables is expected to be normalized to NFC (fully composed).

Fixes https://github.com/liblouis/liblouis/issues/923