### PR TITLE
Adding new Belorussian braille tables

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,7 +14,7 @@ liblouis NEWS -- history of user-visible changes.  	-*- org -*-
   - Many bugs with processing space-symbols were fixed.
   - Improvements to processing dialogs and direct speech.
   - Improvements to processing letters of different alphabets.
-- New tables for Belorussian uncontracted and computer braille thanks to
+- New tables for Belarusian uncontracted and computer braille thanks to
   Andrey Yakuboy.
 ** New, renamed or removed tables
 *** New

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,12 @@ liblouis NEWS -- history of user-visible changes.  	-*- org -*-
   - Many bugs with processing space-symbols were fixed.
   - Improvements to processing dialogs and direct speech.
   - Improvements to processing letters of different alphabets.
+- New tables for Belorussian uncontracted and computer braille thanks to
+  Andrey Yakuboy.
+** New, renamed or removed tables
+*** New
+- bel.utb
+- bel-comp.utb
 
 * Noteworthy changes in release 3.16.1 (2020-12-01)
 In the frenzy to ship the 3.16.0 release a little mishap slipped in.

--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -6,6 +6,8 @@
 * ../../tables/as.tbl                            Assamese                                           Assamese braille
 * ../../tables/awa.tbl                           Awadhi                                             Awadhi braille
 * ../../tables/ba.utb                            Bashkir                                            Bashkir braille
+* ../../tables/bel.utb                           Belarusian                                         Belarusian braille
+* ../../tables/bel-comp.utb                      Belarusian, computer                               Belarusian computer braille
 * ../../tables/bg.tbl                            Bulgarian, computer                                Bulgarian computer braille
 * ../../tables/bh.tbl                            Bihari                                             Bihari braille
 * ../../tables/bn.tbl                            Bengali                                            Bengali braille

--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -15,6 +15,8 @@ table_files = \
 	aw-in-g1.utb \
 	ba.utb \
 	be-in-g1.utb \
+	bel.utb \
+	bel-comp.utb \
 	bengali.cti \
 	bg.ctb \
 	bg.tbl \

--- a/tables/bel-comp.utb
+++ b/tables/bel-comp.utb
@@ -1,7 +1,7 @@
-#-index-name: Belorussian, computer
-#-display-name: Belorussian computer braille
+#-index-name: Belarusian, computer
+#-display-name: Belarusian computer braille
 
-#+locale: bel
+#+locale: be
 #+type: computer
 #+dots: 8
 #+direction: both
@@ -24,16 +24,16 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 
-# This is the Belorussian computer braille table.
+# This is the Belarusian computer braille table.
 # It is based on the Russian computer braille.
 
 #-maintainer-name: Andrey Yakuboy
 
-# As the definition of the grave accent sign in the Russian computer Braille conflicts with the Belorussian letter Ў, this definition should be changed.
+# As the definition of the grave accent sign in the Russian computer Braille conflicts with the Belarusian letter Ў, this definition should be changed.
 
 punctuation ` 378		GRAVE ACCENT
 
-# There are two additional letters in the Belorussian alphabet: І and Ў.
+# There are two additional letters in the Belarusian alphabet: І and Ў.
 # These letters are in the Russian computer braille table, but the letter Ў cannot be translated back.
 
 nofor uppercase \x040e 3467		CYRILLIC CAPITAL LETTER SHORT U

--- a/tables/bel-comp.utb
+++ b/tables/bel-comp.utb
@@ -1,0 +1,42 @@
+#-index-name: Belorussian, computer
+#-display-name: Belorussian computer braille
+
+#+locale: bel
+#+type: computer
+#+dots: 8
+#+direction: both
+
+# Copyright (C) 2021 by Andrey Yakuboy <andrewia2002@yandex.ru>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+# This is the Belorussian computer braille table.
+# It is based on the Russian computer braille.
+
+#-maintainer-name: Andrey Yakuboy
+
+# As the definition of the grave accent sign in the Russian computer Braille conflicts with the Belorussian letter Ў, this definition should be changed.
+
+punctuation ` 378		GRAVE ACCENT
+
+# There are two additional letters in the Belorussian alphabet: І and Ў.
+# These letters are in the Russian computer braille table, but the letter Ў cannot be translated back.
+
+nofor uppercase \x040e 3467		CYRILLIC CAPITAL LETTER SHORT U
+nofor lowercase \x045e 346		CYRILLIC SMALL LETTER SHORT U
+
+include ru.ctb

