### PR TITLE
Prefer clang-format version 9

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get update -qq && sudo apt-get install -y clang-format-7
+      run: sudo apt-get update -qq && sudo apt-get install -y clang-format-9
     - name: Autogen && configure
       run: |
         ./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -115,9 +115,9 @@ done
 # define an additional recursive make target to format the sources.
 # Also check if clang-format is installed
 AM_EXTRA_RECURSIVE_TARGETS([format-sources])
-# prefer version 7 of clang-format
-AC_CHECK_PROGS([SOURCE_FORMATTER], [clang-format-7 clang-format])
-AM_CONDITIONAL([HAVE_SOURCE_FORMATTER], [test x$SOURCE_FORMATTER = xclang-format])
+# prefer version 9 of clang-format as it is part of any release since ubuntu 20.04
+AC_CHECK_PROGS([SOURCE_FORMATTER], [clang-format-9 clang-format])
+AM_CONDITIONAL([HAVE_SOURCE_FORMATTER], [test x$SOURCE_FORMATTER = xclang-format -o x$SOURCE_FORMATTER = xclang-format-9])
 
 # GNU help2man creates man pages from --help output; in many cases,
 # this is sufficient, and obviates the need to maintain man pages

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1186,7 +1186,7 @@ allocateCharacterClasses(TranslationTableHeader *table) {
 	/* Allocate memory for predefined character classes */
 	int k = 0;
 	table->characterClasses = NULL;
-	table->nextCharacterClassAttribute = 1;  // CTC_Space
+	table->nextCharacterClassAttribute = 1;	 // CTC_Space
 	table->nextNumberedCharacterClassAttribute = CTC_UserDefined1;
 	while (characterClassNames[k]) {
 		widechar wname[MAXSTRING];
@@ -2598,12 +2598,12 @@ compileBeforeAfter(FileInfo *file) {
  */
 typedef struct {
 	const char *name;
-	const widechar *definition;  // fixed part
+	const widechar *definition;	 // fixed part
 	int definition_length;
 	const int *substitutions;  // variable part: position and argument index of each
 							   // variable substitution
 	int substitution_count;
-	int argument_count;  // number of expected arguments
+	int argument_count;	 // number of expected arguments
 } Macro;
 
 /**
@@ -2680,7 +2680,7 @@ compileMacro(FileInfo *file, const Macro **macro) {
 	CharsString token;
 	if (!getToken(file, &token, "macro name")) return 0;
 	switch (getOpcode(file, &token)) {
-	case CTO_UpLow:  // deprecated so "uplow" may be used as macro name
+	case CTO_UpLow:	 // deprecated so "uplow" may be used as macro name
 	case CTO_None:
 		break;
 	default:
@@ -2700,7 +2700,7 @@ compileMacro(FileInfo *file, const Macro **macro) {
 	static char name[MAXSTRING + 1];
 	int name_length;
 	for (name_length = 0; name_length < token.length;
-			name_length++)  // we know token can not be longer than MAXSTRING
+			name_length++)	// we know token can not be longer than MAXSTRING
 		name[name_length] = (char)token.chars[name_length];
 	name[name_length] = '\0';
 
@@ -3174,7 +3174,7 @@ doOpcode:
 			case CTO_EndModePhrase: {
 				TranslationTableOffset ruleOffset;
 				switch (compileBeforeAfter(file)) {
-				case 1:  // before
+				case 1:	 // before
 					if ((*table)->emphRules[MAX_EMPH_CLASSES + i][endPhraseAfterOffset]) {
 						compileError(
 								file, "Capital sign after last word already defined.");
@@ -3191,7 +3191,7 @@ doOpcode:
 					(*table)->emphRules[MAX_EMPH_CLASSES + i][endPhraseBeforeOffset] =
 							ruleOffset;
 					return 1;
-				case 2:  // after
+				case 2:	 // after
 					if ((*table)->emphRules[MAX_EMPH_CLASSES + i]
 										   [endPhraseBeforeOffset]) {
 						compileError(

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -76,7 +76,7 @@ typedef struct intCharTupple {
 #define MAXPASS 4
 #define MAXSTRING 2048
 #define MAX_MACRO_VAR 100  // maximal number of variable substitutions a macro can contain
-#define MAX_EMPH_CLASSES 10   // maximal number of emphasis classes
+#define MAX_EMPH_CLASSES 10	  // maximal number of emphasis classes
 #define MAX_MODES 6			  // maximal number of modes that can be handled
 #define MAX_SOURCE_FILES 100  // maximal number of files a table can consist of
 
@@ -120,8 +120,8 @@ typedef enum {
 	CTC_UserDefined6 = 0x200000,
 	CTC_UserDefined7 = 0x400000,
 	CTC_UserDefined8 = 0x800000,
-	CTC_EndOfInput = 0x1000000,  // only used by pattern matcher
-	CTC_EmpMatch = 0x2000000,	// only used in TranslationTableRule->before and
+	CTC_EndOfInput = 0x1000000,	 // only used by pattern matcher
+	CTC_EmpMatch = 0x2000000,	 // only used in TranslationTableRule->before and
 								 // TranslationTableRule->after
 	CTC_MidEndNumericMode = 0x4000000,
 	/* At least 37 more bits available in a unsigned long long (at least 64 bits). Used
@@ -278,8 +278,8 @@ typedef enum { /* Op codes */
 	CTO_MultInd,
 	CTO_CompDots,
 	CTO_Comp6,
-	CTO_Class,  /* define a character class */
-	CTO_After,  /* only match if after character in class */
+	CTO_Class,	/* define a character class */
+	CTO_After,	/* only match if after character in class */
 	CTO_Before, /* only match if before character in class 30 */
 	CTO_NoBack,
 	CTO_NoFor,
@@ -496,7 +496,7 @@ typedef struct {
 	int sourceLine;
 	TranslationTableOffset charsnext;			/** next chars entry */
 	TranslationTableOffset dotsnext;			/** next dots entry */
-	TranslationTableCharacterAttributes after;  /** character types which must follow */
+	TranslationTableCharacterAttributes after;	/** character types which must follow */
 	TranslationTableCharacterAttributes before; /** character types which must precede */
 	TranslationTableOffset patterns;			/** before and after patterns */
 	TranslationTableOpcode opcode; /** rule for testing validity of replacement */
@@ -572,7 +572,7 @@ typedef struct { /* translation table */
 			numberedAttributes[8]; /* attributes 0-7 used in match rules (could also be
 								   stored in `characterClasses', but this is slightly
 								   faster) */
-	int usesAttributeOrClass;	  /* 1 = attribute, 2 = class */
+	int usesAttributeOrClass;	   /* 1 = attribute, 2 = class */
 	char *sourceFiles[MAX_SOURCE_FILES + 1];
 
 	/* needed for translation or other api functions */

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -329,22 +329,22 @@ typedef enum { LOU_ROW_BRAILLE = 0X2800 } LOU_UnicodeConstants;
  * Definitions of braille dots
  */
 typedef enum BrailleDots {
-	LOU_DOT_1 = 0X01,	/** dot 1 */
-	LOU_DOT_2 = 0X02,	/** dot 2 */
-	LOU_DOT_3 = 0X04,	/** dot 3 */
-	LOU_DOT_4 = 0X08,	/** dot 4 */
-	LOU_DOT_5 = 0X10,	/** dot 5 */
-	LOU_DOT_6 = 0X20,	/** dot 6 */
-	LOU_DOT_7 = 0X40,	/** dot 7 */
-	LOU_DOT_8 = 0X80,	/** dot 8 */
-	LOU_DOT_9 = 0X100,   /** virtual dot 9 */
-	LOU_DOT_10 = 0X200,  /** virtual dot A */
-	LOU_DOT_11 = 0X400,  /** virtual dot B */
-	LOU_DOT_12 = 0X800,  /** virtual dot C */
+	LOU_DOT_1 = 0X01,	 /** dot 1 */
+	LOU_DOT_2 = 0X02,	 /** dot 2 */
+	LOU_DOT_3 = 0X04,	 /** dot 3 */
+	LOU_DOT_4 = 0X08,	 /** dot 4 */
+	LOU_DOT_5 = 0X10,	 /** dot 5 */
+	LOU_DOT_6 = 0X20,	 /** dot 6 */
+	LOU_DOT_7 = 0X40,	 /** dot 7 */
+	LOU_DOT_8 = 0X80,	 /** dot 8 */
+	LOU_DOT_9 = 0X100,	 /** virtual dot 9 */
+	LOU_DOT_10 = 0X200,	 /** virtual dot A */
+	LOU_DOT_11 = 0X400,	 /** virtual dot B */
+	LOU_DOT_12 = 0X800,	 /** virtual dot C */
 	LOU_DOT_13 = 0X1000, /** virtual dot D */
 	LOU_DOT_14 = 0X2000, /** virtual dot E */
 	LOU_DOT_15 = 0X4000, /** virtual dot F */
-	LOU_DOTS = 0X8000	/** if this bit is true, the widechar represents a dot pattern */
+	LOU_DOTS = 0X8000	 /** if this bit is true, the widechar represents a dot pattern */
 } BrailleDots;
 
 /**

--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -99,7 +99,7 @@ _lou_logMessage(logLevels level, const char *format, ...) {
 	if (level < logLevel) return;
 	if (logCallbackFunction != NULL) {
 #ifdef _WIN32
-		double f = 2.3;  // Needed to force VC++ runtime floating point support
+		double f = 2.3;	 // Needed to force VC++ runtime floating point support
 #endif
 		char *s;
 		size_t len;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1202,13 +1202,13 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 			continue;
 			break;
 		case CTO_NumberRule:
-			itsANumber = 1;  // Starting number
+			itsANumber = 1;	 // Starting number
 			allUpper = 0;
 			while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_LitDigit:
-			itsANumber = 2;  // In the middle of a number
+			itsANumber = 2;	 // In the middle of a number
 			break;
 		case CTO_BegCompRule:
 			itsANumber = 0;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -40,7 +40,7 @@
 #define SYLLABLE_MARKER_2 0x4000
 #define CAPSEMPH 0x8000
 
-#define EMPHASIS 0x3fff  // all typeform bits that can be used
+#define EMPHASIS 0x3fff	 // all typeform bits that can be used
 
 /* bits for wordBuffer */
 #define WORD_CHAR 0x00000001
@@ -2328,7 +2328,7 @@ putCharacters(const widechar *characters, int count, const TranslationTableHeade
 typedef struct {
 	int inPos;			// begin position of the current word in the input
 	int outPos;			// begin position of the current word in the output
-	int emphasisInPos;  // position of the next character in the input for which to insert
+	int emphasisInPos;	// position of the next character in the input for which to insert
 						// emphasis marks
 } LastWord;
 
@@ -2600,7 +2600,7 @@ resolveEmphasisBeginEnd(EmphasisInfo *buffer, const EmphasisClass *class,
 	int last_space = -1;  // position of the last encountered space
 	int emph_start = -1;  // position of the first emphasized (uppercase) character after
 						  // which no unemphasized (lowercase) character was encountered
-	int last_word = -1;   // position of the first space following the last encountered
+	int last_word = -1;	  // position of the first space following the last encountered
 						  // character if that character was emphasized (uppercase)
 	int emph = 0;		  // whether or not the last encountered character was emphasized
 						  // (uppercase) and happened in the current word
@@ -2677,7 +2677,7 @@ resolveEmphasisWords(EmphasisInfo *buffer, const EmphasisClass *class,
 	int word_start = -1;  // start position of the current emphasized word section
 	int char_cnt = 0;  // number of emphasizable characters within the current emphasized
 					   // word section
-	int last_char = -1;  // position of the last emphasizable character
+	int last_char = -1;	 // position of the last emphasizable character
 	const TranslationTableOffset *emphRule = table->emphRules[class->rule];
 	int letter_defined = emphRule[letterOffset];
 	int endphraseafter_defined = emphRule[begPhraseOffset] &&
@@ -3568,7 +3568,7 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 
 	while (pos < input->length) { /* the main translation loop */
 		if (pos >= compbrlStart && pos < compbrlEnd) {
-			int cs = 2;  // cursor status for this call
+			int cs = 2;	 // cursor status for this call
 			if (!doCompTrans(pos, compbrlEnd, table, &pos, input, output, posMapping,
 						emphasisBuffer, &transRule, cursorPosition, &cs, mode))
 				goto failure;
@@ -4027,7 +4027,7 @@ lou_hyphenate(const char *tableList, const widechar *inbuf, int inlen, char *hyp
 			else
 				textHyphens[k] = '0';
 		if (wordEnd == textLen) break;
-		textHyphens[wordEnd] = '0';  // because hyphenateWord sets it to 0
+		textHyphens[wordEnd] = '0';	 // because hyphenateWord sets it to 0
 		wordStart = wordEnd + 1;
 	}
 

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -302,7 +302,7 @@ read_table(yaml_event_t *start_event, yaml_parser_t *parser, const char *display
 	else if (!_lou_getTranslationTable(v->name))
 		error_at_line(EXIT_FAILURE, 0, file_name, start_event->start_mark.line + 1,
 				"Table %s not valid", v->name);
-	emph_classes = lou_getEmphClasses(v->name);  // get declared emphasis classes
+	emph_classes = lou_getEmphClasses(v->name);	 // get declared emphasis classes
 	table_name = strdup((char *)v->name);
 	if (!display_table) {
 		if (v->content) {
@@ -892,7 +892,7 @@ customTableResolver(const char *tableList, const char *base) {
 	return _lou_defaultTableResolver(tableList, base);
 }
 
-#endif  // HAVE_LIBYAML
+#endif	// HAVE_LIBYAML
 
 int
 main(int argc, char *argv[]) {
@@ -938,8 +938,8 @@ main(int argc, char *argv[]) {
 #ifndef HAVE_LIBYAML
 	fprintf(stderr, "Skipping tests for %s as libyaml was not found\n", argv[1]);
 	return EXIT_SKIPPED;
-#endif  // not HAVE_LIBYAML
-#endif  // WITHOUT_YAML
+#endif	// not HAVE_LIBYAML
+#endif	// WITHOUT_YAML
 
 #ifndef WITHOUT_YAML
 #ifdef HAVE_LIBYAML
@@ -1105,6 +1105,6 @@ main(int argc, char *argv[]) {
 
 	return errors ? 1 : 0;
 
-#endif  // HAVE_LIBYAML
-#endif  // not WITHOUT_YAML
+#endif	// HAVE_LIBYAML
+#endif	// not WITHOUT_YAML
 }


### PR DESCRIPTION
Change the preferred clang-format to version 9 as that is contained in all versions of Ubuntu since 20.04 (which the CI runner is using) up to Ubuntu 22.04. Seems like a pretty save bet. 

BTW my current dev machine doesn't even have clang-format-7 anymore.