### PR TITLE
Simplify liblouis Emacs mode and make it actually usefull.

### DIFF
--- a/contrib/liblouis.el
+++ b/contrib/liblouis.el
@@ -1,6 +1,6 @@
 ;;; liblouis.el --- mode for editing liblouis translation tables
 
-;; Copyright (C) 2009, 2011 Christian Egli
+;; Copyright (C) 2022 Swiss Library for the Blind, Visually Impaired and Print Disabled
 
 ;; This file is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published
@@ -33,109 +33,63 @@
                 ;; ERROR: foo.txt: line 18: only book doctypes can contain level 0 sections
                 '("^\\(ERROR\\|WARNING\\|DEPRECATED\\): \\([^:]*\\): line \\([0-9]+\\):" 2 3)))
 
-(defconst liblouis-comment-regexp "\\(\\s-+.*\\)??")
+(defvar liblouis-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    (modify-syntax-entry ?# "<" table)
+    (modify-syntax-entry ?\n ">" table)
+    (modify-syntax-entry ?\" "." table)
+    table)
+  "Syntax table for `liblouis-mode'.")
 
 (defconst liblouis-font-lock-keywords
   (list
-   
-   ;; Comment Lines
-   (cons "^#.*$" 'font-lock-comment-face)
-   
-   ;; Opcodes (with one word arg)
-   (list
-    (concat "^"
-	    (regexp-opt
-	     '("include" "locale" "noletsign" "noletsignbefore" "noletsignafter"
-	       "nocont" "compbrl" "contraction" "emphclass") 'words)
-	    "\\s-+\\([^       ]+\\)" liblouis-comment-regexp "$")
-    '(1 font-lock-keyword-face)
-    '(2 font-lock-constant-face)
-    '(3 font-lock-comment-face nil t))
-   
-   ;; Opcodes (with one dot pattern arg)
-   (list
-    (concat "^"
-	    (regexp-opt
-	     '("numsign" "capsletter" "firstwordital"
-	       "lastworditalbefore" "lastworditalafter"
-	       "firstletterital" "lastletterital" "singleletterital"
-	       "firstwordbold" "lastwordboldbefore" "lastwordboldafter"
-	       "firstletterbold" "lastletterbold" "singleletterbold"
-	       "firstwordunder" "lastwordunderbefore" "lastwordunderafter"
-	       "firstletterunder" "lastletterunder" "singleletterunder"
-	       "begcomp" "endcomp"
-	       "begcaps" "endcaps" "letsign" "nocontractsign"
-	       "exactdots") 'words)
-	    "\\s-+\\([0-9-@]+\\)" liblouis-comment-regexp "$")
-    '(1 font-lock-keyword-face)
-    '(2 font-lock-constant-face)
-    '(3 font-lock-comment-face nil t))
-   
-   ;; Opcodes (with two args)
-   (list
-    (concat "^"
-	    (regexp-opt
-	     '("comp6" "after" "before" "space" "punctuation" "digit" "lowercase" "uppercase"
-	       "letter" "uplow" "litdigit" "sign" "math" "display" "repeated"  "always"
-	       "nocross" "syllable" "largesign" "word" "partword" "joinnum" "joinword"
-	       "lowword" "sufword" "prfword" "begword" "begmidword" "midword" "midendword"
-	       "endword" "prepunc" "postpunc" "begnum" "midnum" "endnum" "decpoint" "hyphen"
-	       "begemphword" "endemphword" "begemphphrase" "lenemphphrase") 'words)
-	    "\\s-+\\([^       ]+?\\)\\s-+\\([-0-9=@a-f]+\\)" liblouis-comment-regexp "$")
-    '(1 font-lock-keyword-face)
-    '(2 font-lock-string-face)
-    '(3 font-lock-constant-face)
-    '(4 font-lock-comment-face nil t))
-   
-   ;; Opcodes (with three args)
-   (list
-    (concat "^"
-	    (regexp-opt
-	     '("endemphphrase") 'words)
-	    "\\s-+\\([^       ]+?\\)\\s-+\\([^       ]+?\\)\\s-+\\([-0-9=@a-f]+\\)" liblouis-comment-regexp "$")
-    '(1 font-lock-keyword-face)
-    '(2 font-lock-string-face)
-    '(3 font-lock-string-face)
-    '(4 font-lock-constant-face)
-    '(5 font-lock-comment-face nil t))
-
-   ;; Opcodes (with two args where the second one is not a dot pattern)
-   (list
-    (concat "^"
-	    (regexp-opt
-	     '("class" "replace" "context" "correct" "pass2" "pass3" "pass4" ) 'words)
-	    "\\s-+\\([^       ]+?\\)\\s-+\\([^        ]+\\)" liblouis-comment-regexp "$")
-    '(1 font-lock-keyword-face)
-    '(2 font-lock-string-face)
-    '(3 font-lock-constant-face)
-    '(4 font-lock-comment-face nil t))
-					; FIXME: "multind" "lenitalphrase" lenboldphrase lenunderphrase  "swapcd" "swapdd" "capsnocont"
-   )
-  "Default expressions to highlight in liblouis mode.")
+   (cons
+    (regexp-opt
+     '("include" "undefined" "display" "multind"
+       "space" "punctuation" "digit" "grouping" "letter" "base"
+       "lowercase" "uppercase" "litdigit" "sign" "math"
+       "modeletter" "capsletter" "begmodeword" "begcapsword" "endcapsword"
+       "capsmodechars" "begcaps" "endcaps" "begcapsphrase" "endcapsphrase"
+       "lencapsphrase" "letsign" "noletsign" "noletsignbefore" "noletsignafter"
+       "nocontractsign" "numsign" "numericnocontchars" "numericmodechars"
+       "midendnumericmodechars" "begmodephrase" "endmodephrase" "lenmodephrase"
+       "seqdelimiter" "seqbeforechars" "seqafterchars" "seqafterpattern"
+       "seqafterexpression" "class" "emphclass" "begemph" "endemph" "noemphchars"
+       "emphletter" "begemphword" "endemphword" "emphmodechars" "begemphphrase"
+       "endemphphrase" "lenemphphrase" "decpoint" "hyphen" "capsnocont" "compbrl" "comp6"
+       "nocont" "replace" "always" "repeated" "repword" "rependword" "largesign" "word"
+       "syllable" "joinword" "lowword" "contraction" "sufword" "prfword" "begword"
+       "begmidword" "midword" "midendword" "endword" "partword" "exactdots" "prepunc"
+       "postpunc" "begnum" "midnum" "endnum" "joinnum" "begcomp" "endcomp" "attribute"
+       "swapcd" "swapdd" "swapcc" "context" "pass2" "pass3" "pass4" "correct" "match" "literal") 'words)
+    font-lock-builtin-face)
+   (cons (regexp-opt '("before" "after" "noback" "nofor" "nocross") 'words) font-lock-type-face))
+  "Default expressions to highlight in `liblouis-mode'.")
 
 ;;###autoload
 (define-derived-mode liblouis-mode prog-mode "liblouis"
   "Major mode for editing liblouis translation tables.
 Turning on liblouis mode runs the normal hook `liblouis-mode-hook'.
 "
-  (modify-syntax-entry ?\'  ".")
-  (modify-syntax-entry ?# "<")
-  (modify-syntax-entry ?\n ">")
+  (set-syntax-table liblouis-mode-syntax-table)
+  (setq-local compile-command (concat "lou_checktable " buffer-file-name))
+  (setq-local require-final-newline t)
 
-  (set (make-local-variable 'compile-command)
-       (concat "lou_checktable " buffer-file-name))
+  (setq-local comment-start "# ")
+  (setq-local comment-end "")
+  (setq-local comment-start-skip "#[ \t]*")
 
-  (set (make-local-variable 'require-final-newline) t)
+  (setq font-lock-defaults '(liblouis-font-lock-keywords
+			     nil				; KEYWORDS-ONLY: no
+			     nil				; CASE-FOLD: no
+			     ((?_ . "w"))			; SYNTAX-ALIST
+			     ))
 
-  (set (make-local-variable 'font-lock-defaults)
-       '(liblouis-font-lock-keywords
-         nil				; KEYWORDS-ONLY: no
-         nil				; CASE-FOLD: no
-         ((?_ . "w"))			; SYNTAX-ALIST
-	 ))
-
-  (set (make-local-variable 'comment-start) "#")
+  (setq-local comment-start "#")
 
   (run-hooks 'liblouis-mode-hook))
+
+;;;###autoload
+(add-to-list 'magic-mode-alist '("^#[[:blank:]]+liblouis: " . liblouis-mode))
 
 (provide 'liblouis-mode)


### PR DESCRIPTION
No longer try to actually parse all the statements. Just highlight
comments, opcodes and prefixes. Also make sure '"' is handled
properly (as plain punctuation), wrapping in comments works correctly.
Lastly there is an attempt to load the mode automatically based on the
magic string "# liblouis: " at the beginning of the file.