### PR TITLE
Small fixes to Polish G1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 
+* Noteworthy changes in release 3.20.0
+** Braille table improvements
+- Improvements to Polish literary braille table thanks to Łukasz
+  Golonka.
+  - use correct representation of indexes for squared, cubed etc.
+  - use correct representation for fractions
+  - change symbol used for underscore from dots 46 to 6
+
 * Noteworthy changes in release 3.19.0 (2021-09-06)
 For this release Bert Frees has been hard at work to clean up the code
 base. He fixed a few bugs one of which was causing memory corruption.

--- a/tables/Pl-Pl-g1.utb
+++ b/tables/Pl-Pl-g1.utb
@@ -1,4 +1,4 @@
-# liblouis: Polish Grade 1 Braille Table
+# liblouis: Polish literary Braille Table
 #
 #  Copyright (C) 2004-2008 ViewPlus Technologies, Inc. www.viewplus.com
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
@@ -21,7 +21,8 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 
-# Created & maintained by Leon Ungier <Leon.Ungier@ViewPlus.com>.
+# Created by Leon Ungier <Leon.Ungier@ViewPlus.com>.
+# Currently  maintained by Łukasz Golonka <lukasz.golonka@mailbox.org>
 
 space \x00a0 a
 include spaces.uti
@@ -98,7 +99,7 @@ punctuation [ 12356		left square bracket						x005B
 sign \\ 34				reverse solidus								x005C
 punctuation ] 23456		right square bracket					x005D
 sign ^ 5				circumflex accent							x005E
-sign _ 46				low line											x005F
+sign _ 6				low line											x005F
 sign ` 4				grave accent									x0060
 
 # a - z								# 97 - 122								x0061-x007A
@@ -118,15 +119,15 @@ sign © 2356-6-14-2356		copyright																x00A9
 punctuation « 236				left-pointing double angle quotation 		x00AB
 punctuation \x00AD 36 soft hyphen
 sign ° 4-356			degree sign																		x00B0
-sign ² 4-6-126		superscript 2 sign														x00B2
-sign ³ 4-6-146		superscript 3 sign														x00B3
+sign ² 346-23		superscript 2 sign														x00B2
+sign ³ 346-25		superscript 3 sign														x00B3
 noback sign µ 56-134			micro sign																		x00B5
 sign ¶ 4-1234-345 pilcrow sign (paragraph)											x00B6
-sign ¹ 1-27				superscript 1 sign														x00B9
+sign ¹ 346-2				superscript 1 sign														x00B9
 punctuation » 356			right-pointing double angle quotation		x00BB
-math ¼ 6-16-34-1456		vulgar fraction one quarter								x00BC
-math ½ 6-16-34-126		vulgar fraction one half									x00BD
-math ¾ 6-126-34-1456	vulgar fraction 3 quarters								x00BE
+math ¼ 3456-1-256		vulgar fraction one quarter								x00BC
+math ½ 3456-1-23		vulgar fraction one half									x00BD
+math ¾ 3456-14-256	vulgar fraction 3 quarters								x00BE
 
 uplow Åå 16					A with ring above											x00C5 / 00E5
 uplow \x00C2\x00E2 16					letter a with circumflex						x00E2

--- a/tables/pl.tbl
+++ b/tables/pl.tbl
@@ -1,21 +1,12 @@
+# Based on http://liblouis.org/braille-specs/polish
 #-index-name: Polish
 #-display-name: Polish braille
 
 #+locale:pl
 #+type:literary
-#+grade:1
-# Marked as "direction:both" by Bue Vester-Andersen
-# as tests run both forward and backward
 #+direction:both
-
-# TODO: Please correct the metadata above. It is not meant to be
-# accurate nor complete. It hasn't been verified by the table
-# author yet. It is merely an attempt by the liblouis maintainers
-# to get some sensible initial values in place.
-
-# TODO: Please add a reference to official documentation about
-# the implemented braille code. Preferably submit the documents
-# to https://github.com/liblouis/braille-specs.
+#+contraction: no
+#+dots: 6
 
 include Pl-Pl-g1.utb
 include braille-patterns.cti

--- a/tests/braille-specs/litdigits6Dots_backward.yaml
+++ b/tests/braille-specs/litdigits6Dots_backward.yaml
@@ -24,7 +24,7 @@ table:
   __assert-match: nl_BE.tbl # nl-BE-g0.utb
 table:
   locale: pl
-  grade: 1
+  type: literary
   __assert-match: pl.tbl # Pl-Pl-g1.utb
 table:
   locale: sr

--- a/tests/braille-specs/pl-g1.yaml
+++ b/tests/braille-specs/pl-g1.yaml
@@ -12,7 +12,7 @@
 display: unicode-without-blank.dis
 table:
   locale: pl
-  grade: 1
+  type: literary
   __assert-match: pl.tbl
 flags: {testmode: bothDirections}
 tests:
@@ -154,3 +154,20 @@ tests:
   - [mydomain.com/test.mp3, ⠍⠽⠙⠕⠍⠁⠊⠝⠄⠉⠕⠍⠲⠞⠑⠎⠞⠄⠍⠏⠼⠉]
   - [www.mydomain.com/test.mp3, ⠺⠺⠺⠄⠍⠽⠙⠕⠍⠁⠊⠝⠄⠉⠕⠍⠲⠞⠑⠎⠞⠄⠍⠏⠼⠉]
   - ["https://mydomain.com/test.mp3", ⠓⠞⠞⠏⠎⠒⠲⠲⠍⠽⠙⠕⠍⠁⠊⠝⠄⠉⠕⠍⠲⠞⠑⠎⠞⠄⠍⠏⠼⠉]
+flags: {testmode: forward}
+tests:
+  # Indexes squared, cubed etc.
+  - [2² = 4, ⠼⠃⠬⠆ ⠶ ⠼⠙]
+  - [2³ = 8, ⠼⠃⠬⠒ ⠶ ⠼⠓]
+  - [2¹ = 2, ⠼⠃⠬⠂ ⠶ ⠼⠃]
+  # Fractions:
+  - [¼, ⠼⠁⠲]
+  - [½, ⠼⠁⠆]
+  - [¾, ⠼⠉⠲]
+  - [¼ + ½ = ¾, ⠼⠁⠲ ⠖ ⠼⠁⠆ ⠶ ⠼⠉⠲]
+
+  # Tests for underscore.
+  # Unfortunately there is no official standard to follow for this character therefore use dot 6 following the most common representation in screen readers.
+  # The previous representation (dots 4-6) can be easily confused with a capital letter indicator.
+  - [testowy_plik_o_długiej_nazwie.format, ⠞⠑⠎⠞⠕⠺⠽⠠⠏⠇⠊⠅⠠⠕⠠⠙⠣⠥⠛⠊⠑⠚⠠⠝⠁⠵⠺⠊⠑⠄⠋⠕⠗⠍⠁⠞]
+  - ["_Alicja", ⠠⠨⠁⠇⠊⠉⠚⠁]


### PR DESCRIPTION
This pull request:
- Uses correct representation of indexes for squared, cubed etc.
- Used correct representation for fractions (I haven't added any new to the table just made sure that one present are shown according to the specification)
- Changes symbol used for underscore from dots 46 to 6 (the former has been too similar to capital letter sign confusing users)

While at i I've also updated metadata of the table. The change from "grade 1" to "literary" is necessary since in Poland Grade 1 means the first level of contractions and the current table does not implement any contractions. Also "grade 1" in itself means nothing since there are two standards of contractions in Poland so with the former description it was not clear which one this table implements.