### PR TITLE
Various fixes to lou_trace

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3619,9 +3619,6 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 				*cursorPosition, &repwordLength, dontContract, compbrlStart, compbrlEnd,
 				beforeAttributes, &curCharDef, &groupingRule, &groupingOp);
 
-		if (transOpcode != CTO_Context)
-			if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
-				appliedRules[appliedRulesCount++] = transRule;
 		switch (transOpcode) /* Rules that pre-empt context and swap */
 		{
 		case CTO_CompBrl:
@@ -3710,8 +3707,11 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 			default:
 				break;
 			}
-		} else
+		} else {
+			if (appliedRules != NULL && appliedRulesCount < maxAppliedRules)
+				appliedRules[appliedRulesCount++] = transRule;
 			posIncremented = 1;
+		}
 
 		/* Processing before replacement */
 

--- a/tools/lou_trace.c
+++ b/tools/lou_trace.c
@@ -112,7 +112,7 @@ print_number(widechar c) {
 }
 
 static char *
-print_attributes(unsigned int a) {
+print_attributes(unsigned long long a) {
 	static char attr[BUFSIZE];
 	strcpy(attr, _lou_showAttributes(a));
 	return attr;
@@ -180,10 +180,15 @@ print_script(const widechar *buffer, int length) {
 			i += 2;
 			break;
 		case pass_attributes:
-			append_char(script, &j, buffer[i]);
-			append_string(
-					script, &j, print_attributes(buffer[i + 1] << 16 | buffer[i + 2]));
-			i += 3;
+			append_char(script, &j, buffer[i++]);
+			unsigned long long a = buffer[i++];
+			a <<= 16;
+			a |= buffer[i++];
+			a <<= 16;
+			a |= buffer[i++];
+			a <<= 16;
+			a |= buffer[i++];
+			append_string(script, &j, print_attributes(a));
 			if (buffer[i] == 1 && buffer[i + 1] == 1) {
 			} else if (buffer[i] == 1 && buffer[i + 1] == 0xffff)
 				append_char(script, &j, pass_until);


### PR DESCRIPTION
- some rules were printed even though they were not applied
- use %xxx syntax to render single custom attribute in multipass expression
- support multipass rules with reference to swap rule
- fix rendering of multipass rules with attributes
