### PR TITLE
Add macro feature

### DIFF
--- a/.github/workflows/macro.yml
+++ b/.github/workflows/macro.yml
@@ -1,0 +1,36 @@
+name: Test macro feature
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Test macro feature
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y libyaml-dev
+    - name: Enable macro feature
+      run: |
+        cat liblouis/internal.h | sed 's/MACROS_ENABLED 0/MACROS_ENABLED 1/' >liblouis/internal.h.tmp
+        mv liblouis/internal.h.tmp liblouis/internal.h
+    - name: Autogen && configure
+      run: |
+        ./autogen.sh
+        ./configure
+    - name: Make
+      run: make
+    - name: Run macro.yml
+      run: LOUIS_TABLEPATH=$(pwd) tools/lou_checkyaml tests/yaml/macro.yaml >tests/yaml/macro.log
+    - name: Store the test log
+      if: ${{ always() }} # store the test log even if the tests failed
+      uses: actions/upload-artifact@v2
+      with:
+        name: macro.log
+        path: tests/yaml/macro.log

--- a/.github/workflows/macro.yml
+++ b/.github/workflows/macro.yml
@@ -16,21 +16,17 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get update -qq && sudo apt-get install -y libyaml-dev
-    - name: Enable macro feature
-      run: |
-        cat liblouis/internal.h | sed 's/MACROS_ENABLED 0/MACROS_ENABLED 1/' >liblouis/internal.h.tmp
-        mv liblouis/internal.h.tmp liblouis/internal.h
     - name: Autogen && configure
       run: |
         ./autogen.sh
-        ./configure
+        ./configure --enable-macros
     - name: Make
       run: make
-    - name: Run macro.yml
-      run: LOUIS_TABLEPATH=$(pwd) tools/lou_checkyaml tests/yaml/macro.yaml >tests/yaml/macro.log
+    - name: Make check
+      run: make check
     - name: Store the test log
       if: ${{ always() }} # store the test log even if the tests failed
       uses: actions/upload-artifact@v2
       with:
-        name: macro.log
-        path: tests/yaml/macro.log
+        name: test-suite-macro.log
+        path: tests/test-suite.log

--- a/configure.ac
+++ b/configure.ac
@@ -156,8 +156,22 @@ else
 fi
 AM_CONDITIONAL([HAVE_MAKEINFO_5], [test x$have_makeinfo_5 = xtrue])
 