--- a/tables/bel.utb
+++ b/tables/bel.utb
@@ -1,7 +1,7 @@
-#-index-name: Belorussian
-#-display-name: Belorussian braille
+#-index-name: Belarusian
+#-display-name: Belarusian braille
 
-#+locale: bel
+#+locale: be
 #+type: literary
 #+dots: 6
 #+contraction: no
@@ -29,7 +29,7 @@
 
 #-maintainer-name: Andrey Yakuboy
 
-# The Belorussian alphabet has 2 letters that are not in the Russian
+# The Belarusian alphabet has 2 letters that are not in the Russian
 # alphabet, namely І and Ў. Like in ru-litbrl.ctb, the
 # following definitions have dot 9 set to make them distinguishable
 # from the Latin letters.

--- a/tables/bel.utb
+++ b/tables/bel.utb
@@ -1,0 +1,43 @@
+#-index-name: Belorussian
+#-display-name: Belorussian braille
+
+#+locale: bel
+#+type: literary
+#+dots: 6
+#+contraction: no
+#+direction: forward
+
+#  Copyright (C) 2021 Andrey Yakuboy <andrewia2002@yandex.ru>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# Based on the Russian braille.
+
+#-maintainer-name: Andrey Yakuboy
+
+# The Belorussian alphabet has 2 letters that are not in the Russian
+# alphabet, namely І and Ў. Like in ru-litbrl.ctb, the
+# following definitions have dot 9 set to make them distinguishable
+# from the Latin letters.
+uplow \x0406\x0456 134569  CYRILLIC LETTER I    Іі
+uplow \x040e\x045e 3469  CYRILLIC LETTER SHORT U    Ўў
+
+include ru-litbrl.ctb
+
+# Extend classes defined in ru-litbrl.ctb
+attribute uppercyrillic \x0406\x040e
+attribute lowercyrillic \x0456\x045e

--- a/tables/ru.ctb
+++ b/tables/ru.ctb
@@ -7,7 +7,7 @@
 #+direction: both
 
 # Copyright (C) 1995-2008 by The BRLTTY Developers.
-# Copyright (C) 2020 by Andrey Yakuboy
+# Copyright (C) 2020-2021 by Andrey Yakuboy
 #
 #  This file is part of liblouis.
 #
@@ -52,7 +52,7 @@
 # 3. The latin alphabet is implemented to follow the international standard
 #    except it has dot 8 on.
 # 4. Capital latin letters have dots 7 and 8 on.
-# 5. Other alphabets and deacritics is basically implemented to follow the international standard
+# 5. Other alphabets and deacritics are basically implemented to follow the international standard
 #    with rare exceptions. Dots 7 and 8 are also added to these letters
 # 6. Numbers are defined as in the American standard. This means dot-2 for
 #    number '1', and so on.
@@ -155,7 +155,7 @@ lowercase x 13468		LATIN SMALL LETTER X
 lowercase y 134568		LATIN SMALL LETTER Y
 lowercase z 13568		LATIN SMALL LETTER Z
 punctuation { 12678		LEFT CURLY BRACKET
-punctuation | 3457		VERTICAL LINE
+punctuation | 4567		VERTICAL LINE
 punctuation } 34578		RIGHT CURLY BRACKET
 punctuation ~ 12456		TILDE
 punctuation \x00a9 123468		COPYRIGHT SIGN
@@ -238,7 +238,7 @@ uppercase \x0407 14567		CYRILLIC CAPITAL LETTER YI
 uppercase \x0408 134567		CYRILLIC CAPITAL LETTER JE
 uppercase \x0409 1267		CYRILLIC CAPITAL LETTER LJE
 uppercase \x040a 12467		CYRILLIC CAPITAL LETTER NJE
-uppercase \x040e 12367		CYRILLIC CAPITAL LETTER SHORT U
+uppercase \x040e 3467		CYRILLIC CAPITAL LETTER SHORT U
 lowercase \x0452 1456		CYRILLIC SMALL LETTER DJE
 lowercase \x0454 345		CYRILLIC SMALL LETTER UKRAINIAN IE
 lowercase \x0456 13456		CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
