### PR TITLE
Fix nmake build

### DIFF
--- a/windows/Makefile.nmake
+++ b/windows/Makefile.nmake
@@ -4,7 +4,7 @@
 
 !include configure.mk
 
-CC = cl
+CC = clang-cl
 
 CFLAGS = /nologo /O2 /W3 /c /MD /Iinclude /D_EXPORTING
 # The Visual C++ C Runtime deprecates several standard library functions in


### PR DESCRIPTION
I fixed the nmake build by changing cl into clang-cl. In other words, it's now using clang as we do in NVDA. Newer versions of visual studio 2019 add LLVM to the path of the tools command prompt, so the procedure for building liblouis with nmake now works again.