### PR TITLE
Apostrophe update in En-US computer braille

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,8 @@ issues]].
   - Added more accented letters.
 - New tables for Kazakh uncontracted, Tatar uncontracted and Yakut uncontracted braille thanks to
   Andrey Yakuboy.
+- Added more apostrophe symbols to English Computer Braille Code table
+  thanks to BAUM Engineering.
 ** Other changes
 ** Deprecation notice
 - None

--- a/tables/en-us-comp6.ctb
+++ b/tables/en-us-comp6.ctb
@@ -16,9 +16,11 @@
 # http://liblouis.org/braille-specs/english/#computer-braille-code-cbc
 #
 #-copyright: 2019, Timothy Wynn
+#-copyright: 2021, BAUM Engineering
 #-license: LGPLv2.1
 #
 #  Copyright (C) 2019 Timothy Wynn <tmthywynn8@gmail.com>
+#  Copyright (C) 2021, BAUM Engineering <liblouis@baum.ro>
 #
 #  This file is part of liblouis.
 #
@@ -78,6 +80,8 @@ sign $ 1246 dollar sign
 sign % 146 percent sign
 sign & 12346 ampersand
 punctuation ' 3 apostrophe, single quote
+punctuation \x2019 3 # right single quotation mark
+punctuation \x00b4 3 # acute accent
 punctuation ( 12356 left parenthesis
 punctuation ) 23456 right parenthesis
 sign * 16 asterisk, multiplication sign

--- a/tests/braille-specs/en-us-comp6.yaml
+++ b/tests/braille-specs/en-us-comp6.yaml
@@ -64,3 +64,8 @@ tests:
   - ['\x000a', '⠀']
   - ['\x000d', '⠀']
   - ['\x00a0', '⠀']
+
+# Apostrophes
+flags: {testmode: forward}
+tests:
+  - ['\x2019\x00b4\x0027', '⠄⠄⠄']

--- a/tests/braille-specs/en-us-comp6.yaml
+++ b/tests/braille-specs/en-us-comp6.yaml
@@ -1,12 +1,21 @@
+# U.S. English Computer Braille Code
+# <http://liblouis.org/braille-specs/english/#computer-braille-code-cbc>
+#
+# Copyright © 2019 by Timothy Wynn
+# Copyright © 2021 by BAUM Engineering
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+# ----------------------------------------------------------------------------------------------
+
 display: unicode.dis
 table:
   locale: en-US
   type: computer
   dots: 6
   __assert-match: en-us-comp6.ctb
-
-# Computer Braille Code reference:
-# http://liblouis.org/braille-specs/english/#computer-braille-code-cbc
 
 flags: {testmode: bothDirections}
 tests:


### PR DESCRIPTION
Hello again,

We've got a report that apostrophes are not translated correctly. As I saw the table contains just one type of apostrophe, but the client wanted to use "right single quotation mark" and "acute accent" for the same purpose.

I've added two more definitions for those.