### PR TITLE
Refactoring of compileTranslationTable.c

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -2036,10 +2036,6 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, i
 			passLinepos++;
 			passInstructions[passIC++] = pass_string;
 			passGetString(&passLine, &passLinepos, &passHoldString, passNested);
-			if (passHoldString.length == 0) {
-				compileError(nested, "empty string in action part");
-				return 0;
-			}
 			goto actionDoCharsDots;
 		case pass_dots:
 			if (!verifyStringOrDots(nested, opcode, 0, 1, nofor)) {

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1739,7 +1739,10 @@ passGetNumber(CharsString *passLine, int *passLinepos, widechar *passHoldNumber)
 static int
 passGetVariableNumber(FileInfo *nested, CharsString *passLine, int *passLinepos,
 		widechar *passHoldNumber) {
-	if (!passGetNumber(passLine, passLinepos, passHoldNumber)) return 0;
+	if (!passGetNumber(passLine, passLinepos, passHoldNumber)) {
+		compileError(nested, "missing variable number");
+		return 0;
+	}
 	if ((*passHoldNumber >= 0) && (*passHoldNumber < NUMVAR)) return 1;
 	compileError(nested, "variable number out of range");
 	return 0;
@@ -1857,6 +1860,10 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, i
 			passLinepos++;
 			passInstructions[passIC++] = pass_string;
 			passGetString(&passLine, &passLinepos, &passHoldString, passNested);
+			if (passHoldString.length == 0) {
+				compileError(nested, "empty string in test part");
+				return 0;
+			}
 			goto testDoCharsDots;
 		case pass_dots:
 			if (!verifyStringOrDots(nested, opcode, 0, 0, nofor)) {
@@ -1865,8 +1872,11 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, i
 			passLinepos++;
 			passInstructions[passIC++] = pass_dots;
 			passGetDots(&passLine, &passLinepos, &passHoldString, passNested);
+			if (passHoldString.length == 0) {
+				compileError(nested, "expected dot pattern after @ operand in test part");
+				return 0;
+			}
 		testDoCharsDots:
-			if (passHoldString.length == 0) return 0;
 			if (passIC >= MAXSTRING) {
 				compileError(passNested,
 						"@ operand in test part of multipass operand too long");
@@ -2026,6 +2036,10 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, i
 			passLinepos++;
 			passInstructions[passIC++] = pass_string;
 			passGetString(&passLine, &passLinepos, &passHoldString, passNested);
+			if (passHoldString.length == 0) {
+				compileError(nested, "empty string in action part");
+				return 0;
+			}
 			goto actionDoCharsDots;
 		case pass_dots:
 			if (!verifyStringOrDots(nested, opcode, 0, 1, nofor)) {
@@ -2034,8 +2048,12 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, i
 			passLinepos++;
 			passGetDots(&passLine, &passLinepos, &passHoldString, passNested);
 			passInstructions[passIC++] = pass_dots;
+			if (passHoldString.length == 0) {
+				compileError(
+						nested, "expected dot pattern after @ operand in action part");
+				return 0;
+			}
 		actionDoCharsDots:
-			if (passHoldString.length == 0) return 0;
 			if (passIC >= MAXSTRING) {
 				compileError(passNested,
 						"@ operand in action part of multipass operand too long");
@@ -3299,7 +3317,8 @@ doOpcode:
 			for (int k = 0; k < ruleChars.length; k++) {
 				TranslationTableCharacter *c = getChar(ruleChars.chars[k], *table);
 				if (!c) {
-					compileError(nested, "Numeric mode character undefined");
+					compileError(nested, "Numeric mode character undefined: %s",
+							_lou_showString(&ruleChars.chars[k], 1, 0));
 					return 0;
 				}
 				c->attributes |= CTC_NumericMode;
@@ -4126,13 +4145,17 @@ compileFile(const char *fileName, TranslationTableHeader **table,
 	nested.status = 0;
 	nested.lineNumber = 0;
 	if ((nested.in = fopen(nested.fileName, "rb"))) {
-		while (_lou_getALine(&nested)) compileRule(&nested, table, displayTable);
+		while (_lou_getALine(&nested))
+			if (!compileRule(&nested, table, displayTable)) {
+				if (!errorCount) compileError(&nested, "Rule could not be compiled");
+				break;
+			}
 		fclose(nested.in);
-		return 1;
-	} else
+	} else {
 		_lou_logMessage(LOU_LOG_ERROR, "Cannot open table '%s'", nested.fileName);
-	errorCount++;
-	return 0;
+		errorCount++;
+	}
+	return !errorCount;
 }
 
 /**
@@ -4178,6 +4201,9 @@ includeFile(FileInfo *nested, CharsString *includedFile, TranslationTableHeader 
 	}
 	rv = compileFile(*tableFiles, table, displayTable);
 	free_tablefiles(tableFiles);
+	if (!rv)
+		_lou_logMessage(LOU_LOG_ERROR, "%s:%d: Error in included file", nested->fileName,
+				nested->lineNumber);
 	return rv;
 }
 

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -275,7 +275,7 @@ static const char *opcodeNames[CTO_None] = {
 static short opcodeLengths[CTO_None] = { 0 };
 
 static void
-compileError(FileInfo *nested, const char *format, ...);
+compileError(const FileInfo *nested, const char *format, ...);
 
 static void
 free_tablefiles(char **tables);
@@ -360,12 +360,12 @@ _lou_getALine(FileInfo *nested) {
 }
 
 static inline int
-atEndOfLine(FileInfo *nested) {
+atEndOfLine(const FileInfo *nested) {
 	return nested->linepos >= nested->linelen;
 }
 
 static inline int
-atTokenDelimiter(FileInfo *nested) {
+atTokenDelimiter(const FileInfo *nested) {
 	return nested->line[nested->linepos] <= 32;
 }
 
@@ -394,7 +394,7 @@ getToken(FileInfo *nested, CharsString *result, const char *description) {
 }
 
 static void
-compileError(FileInfo *nested, const char *format, ...) {
+compileError(const FileInfo *nested, const char *format, ...) {
 #ifndef __SYMBIAN32__
 	char buffer[MAXSTRING];
 	va_list arguments;
@@ -411,7 +411,7 @@ compileError(FileInfo *nested, const char *format, ...) {
 }
 
 static void
-compileWarning(FileInfo *nested, const char *format, ...) {
+compileWarning(const FileInfo *nested, const char *format, ...) {
 #ifndef __SYMBIAN32__
 	char buffer[MAXSTRING];
 	va_list arguments;
@@ -428,7 +428,7 @@ compileWarning(FileInfo *nested, const char *format, ...) {
 }
 
 static int
-allocateSpaceInTranslationTable(FileInfo *nested, TranslationTableOffset *offset,
+allocateSpaceInTranslationTable(const FileInfo *nested, TranslationTableOffset *offset,
 		int count, TranslationTableHeader **table) {
 	/* allocate memory for table and expand previously allocated memory if necessary */
 	int spaceNeeded = ((count + OFFSETSIZE - 1) / OFFSETSIZE) * OFFSETSIZE;
@@ -461,8 +461,8 @@ allocateSpaceInTranslationTable(FileInfo *nested, TranslationTableOffset *offset
 }
 
 static int
-allocateSpaceInDisplayTable(FileInfo *nested, TranslationTableOffset *offset, int count,
-		DisplayTableHeader **table) {
+allocateSpaceInDisplayTable(const FileInfo *nested, TranslationTableOffset *offset,
+		int count, DisplayTableHeader **table) {
 	/* allocate memory for table and expand previously allocated memory if necessary */
 	int spaceNeeded = ((count + OFFSETSIZE - 1) / OFFSETSIZE) * OFFSETSIZE;
 	TranslationTableOffset newSize = (*table)->bytesUsed + spaceNeeded;
@@ -493,7 +493,7 @@ allocateSpaceInDisplayTable(FileInfo *nested, TranslationTableOffset *offset, in
 }
 
 static int
-allocateTranslationTable(FileInfo *nested, TranslationTableHeader **table) {
+allocateTranslationTable(const FileInfo *nested, TranslationTableHeader **table) {
 	/* Allocate memory for the table and a guess on the number of rules */
 	const TranslationTableOffset startSize = 2 * sizeof(**table);
 	if (*table) return 1;
@@ -512,7 +512,7 @@ allocateTranslationTable(FileInfo *nested, TranslationTableHeader **table) {
 }
 
 static int
-allocateDisplayTable(FileInfo *nested, DisplayTableHeader **table) {
+allocateDisplayTable(const FileInfo *nested, DisplayTableHeader **table) {
 	/* Allocate memory for the table and a guess on the number of rules */
 	const TranslationTableOffset startSize = 2 * sizeof(**table);
 	if (*table) return 1;
@@ -561,7 +561,7 @@ getDots(widechar d, TranslationTableHeader *table) {
 }
 
 static TranslationTableCharacter *
-putChar(FileInfo *nested, widechar c, TranslationTableHeader **table) {
+putChar(const FileInfo *nested, widechar c, TranslationTableHeader **table) {
 	/* See if a character is in the appropriate table. If not, insert it. In either case,
 	 * return a pointer to it. */
 	TranslationTableOffset bucket;
@@ -589,7 +589,7 @@ putChar(FileInfo *nested, widechar c, TranslationTableHeader **table) {
 }
 
 static TranslationTableCharacter *
-putDots(FileInfo *nested, widechar d, TranslationTableHeader **table) {
+putDots(const FileInfo *nested, widechar d, TranslationTableHeader **table) {
 	/* See if a dot pattern is in the appropriate table. If not, insert it. In either
 	 * case, return a pointer to it. */
 	TranslationTableOffset bucket;
@@ -659,7 +659,8 @@ _lou_getCharForDots(widechar d, const DisplayTableHeader *table) {
 }
 
 static int
-putCharDotsMapping(FileInfo *nested, widechar c, widechar d, DisplayTableHeader **table) {
+putCharDotsMapping(
+		const FileInfo *nested, widechar c, widechar d, DisplayTableHeader **table) {
 	if (!getDotsForChar(c, *table)) {
 		TranslationTableOffset bucket;
 		CharDotsMapping *cdPtr;
@@ -715,7 +716,7 @@ getPartName(int actionPart) {
 }
 
 static int
-passFindCharacters(FileInfo *nested, widechar *instructions, int end,
+passFindCharacters(const FileInfo *nested, widechar *instructions, int end,
 		widechar **characters, int *length) {
 	int IC = 0;
 	int lookback = 0;
@@ -801,7 +802,7 @@ passFindCharacters(FileInfo *nested, widechar *instructions, int end,
 /* The following functions are called by addRule to handle various cases. */
 
 static void
-addForwardRuleWithSingleChar(FileInfo *nested, TranslationTableOffset newRuleOffset,
+addForwardRuleWithSingleChar(const FileInfo *nested, TranslationTableOffset newRuleOffset,
 		TranslationTableRule *newRule, TranslationTableHeader **table) {
 	/* direction = 0, newRule->charslen = 1 */
 	TranslationTableRule *currentRule;
@@ -861,7 +862,7 @@ addForwardRuleWithMultipleChars(TranslationTableOffset newRuleOffset,
 }
 
 static void
-addBackwardRuleWithSingleCell(FileInfo *nested, widechar cell,
+addBackwardRuleWithSingleCell(const FileInfo *nested, widechar cell,
 		TranslationTableOffset newRuleOffset, TranslationTableRule *newRule,
 		TranslationTableHeader **table) {
 	/* direction = 1, newRule->dotslen = 1 */
@@ -981,7 +982,7 @@ addBackwardPassRule(TranslationTableOffset newRuleOffset, TranslationTableRule *
 }
 
 static int
-addRule(FileInfo *nested, TranslationTableOpcode opcode, CharsString *ruleChars,
+addRule(const FileInfo *nested, TranslationTableOpcode opcode, CharsString *ruleChars,
 		CharsString *ruleDots, TranslationTableCharacterAttributes after,
 		TranslationTableCharacterAttributes before, TranslationTableOffset *newRuleOffset,
 		TranslationTableRule **newRule, int noback, int nofor,
@@ -1085,7 +1086,7 @@ getNextAttribute(TranslationTableHeader *table) {
 }
 
 static CharacterClass *
-addCharacterClass(FileInfo *nested, const widechar *name, int length,
+addCharacterClass(const FileInfo *nested, const widechar *name, int length,
 		TranslationTableHeader *table) {
 	/* Define a character class, Whether predefined or user-defined */
 	CharacterClass **classes = &table->characterClasses;
@@ -1139,7 +1140,7 @@ allocateCharacterClasses(TranslationTableHeader *table) {
 }
 
 static TranslationTableOpcode
-getOpcode(FileInfo *nested, const CharsString *token) {
+getOpcode(const FileInfo *nested, const CharsString *token) {
 	static TranslationTableOpcode lastOpcode = 0;
 	TranslationTableOpcode opcode = lastOpcode;
 
@@ -1188,7 +1189,7 @@ _lou_findOpcodeName(TranslationTableOpcode opcode) {
 }
 
 static widechar
-hexValue(FileInfo *nested, const widechar *digits, int length) {
+hexValue(const FileInfo *nested, const widechar *digits, int length) {
 	int k;
 	unsigned int binaryValue = 0;
 	for (k = 0; k < length; k++) {
@@ -1213,7 +1214,7 @@ static const unsigned int first0Bit[MAXBYTES] = { 0x80, 0xC0, 0xE0, 0xF0, 0xF8, 
 	0XFE };
 
 static int
-parseChars(FileInfo *nested, CharsString *result, CharsString *token) {
+parseChars(const FileInfo *nested, CharsString *result, CharsString *token) {
 	int in = 0;
 	int out = 0;
 	int lastOutSize = 0;
@@ -1354,7 +1355,7 @@ _lou_extParseChars(const char *inString, widechar *outString) {
 }
 
 static int
-parseDots(FileInfo *nested, CharsString *cells, const CharsString *token) {
+parseDots(const FileInfo *nested, CharsString *cells, const CharsString *token) {
 	/* get dot patterns */
 	widechar cell = 0; /* assembly place for dots */
 	int cellCount = 0;
@@ -1508,8 +1509,8 @@ getRuleDotsPattern(FileInfo *nested, CharsString *ruleDots) {
 }
 
 static int
-includeFile(FileInfo *nested, CharsString *includedFile, TranslationTableHeader **table,
-		DisplayTableHeader **displayTable);
+includeFile(const FileInfo *nested, CharsString *includedFile,
+		TranslationTableHeader **table, DisplayTableHeader **displayTable);
 
 static TranslationTableOffset
 findRuleName(const CharsString *name, const TranslationTableHeader *table) {
@@ -1524,8 +1525,8 @@ findRuleName(const CharsString *name, const TranslationTableHeader *table) {
 }
 
 static int
-addRuleName(FileInfo *nested, CharsString *name, TranslationTableOffset newRuleOffset,
-		TranslationTableHeader *table) {
+addRuleName(const FileInfo *nested, CharsString *name,
+		TranslationTableOffset newRuleOffset, TranslationTableHeader *table) {
 	int k;
 	RuleName *nameRule;
 	if (!(nameRule = malloc(sizeof(*nameRule) + CHARSIZE * (name->length - 1)))) {
@@ -1562,7 +1563,7 @@ deallocateRuleNames(TranslationTableHeader *table) {
 }
 
 static int
-compileSwapDots(FileInfo *nested, CharsString *source, CharsString *dest) {
+compileSwapDots(const FileInfo *nested, CharsString *source, CharsString *dest) {
 	int k = 0;
 	int kk = 0;
 	CharsString dotsSource;
@@ -1626,7 +1627,7 @@ getNumber(widechar *source, widechar *dest) {
 
 static int
 passGetAttributes(CharsString *passLine, int *passLinepos,
-		TranslationTableCharacterAttributes *passAttributes, FileInfo *passNested) {
+		TranslationTableCharacterAttributes *passAttributes, const FileInfo *passNested) {
 	int more = 1;
 	*passAttributes = 0;
 	while (more) {
@@ -1689,7 +1690,7 @@ passGetAttributes(CharsString *passLine, int *passLinepos,
 
 static int
 passGetDots(CharsString *passLine, int *passLinepos, CharsString *passHoldString,
-		FileInfo *passNested) {
+		const FileInfo *passNested) {
 	CharsString collectDots;
 	collectDots.length = 0;
 	while (*passLinepos < passLine->length &&
@@ -1705,7 +1706,7 @@ passGetDots(CharsString *passLine, int *passLinepos, CharsString *passHoldString
 
 static int
 passGetString(CharsString *passLine, int *passLinepos, CharsString *passHoldString,
-		FileInfo *passNested) {
+		const FileInfo *passNested) {
 	passHoldString->length = 0;
 	while (1) {
 		if ((*passLinepos >= passLine->length) || !passLine->chars[*passLinepos]) {
@@ -1737,7 +1738,7 @@ passGetNumber(CharsString *passLine, int *passLinepos, widechar *passHoldNumber)
 }
 
 static int
-passGetVariableNumber(FileInfo *nested, CharsString *passLine, int *passLinepos,
+passGetVariableNumber(const FileInfo *nested, CharsString *passLine, int *passLinepos,
 		widechar *passHoldNumber) {
 	if (!passGetNumber(passLine, passLinepos, passHoldNumber)) {
 		compileError(nested, "missing variable number");
@@ -1772,7 +1773,7 @@ wantsString(TranslationTableOpcode opcode, int actionPart, int nofor) {
 }
 
 static int
-verifyStringOrDots(FileInfo *nested, TranslationTableOpcode opcode, int isString,
+verifyStringOrDots(const FileInfo *nested, TranslationTableOpcode opcode, int isString,
 		int actionPart, int nofor) {
 	if (!wantsString(opcode, actionPart, nofor) == !isString) return 1;
 
@@ -1784,8 +1785,8 @@ verifyStringOrDots(FileInfo *nested, TranslationTableOpcode opcode, int isString
 }
 
 static int
-compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, int nofor,
-		TranslationTableHeader **table) {
+compilePassOpcode(const FileInfo *nested, TranslationTableOpcode opcode, int noback,
+		int nofor, TranslationTableHeader **table) {
 	static CharsString passRuleChars;
 	static CharsString passRuleDots;
 	/* Compile the operands of a pass opcode */
@@ -4170,8 +4171,8 @@ free_tablefiles(char **tables) {
  *
  */
 static int
-includeFile(FileInfo *nested, CharsString *includedFile, TranslationTableHeader **table,
-		DisplayTableHeader **displayTable) {
+includeFile(const FileInfo *nested, CharsString *includedFile,
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	int k;
 	char includeThis[MAXSTRING];
 	char **tableFiles;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1590,9 +1590,8 @@ compileSwapDots(FileInfo *nested, CharsString *source, CharsString *dest) {
 }
 
 static int
-compileSwap(FileInfo *nested, TranslationTableOpcode opcode,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule, int noback,
-		int nofor, TranslationTableHeader **table) {
+compileSwap(FileInfo *nested, TranslationTableOpcode opcode, int noback, int nofor,
+		TranslationTableHeader **table) {
 	CharsString ruleChars;
 	CharsString ruleDots;
 	CharsString name;
@@ -1612,11 +1611,10 @@ compileSwap(FileInfo *nested, TranslationTableOpcode opcode,
 	} else {
 		if (!compileSwapDots(nested, &replacements, &ruleDots)) return 0;
 	}
-	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, &ruleOffset, newRule,
-				noback, nofor, table))
+	if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, &ruleOffset, NULL, noback,
+				nofor, table))
 		return 0;
 	if (!addRuleName(nested, &name, ruleOffset, *table)) return 0;
-	if (newRuleOffset) *newRuleOffset = ruleOffset;
 	return 1;
 }
 
@@ -1788,9 +1786,8 @@ verifyStringOrDots(FileInfo *nested, TranslationTableOpcode opcode, int isString
 }
 
 static int
-compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule, int noback,
-		int nofor, TranslationTableHeader **table) {
+compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode, int noback, int nofor,
+		TranslationTableHeader **table) {
 	static CharsString passRuleChars;
 	static CharsString passRuleDots;
 	/* Compile the operands of a pass opcode */
@@ -2147,8 +2144,8 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode,
 		}
 	}
 
-	if (!addRule(passNested, opcode, &passRuleChars, &passRuleDots, 0, 0, newRuleOffset,
-				newRule, noback, nofor, table))
+	if (!addRule(passNested, opcode, &passRuleChars, &passRuleDots, 0, 0, NULL, NULL,
+				noback, nofor, table))
 		return 0;
 	return 1;
 }
@@ -2157,15 +2154,14 @@ compilePassOpcode(FileInfo *nested, TranslationTableOpcode opcode,
 
 static int
 compileBrailleIndicator(FileInfo *nested, const char *ermsg,
-		TranslationTableOpcode opcode, TranslationTableOffset *newRuleOffset,
-		TranslationTableRule **newRule, int noback, int nofor,
-		TranslationTableHeader **table) {
+		TranslationTableOpcode opcode, TranslationTableOffset *newRuleOffset, int noback,
+		int nofor, TranslationTableHeader **table) {
 	CharsString token;
 	CharsString cells;
 	if (getToken(nested, &token, ermsg))
 		if (parseDots(nested, &cells, &token))
-			if (!addRule(nested, opcode, NULL, &cells, 0, 0, newRuleOffset, newRule,
-						noback, nofor, table))
+			if (!addRule(nested, opcode, NULL, &cells, 0, 0, newRuleOffset, NULL, noback,
+						nofor, table))
 				return 0;
 	return 1;
 }
@@ -2184,9 +2180,8 @@ compileNumber(FileInfo *nested) {
 }
 
 static int
-compileGrouping(FileInfo *nested, TranslationTableOffset *newRuleOffset,
-		TranslationTableRule **newRule, int noback, int nofor,
-		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
+compileGrouping(FileInfo *nested, int noback, int nofor, TranslationTableHeader **table,
+		DisplayTableHeader **displayTable) {
 	int k;
 	CharsString name;
 	CharsString groupChars;
@@ -2229,10 +2224,9 @@ compileGrouping(FileInfo *nested, TranslationTableOffset *newRuleOffset,
 		charsDotsPtr->uppercase = charsDotsPtr->realchar;
 		charsDotsPtr->lowercase = charsDotsPtr->realchar;
 		if (!addRule(nested, CTO_Grouping, &groupChars, &dotsParsed, 0, 0, &ruleOffset,
-					newRule, noback, nofor, table))
+					NULL, noback, nofor, table))
 			return 0;
 		if (!addRuleName(nested, &name, ruleOffset, *table)) return 0;
-		if (newRuleOffset) *newRuleOffset = ruleOffset;
 	}
 	if (displayTable) {
 		putCharDotsMapping(
@@ -2246,22 +2240,21 @@ compileGrouping(FileInfo *nested, TranslationTableOffset *newRuleOffset,
 		endChar = groupChars.chars[1];
 		endDots = dotsParsed.chars[1];
 		groupChars.length = dotsParsed.length = 1;
-		if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
-					newRule, noback, nofor, table))
+		if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, NULL, NULL, noback,
+					nofor, table))
 			return 0;
 		groupChars.chars[0] = endChar;
 		dotsParsed.chars[0] = endDots;
-		if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, newRuleOffset,
-					newRule, noback, nofor, table))
+		if (!addRule(nested, CTO_Math, &groupChars, &dotsParsed, 0, 0, NULL, NULL, noback,
+					nofor, table))
 			return 0;
 	}
 	return 1;
 }
 
 static int
-compileUplow(FileInfo *nested, TranslationTableOffset *newRuleOffset,
-		TranslationTableRule **newRule, int noback, int nofor,
-		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
+compileUplow(FileInfo *nested, int noback, int nofor, TranslationTableHeader **table,
+		DisplayTableHeader **displayTable) {
 	int k;
 	TranslationTableCharacter *upperChar;
 	TranslationTableCharacter *lowerChar;
@@ -2343,12 +2336,12 @@ compileUplow(FileInfo *nested, TranslationTableOffset *newRuleOffset,
 		ruleChars.length = 1;
 		ruleChars.chars[2] = ruleChars.chars[0];
 		ruleChars.chars[0] = ruleChars.chars[1];
-		if (!addRule(nested, CTO_LowerCase, &ruleChars, &lowerDots, 0, 0, newRuleOffset,
-					newRule, noback, nofor, table))
+		if (!addRule(nested, CTO_LowerCase, &ruleChars, &lowerDots, 0, 0, NULL, NULL,
+					noback, nofor, table))
 			return 0;
 		ruleChars.chars[0] = ruleChars.chars[2];
-		if (!addRule(nested, CTO_UpperCase, &ruleChars, &upperDots, 0, 0, newRuleOffset,
-					newRule, noback, nofor, table))
+		if (!addRule(nested, CTO_UpperCase, &ruleChars, &upperDots, 0, 0, NULL, NULL,
+					noback, nofor, table))
 			return 0;
 	}
 	return 1;
@@ -2588,9 +2581,8 @@ compileHyphenation(
 
 static int
 compileCharDef(FileInfo *nested, TranslationTableOpcode opcode,
-		TranslationTableCharacterAttributes attributes,
-		TranslationTableOffset *newRuleOffset, TranslationTableRule **newRule, int noback,
-		int nofor, TranslationTableHeader **table, DisplayTableHeader **displayTable) {
+		TranslationTableCharacterAttributes attributes, int noback, int nofor,
+		TranslationTableHeader **table, DisplayTableHeader **displayTable) {
 	CharsString ruleChars;
 	CharsString ruleDots;
 	if (!getRuleCharsText(nested, &ruleChars)) return 0;
@@ -2623,8 +2615,8 @@ compileCharDef(FileInfo *nested, TranslationTableOpcode opcode,
 	if (displayTable && ruleDots.length == 1)
 		putCharDotsMapping(nested, ruleChars.chars[0], ruleDots.chars[0], displayTable);
 	if (table)
-		if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, newRuleOffset, newRule,
-					noback, nofor, table))
+		if (!addRule(nested, opcode, &ruleChars, &ruleDots, 0, 0, NULL, NULL, noback,
+					nofor, table))
 			return 0;
 	return 1;
 }
@@ -2643,8 +2635,7 @@ compileBeforeAfter(FileInfo *nested) {
 }
 
 static int
-compileRule(FileInfo *nested, TranslationTableOffset *newRuleOffset,
-		TranslationTableRule **newRule, TranslationTableHeader **table,
+compileRule(FileInfo *nested, TranslationTableHeader **table,
 		DisplayTableHeader **displayTable) {
 	int ok = 1;
 	CharsString token;
@@ -2702,48 +2693,38 @@ doOpcode:
 		nofor = 1;
 		goto doOpcode;
 	case CTO_Space:
-		compileCharDef(nested, opcode, CTC_Space, newRuleOffset, newRule, noback, nofor,
-				table, displayTable);
+		compileCharDef(nested, opcode, CTC_Space, noback, nofor, table, displayTable);
 		break;
 	case CTO_Digit:
-		compileCharDef(nested, opcode, CTC_Digit, newRuleOffset, newRule, noback, nofor,
-				table, displayTable);
+		compileCharDef(nested, opcode, CTC_Digit, noback, nofor, table, displayTable);
 		break;
 	case CTO_LitDigit:
-		compileCharDef(nested, opcode, CTC_LitDigit, newRuleOffset, newRule, noback,
-				nofor, table, displayTable);
+		compileCharDef(nested, opcode, CTC_LitDigit, noback, nofor, table, displayTable);
 		break;
 	case CTO_Punctuation:
-		compileCharDef(nested, opcode, CTC_Punctuation, newRuleOffset, newRule, noback,
-				nofor, table, displayTable);
+		compileCharDef(
+				nested, opcode, CTC_Punctuation, noback, nofor, table, displayTable);
 		break;
 	case CTO_Math:
-		compileCharDef(nested, opcode, CTC_Math, newRuleOffset, newRule, noback, nofor,
-				table, displayTable);
+		compileCharDef(nested, opcode, CTC_Math, noback, nofor, table, displayTable);
 		break;
 	case CTO_Sign:
-		compileCharDef(nested, opcode, CTC_Sign, newRuleOffset, newRule, noback, nofor,
-				table, displayTable);
+		compileCharDef(nested, opcode, CTC_Sign, noback, nofor, table, displayTable);
 		break;
 	case CTO_Letter:
-		compileCharDef(nested, opcode, CTC_Letter, newRuleOffset, newRule, noback, nofor,
-				table, displayTable);
+		compileCharDef(nested, opcode, CTC_Letter, noback, nofor, table, displayTable);
 		break;
 	case CTO_UpperCase:
-		compileCharDef(nested, opcode, CTC_UpperCase, newRuleOffset, newRule, noback,
-				nofor, table, displayTable);
+		compileCharDef(nested, opcode, CTC_UpperCase, noback, nofor, table, displayTable);
 		break;
 	case CTO_LowerCase:
-		compileCharDef(nested, opcode, CTC_LowerCase, newRuleOffset, newRule, noback,
-				nofor, table, displayTable);
+		compileCharDef(nested, opcode, CTC_LowerCase, noback, nofor, table, displayTable);
 		break;
 	case CTO_Grouping:
-		ok = compileGrouping(
-				nested, newRuleOffset, newRule, noback, nofor, table, displayTable);
+		ok = compileGrouping(nested, noback, nofor, table, displayTable);
 		break;
 	case CTO_UpLow:
-		ok = compileUplow(
-				nested, newRuleOffset, newRule, noback, nofor, table, displayTable);
+		ok = compileUplow(nested, noback, nofor, table, displayTable);
 		break;
 	case CTO_Display:
 		if (!displayTable) break;
@@ -2773,9 +2754,8 @@ doOpcode:
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->undefined;
 			ok = compileBrailleIndicator(nested, "undefined character opcode",
-					CTO_Undefined, &ruleOffset, newRule, noback, nofor, table);
+					CTO_Undefined, &ruleOffset, noback, nofor, table);
 			(*table)->undefined = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_Match: {
@@ -2837,8 +2817,6 @@ doOpcode:
 			memcpy(&(*table)->ruleArea[patternsOffset], patterns, len * sizeof(widechar));
 			rule->patterns = patternsOffset;
 
-			if (newRule) *newRule = rule;
-			if (newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 
@@ -2902,8 +2880,6 @@ doOpcode:
 			memcpy(&(*table)->ruleArea[patternOffset], patterns, len * sizeof(widechar));
 			rule->patterns = patternOffset;
 
-			if (newRule) *newRule = rule;
-			if (newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 
@@ -2912,9 +2888,8 @@ doOpcode:
 			TranslationTableOffset ruleOffset =
 					(*table)->emphRules[capsRule][begPhraseOffset];
 			ok = compileBrailleIndicator(nested, "first word capital sign",
-					CTO_BegCapsPhraseRule, &ruleOffset, newRule, noback, nofor, table);
+					CTO_BegCapsPhraseRule, &ruleOffset, noback, nofor, table);
 			(*table)->emphRules[capsRule][begPhraseOffset] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_EndCapsPhrase: {
@@ -2930,10 +2905,8 @@ doOpcode:
 				// table
 				ruleOffset = (*table)->emphRules[capsRule][endPhraseBeforeOffset];
 				ok = compileBrailleIndicator(nested, "capital sign before last word",
-						CTO_EndCapsPhraseBeforeRule, &ruleOffset, newRule, noback, nofor,
-						table);
+						CTO_EndCapsPhraseBeforeRule, &ruleOffset, noback, nofor, table);
 				(*table)->emphRules[capsRule][endPhraseBeforeOffset] = ruleOffset;
-				if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 				break;
 			case 2:  // after
 				if ((*table)->emphRules[capsRule][endPhraseBeforeOffset]) {
@@ -2946,10 +2919,8 @@ doOpcode:
 				// table
 				ruleOffset = (*table)->emphRules[capsRule][endPhraseAfterOffset];
 				ok = compileBrailleIndicator(nested, "capital sign after last word",
-						CTO_EndCapsPhraseAfterRule, &ruleOffset, newRule, noback, nofor,
-						table);
+						CTO_EndCapsPhraseAfterRule, &ruleOffset, noback, nofor, table);
 				(*table)->emphRules[capsRule][endPhraseAfterOffset] = ruleOffset;
-				if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 				break;
 			default:  // error
 				compileError(nested, "Invalid lastword indicator location.");
@@ -2962,18 +2933,16 @@ doOpcode:
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->emphRules[capsRule][begOffset];
 			ok = compileBrailleIndicator(nested, "first letter capital sign",
-					CTO_BegCapsRule, &ruleOffset, newRule, noback, nofor, table);
+					CTO_BegCapsRule, &ruleOffset, noback, nofor, table);
 			(*table)->emphRules[capsRule][begOffset] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_EndCaps: {
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->emphRules[capsRule][endOffset];
 			ok = compileBrailleIndicator(nested, "last letter capital sign",
-					CTO_EndCapsRule, &ruleOffset, newRule, noback, nofor, table);
+					CTO_EndCapsRule, &ruleOffset, noback, nofor, table);
 			(*table)->emphRules[capsRule][endOffset] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_CapsLetter: {
@@ -2981,9 +2950,8 @@ doOpcode:
 			TranslationTableOffset ruleOffset =
 					(*table)->emphRules[capsRule][letterOffset];
 			ok = compileBrailleIndicator(nested, "single letter capital sign",
-					CTO_CapsLetterRule, &ruleOffset, newRule, noback, nofor, table);
+					CTO_CapsLetterRule, &ruleOffset, noback, nofor, table);
 			(*table)->emphRules[capsRule][letterOffset] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_BegCapsWord: {
@@ -2991,9 +2959,8 @@ doOpcode:
 			TranslationTableOffset ruleOffset =
 					(*table)->emphRules[capsRule][begWordOffset];
 			ok = compileBrailleIndicator(nested, "capital word", CTO_BegCapsWordRule,
-					&ruleOffset, newRule, noback, nofor, table);
+					&ruleOffset, noback, nofor, table);
 			(*table)->emphRules[capsRule][begWordOffset] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_EndCapsWord: {
@@ -3001,9 +2968,8 @@ doOpcode:
 			TranslationTableOffset ruleOffset =
 					(*table)->emphRules[capsRule][endWordOffset];
 			ok = compileBrailleIndicator(nested, "capital word stop", CTO_EndCapsWordRule,
-					&ruleOffset, newRule, noback, nofor, table);
+					&ruleOffset, noback, nofor, table);
 			(*table)->emphRules[capsRule][endWordOffset] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_LenCapsPhrase:
@@ -3144,7 +3110,7 @@ doOpcode:
 						ruleOffset = (*table)->emphRules[i][letterOffset];
 						ok = compileBrailleIndicator(nested, "single letter",
 								CTO_Emph1LetterRule + letterOffset + (8 * i), &ruleOffset,
-								newRule, noback, nofor, table);
+								noback, nofor, table);
 						(*table)->emphRules[i][letterOffset] = ruleOffset;
 					} else if (opcode == CTO_BegEmphWord) {
 						// not passing pointer because compileBrailleIndicator may
@@ -3152,7 +3118,7 @@ doOpcode:
 						ruleOffset = (*table)->emphRules[i][begWordOffset];
 						ok = compileBrailleIndicator(nested, "word",
 								CTO_Emph1LetterRule + begWordOffset + (8 * i),
-								&ruleOffset, newRule, noback, nofor, table);
+								&ruleOffset, noback, nofor, table);
 						(*table)->emphRules[i][begWordOffset] = ruleOffset;
 					} else if (opcode == CTO_EndEmphWord) {
 						// not passing pointer because compileBrailleIndicator may
@@ -3160,7 +3126,7 @@ doOpcode:
 						ruleOffset = (*table)->emphRules[i][endWordOffset];
 						ok = compileBrailleIndicator(nested, "word stop",
 								CTO_Emph1LetterRule + endWordOffset + (8 * i),
-								&ruleOffset, newRule, noback, nofor, table);
+								&ruleOffset, noback, nofor, table);
 						(*table)->emphRules[i][endWordOffset] = ruleOffset;
 					} else if (opcode == CTO_BegEmph) {
 						/* fail if both begemph and any of begemphphrase or begemphword
@@ -3180,7 +3146,7 @@ doOpcode:
 						ruleOffset = (*table)->emphRules[i][begOffset];
 						ok = compileBrailleIndicator(nested, "first letter",
 								CTO_Emph1LetterRule + begOffset + (8 * i), &ruleOffset,
-								newRule, noback, nofor, table);
+								noback, nofor, table);
 						(*table)->emphRules[i][begOffset] = ruleOffset;
 					} else if (opcode == CTO_EndEmph) {
 						if ((*table)->emphRules[i][endWordOffset] ||
@@ -3199,7 +3165,7 @@ doOpcode:
 						ruleOffset = (*table)->emphRules[i][endOffset];
 						ok = compileBrailleIndicator(nested, "last letter",
 								CTO_Emph1LetterRule + endOffset + (8 * i), &ruleOffset,
-								newRule, noback, nofor, table);
+								noback, nofor, table);
 						(*table)->emphRules[i][endOffset] = ruleOffset;
 					} else if (opcode == CTO_BegEmphPhrase) {
 						// not passing pointer because compileBrailleIndicator may
@@ -3207,7 +3173,7 @@ doOpcode:
 						ruleOffset = (*table)->emphRules[i][begPhraseOffset];
 						ok = compileBrailleIndicator(nested, "first word",
 								CTO_Emph1LetterRule + begPhraseOffset + (8 * i),
-								&ruleOffset, newRule, noback, nofor, table);
+								&ruleOffset, noback, nofor, table);
 						(*table)->emphRules[i][begPhraseOffset] = ruleOffset;
 					} else if (opcode == CTO_EndEmphPhrase)
 						switch (compileBeforeAfter(nested)) {
@@ -3222,7 +3188,7 @@ doOpcode:
 							ruleOffset = (*table)->emphRules[i][endPhraseBeforeOffset];
 							ok = compileBrailleIndicator(nested, "last word before",
 									CTO_Emph1LetterRule + endPhraseBeforeOffset + (8 * i),
-									&ruleOffset, newRule, noback, nofor, table);
+									&ruleOffset, noback, nofor, table);
 							(*table)->emphRules[i][endPhraseBeforeOffset] = ruleOffset;
 							break;
 						case 2:  // after
@@ -3236,7 +3202,7 @@ doOpcode:
 							ruleOffset = (*table)->emphRules[i][endPhraseAfterOffset];
 							ok = compileBrailleIndicator(nested, "last word after",
 									CTO_Emph1LetterRule + endPhraseAfterOffset + (8 * i),
-									&ruleOffset, newRule, noback, nofor, table);
+									&ruleOffset, noback, nofor, table);
 							(*table)->emphRules[i][endPhraseAfterOffset] = ruleOffset;
 							break;
 						default:  // error
@@ -3297,16 +3263,14 @@ doOpcode:
 					}
 					free(s);
 				}
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_LetterSign: {
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->letterSign;
 			ok = compileBrailleIndicator(nested, "letter sign", CTO_LetterRule,
-					&ruleOffset, newRule, noback, nofor, table);
+					&ruleOffset, noback, nofor, table);
 			(*table)->letterSign = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_NoLetsignBefore:
@@ -3350,9 +3314,8 @@ doOpcode:
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->numberSign;
 			ok = compileBrailleIndicator(nested, "number sign", CTO_NumberRule,
-					&ruleOffset, newRule, noback, nofor, table);
+					&ruleOffset, noback, nofor, table);
 			(*table)->numberSign = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 
@@ -3418,9 +3381,8 @@ doOpcode:
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->noContractSign;
 			ok = compileBrailleIndicator(nested, "no contractions sign",
-					CTO_NoContractRule, &ruleOffset, newRule, noback, nofor, table);
+					CTO_NoContractRule, &ruleOffset, noback, nofor, table);
 			(*table)->noContractSign = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_SeqDelimiter:
@@ -3528,18 +3490,16 @@ doOpcode:
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->begComp;
 			ok = compileBrailleIndicator(nested, "begin computer braille",
-					CTO_BegCompRule, &ruleOffset, newRule, noback, nofor, table);
+					CTO_BegCompRule, &ruleOffset, noback, nofor, table);
 			(*table)->begComp = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_EndComp: {
 			// not passing pointer because compileBrailleIndicator may reallocate table
 			TranslationTableOffset ruleOffset = (*table)->endComp;
 			ok = compileBrailleIndicator(nested, "end computer braslle", CTO_EndCompRule,
-					&ruleOffset, newRule, noback, nofor, table);
+					&ruleOffset, noback, nofor, table);
 			(*table)->endComp = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_NoCross:
@@ -3588,9 +3548,8 @@ doOpcode:
 						}
 					TranslationTableRule *r;
 					if (addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-								newRuleOffset, &r, noback, nofor, table)) {
+								NULL, &r, noback, nofor, table)) {
 						if (nocross) r->nocross = 1;
-						if (newRule) *newRule = r;
 						ok = 1;
 					}
 				}
@@ -3634,8 +3593,7 @@ doOpcode:
 													y.chars[l];
 								}
 								if (addRule(nested, opcode, &ruleChars, &ruleDots, after,
-											before, newRuleOffset, newRule, noback, nofor,
-											table))
+											before, NULL, NULL, noback, nofor, table))
 									ok = 1;
 								break;
 							}
@@ -3654,10 +3612,9 @@ doOpcode:
 			}
 			if (!getRuleDotsPattern(nested, &ruleDots)) return 0;
 			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-						&ruleOffset, newRule, noback, nofor, table))
+						&ruleOffset, NULL, noback, nofor, table))
 				ok = 0;
 			(*table)->compdotsPattern[ruleChars.chars[0]] = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_ExactDots:
@@ -3670,8 +3627,8 @@ doOpcode:
 				scratchPad.chars[k - 1] = ruleChars.chars[k];
 			scratchPad.length = ruleChars.length - 1;
 			if (!parseDots(nested, &ruleDots, &scratchPad)) return 0;
-			if (!addRule(nested, opcode, &ruleChars, &ruleDots, before, after,
-						newRuleOffset, newRule, noback, nofor, table))
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, before, after, NULL, NULL,
+						noback, nofor, table))
 				ok = 0;
 			break;
 		case CTO_CapsNoCont: {
@@ -3679,10 +3636,9 @@ doOpcode:
 			ruleChars.length = 1;
 			ruleChars.chars[0] = 'a';
 			if (!addRule(nested, CTO_CapsNoContRule, &ruleChars, NULL, after, before,
-						&ruleOffset, newRule, noback, nofor, table))
+						&ruleOffset, NULL, noback, nofor, table))
 				ok = 0;
 			(*table)->capsNoCont = ruleOffset;
-			if (ok && newRuleOffset) *newRuleOffset = ruleOffset;
 			break;
 		}
 		case CTO_Replace:
@@ -3702,8 +3658,8 @@ doOpcode:
 				putChar(nested, ruleChars.chars[k], table);
 			for (k = 0; k < ruleDots.length; k++)
 				putChar(nested, ruleDots.chars[k], table);
-			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-						newRuleOffset, newRule, noback, nofor, table))
+			if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before, NULL, NULL,
+						noback, nofor, table))
 				ok = 0;
 			break;
 		case CTO_Correct:
@@ -3725,9 +3681,7 @@ doOpcode:
 				ok = 0;
 				break;
 			}
-			if (!compilePassOpcode(
-						nested, opcode, newRuleOffset, newRule, noback, nofor, table))
-				ok = 0;
+			if (!compilePassOpcode(nested, opcode, noback, nofor, table)) ok = 0;
 			break;
 		case CTO_Contraction:
 		case CTO_NoCont:
@@ -3742,8 +3696,8 @@ doOpcode:
 						return 0;
 					}
 				}
-				if (!addRule(nested, opcode, &ruleChars, NULL, after, before,
-							newRuleOffset, newRule, noback, nofor, table))
+				if (!addRule(nested, opcode, &ruleChars, NULL, after, before, NULL, NULL,
+							noback, nofor, table))
 					ok = 0;
 			}
 			break;
@@ -3763,8 +3717,8 @@ doOpcode:
 				}
 			} else
 				ok = 0;
-			if (!addRule(nested, CTO_MultInd, &ruleChars, &cells, after, before,
-						newRuleOffset, newRule, noback, nofor, table))
+			if (!addRule(nested, CTO_MultInd, &ruleChars, &cells, after, before, NULL,
+						NULL, noback, nofor, table))
 				ok = 0;
 			break;
 		}
@@ -3937,9 +3891,7 @@ doOpcode:
 		case CTO_SwapCc:
 		case CTO_SwapCd:
 		case CTO_SwapDd:
-			if (!compileSwap(
-						nested, opcode, newRuleOffset, newRule, noback, nofor, table))
-				ok = 0;
+			if (!compileSwap(nested, opcode, noback, nofor, table)) ok = 0;
 			break;
 		case CTO_Hyphen:
 		case CTO_DecPoint:
@@ -3954,7 +3906,7 @@ doOpcode:
 						ok = 0;
 					}
 					if (!addRule(nested, opcode, &ruleChars, &ruleDots, after, before,
-								newRuleOffset, newRule, noback, nofor, table))
+								NULL, NULL, noback, nofor, table))
 						ok = 0;
 					// if (opcode == CTO_DecPoint)
 					// {
@@ -4025,7 +3977,7 @@ compileString(const char *inString, TranslationTableHeader **table,
 	for (k = 0; inString[k]; k++) nested.line[k] = inString[k];
 	nested.line[k] = 0;
 	nested.linelen = k;
-	return compileRule(&nested, NULL, NULL, table, displayTable);
+	return compileRule(&nested, table, displayTable);
 }
 
 static int
@@ -4289,8 +4241,7 @@ compileFile(const char *fileName, TranslationTableHeader **table,
 	nested.status = 0;
 	nested.lineNumber = 0;
 	if ((nested.in = fopen(nested.fileName, "rb"))) {
-		while (_lou_getALine(&nested))
-			compileRule(&nested, NULL, NULL, table, displayTable);
+		while (_lou_getALine(&nested)) compileRule(&nested, table, displayTable);
 		fclose(nested.in);
 		return 1;
 	} else

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -145,13 +145,13 @@ static int appliedRulesCount;
 static TranslationTableCharacter *
 getChar(widechar c, const TranslationTableHeader *table) {
 	static TranslationTableCharacter notFound = { 0, 0, 0, CTC_Space, 32, 32, 32 };
-	unsigned long int makeHash = _lou_charHash(c);
-	TranslationTableOffset bucket = table->characters[makeHash];
-	while (bucket) {
+	const TranslationTableOffset bucket = table->characters[_lou_charHash(c)];
+	TranslationTableOffset offset = bucket;
+	while (offset) {
 		TranslationTableCharacter *character =
-				(TranslationTableCharacter *)&table->ruleArea[bucket];
+				(TranslationTableCharacter *)&table->ruleArea[offset];
 		if (character->realchar == c) return character;
-		bucket = character->next;
+		offset = character->next;
 	}
 	notFound.realchar = notFound.uppercase = notFound.lowercase = c;
 	return &notFound;
@@ -161,13 +161,13 @@ static TranslationTableCharacter *
 getDots(widechar c, const TranslationTableHeader *table) {
 	static TranslationTableCharacter notFound = { 0, 0, 0, CTC_Space, LOU_DOTS, LOU_DOTS,
 		LOU_DOTS };
-	unsigned long int makeHash = _lou_charHash(c);
-	TranslationTableOffset bucket = table->dots[makeHash];
-	while (bucket) {
+	const TranslationTableOffset bucket = table->dots[_lou_charHash(c)];
+	TranslationTableOffset offset = bucket;
+	while (offset) {
 		TranslationTableCharacter *character =
-				(TranslationTableCharacter *)&table->ruleArea[bucket];
+				(TranslationTableCharacter *)&table->ruleArea[offset];
 		if (character->realchar == c) return character;
-		bucket = character->next;
+		offset = character->next;
 	}
 	notFound.realchar = notFound.uppercase = notFound.lowercase = c;
 	return &notFound;

--- a/tables/afr-za-g2.ctb
+++ b/tables/afr-za-g2.ctb
@@ -179,8 +179,7 @@ noback match - her E%[^_.]|e%[^_.]|EREG|ereg|ETJIE|etjie 125-15-1235
 
 #k
 noback match - kamper END|end|ING|ing 13-1-134-1234-15-1235
-# FIXME: this rule does not compile
-# noback match %[^_.] kana %[^_.]| 13-1-1345-1
+noback match %[^_.] kana %[^_.] 13-1-1345-1
 noback match %[^_.]|[FfGgMmTt]|IN|in ker END|end|ING|ing 13-15-1235
 noback match - kom EDI|edi 5-13
 noback match - kom [Aa]%[^_.]|AS%[^_.]|as%[^_.]|E|e|IE|ie|ING|ing 13-135-134

--- a/tables/afr-za-g2.ctb
+++ b/tables/afr-za-g2.ctb
@@ -179,7 +179,8 @@ noback match - her E%[^_.]|e%[^_.]|EREG|ereg|ETJIE|etjie 125-15-1235
 
 #k
 noback match - kamper END|end|ING|ing 13-1-134-1234-15-1235
-noback match %[^_.] kana %[^_.]| 13-1-1345-1
+# FIXME: this rule does not compile
+# noback match %[^_.] kana %[^_.]| 13-1-1345-1
 noback match %[^_.]|[FfGgMmTt]|IN|in ker END|end|ING|ing 13-15-1235
 noback match - kom EDI|edi 5-13
 noback match - kom [Aa]%[^_.]|AS%[^_.]|as%[^_.]|E|e|IE|ie|ING|ing 13-135-134

--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -30,8 +30,8 @@ space \t 9 tab
 space \x001b 1b escape character for html back-translation
 space \x00A0 a NO-BREAK SPACE <noBreak> 0020 NON-BREAKING SPACE
 
-include spaces.uti
 noback correct "\x200b" "\s"
+include spaces.uti
 
 include latinLetterDef8Dots.uti
 

--- a/tables/ms-my-g2.ctb
+++ b/tables/ms-my-g2.ctb
@@ -1933,7 +1933,8 @@ always kampung 13-1245
 always kampungkan 13-1245-345
 always kamukan 13-1-134-136-345
 word kan 345
-match %![^_] kan ![AaEeGgIiOoUu] 345
+# FIXME: this rule does not compile
+# match %![^_] kan ![AaEeGgIiOoUu] 345
 match ng kan - 345
 always kanada 13-1345-145
 contraction knd

--- a/tables/ms-my-g2.ctb
+++ b/tables/ms-my-g2.ctb
@@ -1933,8 +1933,7 @@ always kampung 13-1245
 always kampungkan 13-1245-345
 always kamukan 13-1-134-136-345
 word kan 345
-# FIXME: this rule does not compile
-# match %![^_] kan ![AaEeGgIiOoUu] 345
+match !%[^_] kan ![AaEeGgIiOoUu] 345
 match ng kan - 345
 always kanada 13-1345-145
 contraction knd

--- a/tables/spaces.uti
+++ b/tables/spaces.uti
@@ -55,7 +55,7 @@ space \x2800 0		BRAILLE PATTERN BLANK
 space \xfeff 0		ZERO WIDTH NO-BREAK SPACE (also Unicode BOM)
 
 # replace \x200b		ZERO WIDTH SPACE
-noback correct "\x200b" ""
+# noback correct "\x200b" ""
 
 replace \x2060		WORD JOINER
 replace \xfeff		ZERO WIDTH NO-BREAK SPACE (also Unicode BOM)

--- a/tables/spaces.uti
+++ b/tables/spaces.uti
@@ -55,7 +55,7 @@ space \x2800 0		BRAILLE PATTERN BLANK
 space \xfeff 0		ZERO WIDTH NO-BREAK SPACE (also Unicode BOM)
 
 # replace \x200b		ZERO WIDTH SPACE
-# noback correct "\x200b" ""
+noback correct "\x200b" ""
 
 replace \x2060		WORD JOINER
 replace \xfeff		ZERO WIDTH NO-BREAK SPACE (also Unicode BOM)

--- a/tests/braille-specs/spaces.yaml
+++ b/tests/braille-specs/spaces.yaml
@@ -575,7 +575,6 @@ tests:
   - ['\x2008', '\x0020']
   - ['\x200a', '\x0020']
   - ['\x200b', '\x0020']
-  - ['\x200b', '\x0020']
   - ['\x202f', '\x0020']
 table: en-us-comp8.ctb,spaces.uti
 flags: {testmode: bothDirections}


### PR DESCRIPTION
I start with some code cleanup and refactoring, and then I move on to making the compilation functions more strict by not ignoring compilation errors and aborting immediately when the first error is found. The error reporting has also been improved a bit. Thanks to these changes I was able to find a bug in the code and two errors in the tables. I fixed the bug and the two rules are commented out for now. I think I managed to fix them (locally) but would like the table authors to confirm this, and also add tests for these rules.