### PR TITLE
Fix bug discovered by Dang Hoai Phúc

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -571,7 +571,7 @@ putChar(const FileInfo *file, widechar c, TranslationTableHeader **table) {
 		return NULL;
 	character = (TranslationTableCharacter *)&(*table)->ruleArea[offset];
 	memset(character, 0, sizeof(*character));
-	character->realchar = c;
+	character->realchar = character->lowercase = character->uppercase = c;
 	const unsigned long int charHash = _lou_charHash(c);
 	const TranslationTableOffset bucket = (*table)->characters[charHash];
 	if (!bucket)

--- a/tests/yaml/issue-332.yaml
+++ b/tests/yaml/issue-332.yaml
@@ -107,17 +107,17 @@ tests:
 # It works as long as there is a display rule to display the cell in the output...
 table: |
   display x 2
-  always a 2-2
+  always abc 2
 # ... or as long as the cell does not end up in output.
 table: |
   sign x 3
-  always a 2-2
+  always abc 2
   noback pass2 @2 @3
   nofor pass2 @3 @2
 flags: {testmode: bothDirections}
 tests:
-  - - a
-    - xx
+  - - abc
+    - x
 # If a cell ends up in the output and can not be displayed, it results in an error.
 # FIXME: use the expectedError flag (https://github.com/liblouis/liblouis/issues/875)
 # table: |
@@ -126,3 +126,13 @@ tests:
 # tests:
 #   - - a
 #     - " "
+
+# It does not matter whether the first character of the always rule is given an attribute or not (regression test for #1116)
+table: |
+  display x 2
+  attribute foo a
+  always abc 2
+flags: {testmode: bothDirections}
+tests:
+  - - abc
+    - x


### PR DESCRIPTION
See https://www.freelists.org/post/liblouis-liblouisxml/SV-Translate-Combined-Cap-Letters,2

An always rule starting with an undefined character would not work when that character was given an attribute (with the "attribute" opcode).

Related to commit bdaeb4c.