@@ -246,7 +246,7 @@ lowercase \x0457 1456		CYRILLIC SMALL LETTER YI
 lowercase \x0458 13456		CYRILLIC SMALL LETTER JE
 lowercase \x0459 126		CYRILLIC SMALL LETTER LJE
 lowercase \x045a 1246		CYRILLIC SMALL LETTER NJE
-lowercase \x045e 1236		CYRILLIC SMALL LETTER SHORT U
+lowercase \x045e 346		CYRILLIC SMALL LETTER SHORT U
 uppercase \x0462 3457		CYRILLIC CAPITAL LETTER YAT
 lowercase \x0463 345		CYRILLIC SMALL LETTER YAT
 uppercase \x0466 17		CYRILLIC CAPITAL LETTER LITTLE YUS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -72,6 +72,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/ar-ar-g1_harness.yaml		  \
 	braille-specs/ar-ar-g2.yaml			  \
 	braille-specs/ba.yaml				  \
+	braille-specs/bel.yaml				  \
 	braille-specs/chr-us-g1_harness.yaml		  \
 	braille-specs/cop-eg.yaml			  \
 	braille-specs/cs_harness.yaml			  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST =					\
 	ar-ar-g1_harness.yaml			\
 	ar-ar-g2.yaml				\
 	ba.yaml					\
+	bel.yaml				\
 	chr-us-g1_harness.yaml			\
 	cop-eg.yaml				\
 	cs_harness.yaml				\