+# Check if the user wants to enable macros.
+# Macros are an experimental feature and need to be enabled
+# explicitely. They are a helpful tool for refactoring, but for now we
+# don't want to expose it to users yet.
+AC_ARG_ENABLE([macros],
+  [AS_HELP_STRING([--enable-macros], [enable macros @<:@default=no@:>@])],
+  [enable_macros=$enableval],
+  [])
+
+if test "x$enable_macros" == xyes; then
+   AC_DEFINE([ENABLE_MACROS],[1],[Enable macros])
+fi
+AM_CONDITIONAL([ENABLE_MACROS], [test "x$enable_macros" = xyes])
+
 AC_ARG_ENABLE(ucs4,
-              AC_HELP_STRING(--enable-ucs4, Enable 4 byte-wide characters),
+              AC_HELP_STRING(--enable-ucs4, enable 4 byte-wide characters),
               [AC_DEFINE([WIDECHARS_ARE_UCS4], [1], [Define if widechars are ucs4])],
               [enable_ucs4=no])
 

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -2815,6 +2815,10 @@ doOpcode:
 	switch (opcode) {
 	case CTO_Macro: {
 		const Macro *macro;
+		if (!MACROS_ENABLED) {
+			compileError(file, "Macro feature is disabled.");
+			return 0;
+		}
 		if (!inScopeMacros) {
 			compileError(file, "Defining macros only allowed in table files.");
 			return 0;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -2815,10 +2815,7 @@ doOpcode:
 	switch (opcode) {
 	case CTO_Macro: {
 		const Macro *macro;
-		if (!MACROS_ENABLED) {
-			compileError(file, "Macro feature is disabled.");
-			return 0;
-		}
+#ifdef ENABLE_MACROS
 		if (!inScopeMacros) {
 			compileError(file, "Defining macros only allowed in table files.");
 			return 0;
@@ -2828,6 +2825,10 @@ doOpcode:
 			return 1;
 		}
 		return 0;
+#else
+		compileError(file, "Macro feature is disabled.");
+		return 0;
+#endif
 	}
 	case CTO_IncludeFile: {
 		CharsString includedFile;

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -78,10 +78,6 @@ typedef struct intCharTupple {
 #define MAX_MACRO_VAR 100  // maximal number of variable substitutions a macro can contain
 #define MAX_EMPH_CLASSES 10  // {emph_1...emph_10} in typeforms enum (liblouis.h)
 
-/* macro is implemented but disabled by default: it is a helpful tool for refactoring, but
- * for now we don't want to expose it to users yet. */
-#define MACROS_ENABLED 0
-
 typedef unsigned int TranslationTableOffset;
 
 /* Basic type for translation table data, which carries all alignment

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -75,7 +75,7 @@ typedef struct intCharTupple {
 
 #define MAXPASS 4
 #define MAXSTRING 2048
-
+#define MAX_MACRO_VAR 100  // maximal number of variable substitutions a macro can contain
 #define MAX_EMPH_CLASSES 10  // {emph_1...emph_10} in typeforms enum (liblouis.h)
 
 typedef unsigned int TranslationTableOffset;
@@ -330,6 +330,7 @@ typedef enum { /* Op codes */
 	CTO_Match,
 	CTO_BackMatch,
 	CTO_Attribute,
+	CTO_Macro,
 	CTO_None,
 
 	/* More internal opcodes */

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -78,6 +78,10 @@ typedef struct intCharTupple {
 #define MAX_MACRO_VAR 100  // maximal number of variable substitutions a macro can contain
 #define MAX_EMPH_CLASSES 10  // {emph_1...emph_10} in typeforms enum (liblouis.h)
 
+/* macro is implemented but disabled by default: it is a helpful tool for refactoring, but
+ * for now we don't want to expose it to users yet. */
+#define MACROS_ENABLED 0
+
 typedef unsigned int TranslationTableOffset;
 
 /* Basic type for translation table data, which carries all alignment

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -254,6 +254,12 @@ dist_yaml_TESTS +=				\
 	yaml/face-with-tears-of-joy-ucs4.yaml
 endif
 
+# Tests for macros
+if ENABLE_MACROS
+dist_yaml_TESTS +=				\
+	yaml/macro.yaml
+endif
+
 YAML_LOG_COMPILER_SCRIPT = yaml-log-compiler.sh
 TEST_EXTENSIONS = .yaml
 YAML_LOG_COMPILER = $(top_srcdir)/tests/$(YAML_LOG_COMPILER_SCRIPT)
@@ -261,10 +267,8 @@ LOG_COMPILE = $(WINE)
 
 EXTRA_DIST = $(dist_yaml_TESTS) $(dist_braille_specs_TESTS) $(YAML_LOG_COMPILER_SCRIPT)
 
-# macro feature is disabled
 # ueb_test_data.pl fails (see also issues #764 and #268)
 XFAIL_TESTS =					\
-	yaml/macro.yaml				\
 	ueb_test_data.pl
 
 TESTS =				     \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -231,6 +231,7 @@ dist_yaml_TESTS =				\
 	yaml/issue-615.yaml			\
 	yaml/issue-963.yaml			\
 	yaml/letterDefTest_harness.yaml		\
+	yaml/macro.yaml				\
 	yaml/multipass-backward.yaml		\
 	yaml/multipass-forward.yaml		\
 	yaml/multipass.yaml			\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -231,7 +231,6 @@ dist_yaml_TESTS =				\
 	yaml/issue-615.yaml			\
 	yaml/issue-963.yaml			\
 	yaml/letterDefTest_harness.yaml		\
-	yaml/macro.yaml				\
 	yaml/multipass-backward.yaml		\
 	yaml/multipass-forward.yaml		\
 	yaml/multipass.yaml			\
@@ -262,7 +261,10 @@ LOG_COMPILE = $(WINE)
 
 EXTRA_DIST = $(dist_yaml_TESTS) $(dist_braille_specs_TESTS) $(YAML_LOG_COMPILER_SCRIPT)
 
+# macro feature is disabled
+# ueb_test_data.pl fails (see also issues #764 and #268)
 XFAIL_TESTS =					\
+	yaml/macro.yaml				\
 	ueb_test_data.pl
 
 TESTS =				     \

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -25,6 +25,8 @@ EXTRA_DIST =					\
 	issue-615.yaml				\
 	issue-963.yaml				\
 	letterDefTest_harness.yaml		\
+	macro.yaml				\
+	macro.utb				\
 	multipass-backward.yaml			\
 	multipass-forward.yaml			\
 	multipass.yaml				\

--- a/tests/yaml/macro.utb
+++ b/tests/yaml/macro.utb
@@ -1,0 +1,9 @@
+macro att
+attribute $1 $2
+eom
+macro myletter
+letter $1 $2
+att myletter $1
+eom
+myletter a 1
+noback context []%myletter @123456

--- a/tests/yaml/macro.yaml
+++ b/tests/yaml/macro.yaml
@@ -1,0 +1,6 @@
+# Tests that a macro can call another macro.
+display: tables/unicode.dis
+table: macro.utb
+tests:
+  - - a
+    - ⠿⠁


### PR DESCRIPTION
The syntax is explained in [the test](https://github.com/liblouis/liblouis/blob/55b29f2458ff19a6f607497eea1c330616e7b4df/tests/yaml/macro.utb). It's a very minimalist mechanism to perform string substitutions, with positional arguments. It's similar to e.g. [user-defined functions in Make](https://www.gnu.org/software/make/manual/html_node/Call-Function.html#Call-Function). To use a macro it needs to be defined in the same file, before the call.

Limitations:
- A macro is a multiline thing so can't be created using the `compileString` function. A consequence of this is that you can't define macros in YAML (because checkyaml uses `compileString`) to compile inline tables.

To do:
- The documentation needs to be updated.

Credit goes out to Mike Gray who originally came up with the macro idea.