### PR TITLE
Add test for issue #963

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -228,6 +228,7 @@ dist_yaml_TESTS =				\
 	yaml/issue-332.yaml			\
 	yaml/issue-479.yaml			\
 	yaml/issue-615.yaml			\
+	yaml/issue-963.yaml			\
 	yaml/letterDefTest_harness.yaml		\
 	yaml/multipass-backward.yaml		\
 	yaml/multipass-forward.yaml		\

--- a/tests/yaml/Makefile.am
+++ b/tests/yaml/Makefile.am
@@ -23,6 +23,7 @@ EXTRA_DIST =					\
 	issue-332_hyph.dic			\
 	issue-479.yaml				\
 	issue-615.yaml				\
+	issue-963.yaml				\
 	letterDefTest_harness.yaml		\
 	multipass-backward.yaml			\
 	multipass-forward.yaml			\

--- a/tests/yaml/issue-963.yaml
+++ b/tests/yaml/issue-963.yaml
@@ -1,0 +1,29 @@
+# Test for issue #963: dot 7 capitalization indicator remains active when it shouldn't (https://github.com/liblouis/liblouis/issues/963)
+table: |
+  include tables/unicode.dis
+  space \s 0
+  include tables/latinLetterDef8Dots.uti
+  capsletter 6
+tests:
+  - - "T"
+    - ⠠⠞
+  - - "Te"
+    - ⠠⠞⠑
+  - - "T"
+    - ⡞
+    - mode: [compbrlAtCursor]
+      cursorPos: 0
+  - - "Te"
+    - ⡞⠑
+    - mode: [compbrlAtCursor]
+      cursorPos: 1
+  - - "Te "
+    - ⠠⠞⠑⠀
+    - mode: [compbrlAtCursor]
+      cursorPos: 2
+      xfail: got "⠠⡞⠑⠀"
+  - - "Te T"
+    - ⠠⠞⠑⠀⡞
+    - mode: [compbrlAtCursor]
+      cursorPos: 3
+      xfail: got "⠠⡞⠑⠀⡞"


### PR DESCRIPTION
dot 7 capitalization indicator remains active when it shouldn't

See https://github.com/liblouis/liblouis/issues/963