--- a/tests/braille-specs/bel.yaml
+++ b/tests/braille-specs/bel.yaml
@@ -1,0 +1,76 @@
+# Tests for Belorussian literary and computer braille
+#
+# Initial version of this test was adapted from ru.yaml
+#
+# Copyright © 2018 by Sergiy Moskalets <www.trosti.com.ua>
+# Copyright © 2020-2021 by Andrey Yakuboy <andrewia2002@yandex.ru>
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+# ----------------------------------------------------------------------------------------------
+
+# literary braille
+display: unicode-without-blank.dis,ru-unicode.dis
+table:
+  locale: bel
+  type: literary
+  __assert-match: bel.utb
+  contraction: no
+  dots: 6
+tests:
+
+  - - У Іўі худы жвавы чорт у зялёнай камізэльцы пабег пад’есці фаршу з юшкай.
+    - ⠥ ⠽⠬⠽ ⠓⠥⠙⠮ ⠚⠺⠁⠺⠮ ⠟⠕⠗⠞ ⠥ ⠵⠫⠇⠡⠝⠁⠯ ⠅⠁⠍⠽⠵⠪⠇⠾⠉⠮ ⠏⠁⠃⠑⠛ ⠏⠁⠙⠄⠑⠎⠉⠽ ⠋⠁⠗⠱⠥ ⠵ ⠳⠱⠅⠁⠯⠲
+  - - 123,5+46=169,5
+    - ⠼⠁⠃⠉⠂⠑ ⠖⠼⠙⠋ ⠶⠼⠁⠋⠊⠂⠑
+  - - 1, 3, 5, 7, 11, 13, 17, 19, 23
+    - ⠼⠁⠠⠂⠼⠉⠠⠂⠼⠑⠠⠂⠼⠛⠠⠂⠼⠁⠁⠠⠂⠼⠁⠉⠠⠂⠼⠁⠛⠠⠂⠼⠁⠊⠠⠂⠼⠃⠉
+
+# with indication of capitals
+  - - У Іўі худы жвавы чорт у зялёнай камізэльцы пабег пад’есці фаршу з юшкай.
+    - ⠘⠥ ⠘⠽⠬⠽ ⠓⠥⠙⠮ ⠚⠺⠁⠺⠮ ⠟⠕⠗⠞ ⠥ ⠵⠫⠇⠡⠝⠁⠯ ⠅⠁⠍⠽⠵⠪⠇⠾⠉⠮ ⠏⠁⠃⠑⠛ ⠏⠁⠙⠄⠑⠎⠉⠽ ⠋⠁⠗⠱⠥ ⠵ ⠳⠱⠅⠁⠯⠲
+    - xfail: option to indicate capitals does not exist yet
+
+# Spaces
+  - ['\x0009', '\x0020']
+  - ['\x0020', '\x0020']
+  - ['\x00a0', '\x0020']
+  - ['\x000a', '\x0020']
+  - ['\x000c', '\x0020']
+  - ['\x000d', '\x0020']
+
+# computer braille
+display: |
+  include unicode.dis
+  display 9 9
+  display a a
+table:
+  locale: bel
+  type: computer
+  __assert-match: bel-comp.utb
+flags: {testmode: bothDirections}
+tests:
+  - ['\x0009', '9']
+  - ['\x000a', '⣀']
+  - ['\x0020', '⠀']
+  - ['\x00a0', 'a']
+  - ['У Іўі худы жвавы чорт у зялёнай камізэльцы пабег пад\x0027есці фаршу з юшкай.', '⡥⠀⡽⠬⠽⠀⠓⠥⠙⠮⠀⠚⠺⠁⠺⠮⠀⠟⠕⠗⠞⠀⠥⠀⠵⠫⠇⠡⠝⠁⠯⠀⠅⠁⠍⠽⠵⠪⠇⠾⠉⠮⠀⠏⠁⠃⠑⠛⠀⠏⠁⠙⡈⠑⠎⠉⠽⠀⠋⠁⠗⠱⠥⠀⠵⠀⠳⠱⠅⠁⠯⠄']
+  - ['Hello, World!', '⣓⢑⢇⢇⢕⠠⠀⣺⢕⢗⢇⢙⠐']
+  - ['1234567890', '⠂⠆⠒⠲⠢⠖⠶⠦⠔⠴']
+  - ['2 + 7 = 9', '⠆⠀⡖⠀⠶⠀⠿⠀⠔']
+  - ['3 < 5, а 5 > 3.', '⠒⠀⠰⠀⠢⠠⠀⠁⠀⠢⠀⠘⠀⠒⠄']
+  - ['Для апрацоўкі гэтай табліцы выкарыстоўваецца кампанент "Liblouis".', '⡙⠇⠫⠀⠁⠏⠗⠁⠉⠕⠬⠅⠽⠀⠛⠪⠞⠁⠯⠀⠞⠁⠃⠇⠽⠉⠮⠀⠺⠮⠅⠁⠗⠮⠎⠞⠕⠬⠺⠁⠑⠉⠉⠁⠀⠅⠁⠍⠏⠁⠝⠑⠝⠞⠀⠈⣇⢊⢃⢇⢕⢥⢊⢎⠈⠄']
+  - ['Як справы?', '⡫⠅⠀⠎⠏⠗⠁⠺⠮⠹']
+  - ['(~)', '⠣⠻⠜']
+  - ['example@domain.com', '⢑⢭⢁⢍⢏⢇⢑⡜⢙⢕⢍⢁⢊⢝⠄⢉⢕⢍']
+  - ['`', '⣄']
+flags: {testmode: forward}
+tests:
+  - ['\x000c', '⠀']
+  - ['\x000d', '⠀']
+  - ['\x2003', '⠀']
+  - ['\x000b', '9']
+  - ['Γεια σου κόσμο!', '⣛⢑⢊⢁⠀⢎⢕⢥⠀⢅⢪⢎⢍⢕⠐']
+  - ['שלום עולם!', '⢩⢇⢺⢍⠀⢫⢺⢇⢍⠐']

--- a/tests/braille-specs/bel.yaml
+++ b/tests/braille-specs/bel.yaml
@@ -14,7 +14,7 @@
 # literary braille
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: bel
+  locale: be
   type: literary
   __assert-match: bel.utb
   contraction: no
@@ -47,7 +47,7 @@ display: |
   display 9 9
   display a a
 table:
-  locale: bel
+  locale: be
   type: computer
   __assert-match: bel-comp.utb
 flags: {testmode: bothDirections}


### PR DESCRIPTION
Hello!
  
  These are two Belorussian braille tables - for literary and computer braille. They/re based on the Russian braille code.
  
  I'll add the NEWS-file with https://github.com/pull/1041 later, this can be merged without news.
  
  Andrey