### PR TITLE
Make end comments explicit

### DIFF
--- a/tables/Es-Es-G0.utb
+++ b/tables/Es-Es-G0.utb
@@ -36,7 +36,7 @@
 # -----------------------------------------------------------------------------
 
 
-space \s 0      			# blank 32
+space \s 0      	# blank 32
 space \t 9              # tab 9
 space \x001B 1b         # escape
 space \x000A 0          # lf
@@ -45,204 +45,204 @@ space \x00A0 0          # Espacio de no separación
 
 # all except 0 are the same, so define 0 here to take higher presidence
 # Also define ó (lowercase o acute) not to clash with the definition of 0 in original include.
-digit 0 34678				cero
-uppercase \x00d3 3467     o con acento
-lowercase \x00f3 346      o con acento
+digit 0 34678		  # cero
+uppercase \x00d3 3467     # o con acento
+lowercase \x00f3 346      # o con acento
 
 include digits6DotsPlusDot6.uti
 include latinLetterDef8Dots.uti
 
-lowercase \x00e7 123468      c cedilla
-lowercase \x00e1 12356       a con acento
-lowercase \x00e9 2346        e con acento
-lowercase \x00ed 34          i con acento
-lowercase \x00fa 23456       u con acento
-lowercase \x00e0 123568      a grave
-lowercase \x00e8 23468       e grave
-lowercase \x00ec 348         i grave
-lowercase \x00f2 3468        o grave
-lowercase \x00f9 234568      u grave
-lowercase \x00e2 18          a con circunflejo
-lowercase \x00ea 158         e con circunflejo
-lowercase \x00ee 248         i con circunflejo
-lowercase \x00f4 1358        o con circunflejo
-lowercase \x00fb 1368        u con circunflejo
-lowercase \x00e4 3458        a con diéresis
-lowercase \x00eb 12468       e con diéresis
-lowercase \x00ef 258         i con diéresis
-lowercase \x00f6 2468        o con diéresis
-lowercase \x00fc 12568       u con diéresis
-lowercase \x00fd 2348        ye con acento agudo
-lowercase \x00FF 67          ye con diéresis
-lowercase \x00e6 1348        ae
-lowercase \x0153 1238        oe
-lowercase \x009C 1238        oe
-lowercase \x00E3 168         a con tilde
-lowercase \x00F5 4567        o con tilde
-lowercase \x00F1 124568      letra eñe
-uppercase \x00c7 1234678     c cedilla
-uppercase \x00c1 123567      a con acento
-uppercase \x00c9 23467       e con acento
-uppercase \x00cd 347         i con acento
-uppercase \x00da 234567      u con acento
-uppercase \x00c0 1235678     a grave
-uppercase \x00c8 234678      e grave
-uppercase \x00cc 345         i grave
-uppercase \x00d2 2458        o grave
-uppercase \x00d9 2345678     u grave
-uppercase \x00c2 178         a con circunflejo
-uppercase \x00ca 1578        e con circunflejo
-uppercase \x00ce 2478        i con circunflejo
-uppercase \x00d4 13578       o con circunflejo
-uppercase \x00db 13678       u con circunflejo
-uppercase \x00c4 34578       a con diéresis
-uppercase \x00cb 124678      e con diéresis
-uppercase \x00cf 1245678     i con diéresis
-uppercase \x00d6 24678       o con diéresis
-uppercase \x00dc 125678      u con diéresis
-uppercase \x00dd 1567        ye con acento agudo
-uppercase \x009F 367         ye con diéresis
-uppercase \x00c6 38          ae
-uppercase \x0152 1468        oe
-uppercase \x008C 1468        oe
-uppercase \x00C3 3567        a con tilde
-uppercase \x00D5 12458       o con tilde
-uppercase \x00D1 124567      letra eñe
+lowercase \x00e7 123468      # c cedilla
+lowercase \x00e1 12356       # a con acento
+lowercase \x00e9 2346        # e con acento
+lowercase \x00ed 34          # i con acento
+lowercase \x00fa 23456       # u con acento
+lowercase \x00e0 123568      # a grave
+lowercase \x00e8 23468       # e grave
+lowercase \x00ec 348         # i grave
+lowercase \x00f2 3468        # o grave
+lowercase \x00f9 234568      # u grave
+lowercase \x00e2 18          # a con circunflejo
+lowercase \x00ea 158         # e con circunflejo
+lowercase \x00ee 248         # i con circunflejo
+lowercase \x00f4 1358        # o con circunflejo
+lowercase \x00fb 1368        # u con circunflejo
+lowercase \x00e4 3458        # a con diéresis
+lowercase \x00eb 12468       # e con diéresis
+lowercase \x00ef 258         # i con diéresis
+lowercase \x00f6 2468        # o con diéresis
+lowercase \x00fc 12568       # u con diéresis
+lowercase \x00fd 2348        # ye con acento agudo
+lowercase \x00FF 67          # ye con diéresis
+lowercase \x00e6 1348        # ae
+lowercase \x0153 1238        # oe
+lowercase \x009C 1238        # oe
+lowercase \x00E3 168         # a con tilde
+lowercase \x00F5 4567        # o con tilde
+lowercase \x00F1 124568      # letra eñe
+uppercase \x00c7 1234678     # c cedilla
+uppercase \x00c1 123567      # a con acento
+uppercase \x00c9 23467       # e con acento
+uppercase \x00cd 347         # i con acento
+uppercase \x00da 234567      # u con acento
+uppercase \x00c0 1235678     # a grave
+uppercase \x00c8 234678      # e grave
+uppercase \x00cc 345         # i grave
+uppercase \x00d2 2458        # o grave
+uppercase \x00d9 2345678     # u grave
+uppercase \x00c2 178         # a con circunflejo
+uppercase \x00ca 1578        # e con circunflejo
+uppercase \x00ce 2478        # i con circunflejo
+uppercase \x00d4 13578       # o con circunflejo
+uppercase \x00db 13678       # u con circunflejo
+uppercase \x00c4 34578       # a con diéresis
+uppercase \x00cb 124678      # e con diéresis
+uppercase \x00cf 1245678     # i con diéresis
+uppercase \x00d6 24678       # o con diéresis
+uppercase \x00dc 125678      # u con diéresis
+uppercase \x00dd 1567        # ye con acento agudo
+uppercase \x009F 367         # ye con diéresis
+uppercase \x00c6 38          # ae
+uppercase \x0152 1468        # oe
+uppercase \x008C 1468        # oe
+uppercase \x00C3 3567        # a con tilde
+uppercase \x00D5 12458       # o con tilde
+uppercase \x00D1 124567      # letra eñe
 
-punctuation , 2			coma
-punctuation ; 23		punto y coma
-punctuation : 25		dos puntos
-punctuation - 36		guión
-punctuation . 3		punto
-punctuation ? 26		cerrar interrogación
-punctuation ! 2357		cerrar admiración
-punctuation \x0022 56 	comillas
-punctuation \x201c 14568 	abrir comillas
-punctuation \x201d 12348 	cerrar comillas
-punctuation ( 1268		abre paréntesis
-punctuation ) 3457		cierra paréntesis
-punctuation ' 4			apóstrofo
-punctuation \x00ab 238		comillas angulares izquierda
-punctuation \x00bb 567		comillas angulares derecha
-punctuation [ 2367		abre corchetes
-punctuation ] 3568	 	cierra corchetes
-punctuation { 46			abre llave
-punctuation } 35			cierra llave
+punctuation , 2              # coma
+punctuation ; 23             # punto y coma
+punctuation : 25             # dos puntos
+punctuation - 36             # guión
+punctuation . 3              # punto
+punctuation ? 26             # cerrar interrogación
+punctuation ! 2357           # cerrar admiración
+punctuation \x0022 56        # comillas
+punctuation \x201c 14568     # abrir comillas
+punctuation \x201d 12348     # cerrar comillas
+punctuation ( 1268           # abre paréntesis
+punctuation ) 3457           # cierra paréntesis
+punctuation ' 4              # apóstrofo
+punctuation \x00ab 238       # comillas angulares izquierda
+punctuation \x00bb 567       # comillas angulares derecha
+punctuation [ 2367           # abre corchetes
+punctuation ] 3568           # cierra corchetes
+punctuation { 46             # abre llave
+punctuation } 35             # cierra llave
 
-sign * 256						asterisco
-sign \\ 123456						barra invertida
-sign @ 5					arroba
-sign % 456					por ciento
-sign _ 6								subrayado
-sign # 3456					signo de número
-sign \x0060 58					acento grave
-sign ^ 45					circunflejo
-sign \x007E   57     #126 ~    tilde
-sign \x007C 4568   # barra vertical
-sign \x007F 7   # borrar
+sign * 256	    # asterisco
+sign \\ 123456	    # barra invertida
+sign @ 5	    # arroba
+sign % 456	    # por ciento
+sign _ 6	    # subrayado
+sign # 3456	    # signo de número
+sign \x0060 58	    # acento grave
+sign ^ 45	    # circunflejo
+sign \x007E   57    # 126 ~    tilde
+sign \x007C 4568    # barra vertical
+sign \x007F 7       # borrar
 sign \x00a1 23578   # abrir admiración
-sign \x00A6 478   # barra vertical cortada
-sign \x00A7 167   # sección
-sign \x00A8 268   # diéresis
+sign \x00A6 478     # barra vertical cortada
+sign \x00A7 167     # sección
+sign \x00A8 268     # diéresis
 sign \x00A9 23567   # copyright
-sign \x00AC 257   # guión opcional
+sign \x00AC 257     # guión opcional
 sign \x20AC 12358   # euros
-sign \x00AD 2358   # soft hyphen
-sign \x00AE 2368   # registrado
+sign \x00AD 2358    # soft hyphen
+sign \x00AE 2368    # registrado
 sign \x00AF 24568   # macron
 sign \x00B1 12467   # más-menos
 sign \x00B5 13468   # my
 sign \x00B6 14567   # párrafo
 sign \x00B7 14678   # punto centrado
-sign \x00B9 237   # Super uno
-sign \x00BA 5678   # ordinal masculino
-sign \x00AA 23568  # ordinal femenino 
-sign \x00BF 267   # abrir interrogación
-sign \x00C5 12368   #*a mayúscula con círculo superescrito
+sign \x00B9 237     # Super uno
+sign \x00BA 5678    # ordinal masculino
+sign \x00AA 23568   # ordinal femenino
+sign \x00BF 267     # abrir interrogación
+sign \x00C5 12368   # *a mayúscula con círculo superescrito
 
 sign \x00D0 13458   # letra eth mayúscula
-sign \x00D7 1678   # multiplicado por
+sign \x00D7 1678    # multiplicado por
 sign \x00D8 34567   # Alfa
-sign \x00DE 123458   # Thorn
-sign \x00DF 128   # Beta
+sign \x00DE 123458  # Thorn
+sign \x00DF 128     # Beta
 sign \x00E5 15678   # a con círculo superescrito
-sign \x00F0 235678   # letra eth
-sign \x00F7 2578   # dividido por
-sign \x00F8 457   # latin small letter o with stroke
-sign \x00FE 1568   # thorn
-sign \x00A8 268			diéresis
+sign \x00F0 235678  # letra eth
+sign \x00F7 2578    # dividido por
+sign \x00F8 457     # latin small letter o with stroke
+sign \x00FE 1568    # thorn
+sign \x00A8 268     # diéresis
 
-math + 235				más
-math = 2356				igual
-math \x00d7 1678					multiplicado por
-math < 236				menor que
-math > 356				mayor que
-math / 3478						barra oblicua
-math \x00F7 2578		dividido por
+math + 235	    # más
+math = 2356	    # igual
+math \x00d7 1678    # multiplicado por
+math < 236	    # menor que
+math > 356	    # mayor que
+math / 3478	    # barra oblicua
+math \x00F7 2578    # dividido por
 
-sign \x00a9 23567							copyright
-sign \x00b0 8						grado
-sign & 12346					ampersand
-sign \x00a2 12678						centavo
-sign \x00a4 2567						
-sign \x00a3 2378						libra
-sign \x00a7 167					sección
-sign \x0024 123467						dólar
-sign \x00a5 145678					yen
-sign \x00b9 237						super 1
-sign \x00b2 47					al cuadrado
-sign \x00b3 568					al cubo
-sign \x00bc 1467			un cuarto
-sign \x00bd 468			un medio
-sign \x00be 48		tres cuartos
+sign \x00a9 23567   # copyright
+sign \x00b0 8	    # grado
+sign & 12346	    # ampersand
+sign \x00a2 12678   # centavo
+sign \x00a4 2567
+sign \x00a3 2378    # libra
+sign \x00a7 167     # sección
+sign \x0024 123467  # dólar
+sign \x00a5 145678  # yen
+sign \x00b9 237     # super 1
+sign \x00b2 47	    # al cuadrado
+sign \x00b3 568     # al cubo
+sign \x00bc 1467    # un cuarto
+sign \x00bd 468     # un medio
+sign \x00be 48	    # tres cuartos
 
-sign \x0081 358		sin nombre
-sign \x0082 37		por
-sign \x201a 37		por
-sign \x0083 1248		signo
-sign \x0192 1248		signo
-sign \x0084 78		signo
-sign \x201e 78		signo
-sign \x0085 1267		elipsis
-sign \x2026 1267		elipsis
-sign \x0086 28		sin nombre
-sign \x2020 28		sin nombre
-sign \x0087 23458		sin nombre
-sign \x2021 23458		sin nombre
-sign \x0088 458		sin nombre
-sign \x02c6 23458		sin nombre
-sign \x0089 45678		sin nombre
-sign \x2030 45678		sin nombre
-sign \x008a 1234568		sh mayúscula
-sign \x0160 1234568		sh mayúscula
-sign \x008b 1258		
-sign \x2039 1258		
-sign \x008d 357		sin nombre
-sign \x008e 148		sin nombre
-sign \x017d 148		sin nombre
-sign \x008f 58		
-sign \x0090 68		sin 	nombre
-sign \x2018 4		apóstrofo
-sign \x2019 4		apóstrofo
-sign \x0095 1458		signo
-sign \x2022 1458		signo
-sign \x0096 368		guión
-sign \x2013 368		guión
-sign \x0097 3678		guión
-sign \x2014 3678		guión
-sign \x0098 134568		tilde
-sign \x02dc 134568		tilde
-sign \x0099 2467		marca registrada
-sign \x2122 2467		marca registrada
-sign \x009a 34568		signo
-sign \x203a 34568		signo
-sign \x0161 12567		sh
-sign \x009d 25678		
-sign \x009e 2568		
-sign \x017e 2568		
-sign \x009f 367		
-sign \x0178 367		
-sign \x00b4 467     acento agudo
-sign \x00B8 135678     z con caron
+sign \x0081 358     # sin nombre
+sign \x0082 37	    # por
+sign \x201a 37	    # por
+sign \x0083 1248    # signo
+sign \x0192 1248    # signo
+sign \x0084 78	    # signo
+sign \x201e 78	    # signo
+sign \x0085 1267    # elipsis
+sign \x2026 1267    # elipsis
+sign \x0086 28	    # sin nombre
+sign \x2020 28	    # sin nombre
+sign \x0087 23458   # sin nombre
+sign \x2021 23458   # sin nombre
+sign \x0088 458     # sin nombre
+sign \x02c6 23458   # sin nombre
+sign \x0089 45678   # sin nombre
+sign \x2030 45678   # sin nombre
+sign \x008a 1234568 # sh mayúscula
+sign \x0160 1234568 # sh mayúscula
+sign \x008b 1258
+sign \x2039 1258
+sign \x008d 357     # sin nombre
+sign \x008e 148     # sin nombre
+sign \x017d 148     # sin nombre
+sign \x008f 58
+sign \x0090 68	    # sin nombre
+sign \x2018 4	    # apóstrofo
+sign \x2019 4	    # apóstrofo
+sign \x0095 1458    # signo
+sign \x2022 1458    # signo
+sign \x0096 368     # guión
+sign \x2013 368     # guión
+sign \x0097 3678    # guión
+sign \x2014 3678    # guión
+sign \x0098 134568  # tilde
+sign \x02dc 134568  # tilde
+sign \x0099 2467    # marca registrada
+sign \x2122 2467    # marca registrada
+sign \x009a 34568   # signo
+sign \x203a 34568   # signo
+sign \x0161 12567   # sh
+sign \x009d 25678
+sign \x009e 2568
+sign \x017e 2568
+sign \x009f 367
+sign \x0178 367
+sign \x00b4 467     # acento agudo
+sign \x00B8 135678  # z con caron
 
-noback sign \x25CF 256 black circle
+noback sign \x25CF 256 # black circle

--- a/tables/Lv-Lv-g1.utb
+++ b/tables/Lv-Lv-g1.utb
@@ -33,42 +33,42 @@ include spaces.uti
 
 # ----------- define all chars --------------------------------------
 
-punctuation ! 235				exclamation sign 						x0021
-punctuation " 356				double quote								x0022
-sign # 3456							number sign									x0023
-sign $ 4-256						dollar sign									x0024
-math % 3456-245-356					percent sign								x0025
-sign & 4-12346					ampersand										z0026
-punctuation ' 3					apostrophe									x0027
-punctuation ( 2356			left parenthesis						x0028
-punctuation ) 2356			right parenthesis						x0029
-sign * 35						asterisk										x002A
-math + 235						plus												002B
-punctuation , 2					coma												002C
-punctuation - 36			hyphen-minus								002D
-punctuation . 256				point												002E
-math / 34								solidus											002F
+punctuation ! 235		# exclamation sign 	x0021
+punctuation " 356		# double quote		x0022
+sign # 3456			# number sign		x0023
+sign $ 4-256			# dollar sign		x0024
+math % 3456-245-356		# percent sign		x0025
+sign & 4-12346			# ampersand		z0026
+punctuation ' 3			# apostrophe		x0027
+punctuation ( 2356		# left parenthesis	x0028
+punctuation ) 2356		# right parenthesis	x0029
+sign * 35			# asterisk		x002A
+math + 235			# plus			002B
+punctuation , 2			# coma			002C
+punctuation - 36		# hyphen-minus		002D
+punctuation . 256		# point			002E
+math / 34			# solidus		002F
 
-punctuation : 25				colon								x003A
-punctuation ; 23				semicolon						x003B
-punctuation < 246				less-than sign			x003C
-math = 2356						equal sign					x003D
-punctuation ? 26				question mark				x003F
-sign @ 4				commercial at				x0040
+punctuation : 25		# colon			x003A
+punctuation ; 23		# semicolon		x003B
+punctuation < 246		# less-than sign	x003C
+math = 2356			# equal sign		x003D
+punctuation ? 26		# question mark		x003F
+sign @ 4			# commercial at		x0040
 
-lowercase \x0101 16		letter A with macron
-lowercase \x010D 146		letter C with caron
-lowercase \x0113 156		letter E with macron
-lowercase \x0123 12456		letter g with cedilla
-lowercase \x012B 246		letter I with macron
-lowercase \x0137 136		letter K with cedilla
-lowercase \x013C 1236		letter L with cedilla
-lowercase \x0146 13456		Letter N with cedilla
-lowercase \x014D 1356		letter O with macron
-lowercase \x0157 12356		letter R with cedilla
-lowercase \x0161 2346		letter S with caron
-lowercase \x016B 346		letter U with macron
-lowercase \x017E 3456		letter Z with caron
+lowercase \x0101 16		# letter A with macron
+lowercase \x010D 146		# letter C with caron
+lowercase \x0113 156		# letter E with macron
+lowercase \x0123 12456		# letter g with cedilla
+lowercase \x012B 246		# letter I with macron
+lowercase \x0137 136		# letter K with cedilla
+lowercase \x013C 1236		# letter L with cedilla
+lowercase \x0146 13456		# Letter N with cedilla
+lowercase \x014D 1356		# letter O with macron
+lowercase \x0157 12356		# letter R with cedilla
+lowercase \x0161 2346		# letter S with caron
+lowercase \x016B 346		# letter U with macron
+lowercase \x017E 3456		# letter Z with caron
 
 # define the dot combinations that are different from the default: U, V and Z
 # these definitions need to be placed before AND after the "latinLetterDef6Dots" include
@@ -78,114 +78,114 @@ lowercase u 34
 lowercase v 2456
 lowercase z 345
 include latinLetterDef6Dots.uti
-include digits6Dots.uti # Must come after letters.
-include litdigits6Dots.uti # Must come after letters.
+include digits6Dots.uti		# Must come after letters.
+include litdigits6Dots.uti 	# Must come after letters.
 lowercase u 34
 lowercase v 2456
 lowercase z 345
 
-math > 135							greater-than sign		x003E
-punctuation [ 12356		left square bracket		x005B
-sign \\ 56-36				reverse solidus				x005C
-punctuation ] 23456			right square bracket	x005D
-sign ^ 46								circumflex accent			x005E
-sign _ 6							low line							x005F
-sign ` 3							grave accent					x0060
+math > 135			# greater-than sign	x003E
+punctuation [ 12356		# left square bracket	x005B
+sign \\ 56-36			# reverse solidus		x005C
+punctuation ] 23456		# right square bracket	x005D
+sign ^ 46			# circumflex accent	x005E
+sign _ 6			# low line		x005F
+sign ` 3			# grave accent		x0060
 
-# a - z								# 97 - 122							x0061-x007A
+# a - z	 97 - 122		x0061-x007A
 
-punctuation { 12346		left curly bracket		x007B
-sign | 456							vertical line					x007C
-punctuation } 13456		right curly bracket		x007D
-math ~ 25-25								tilde									x007E
-sign \x0080 15-136-1235-135										x0080
+punctuation { 12346		# left curly bracket	x007B
+sign | 456			# vertical line		x007C
+punctuation } 13456		# right curly bracket	x007D
+math ~ 25-25			# tilde			x007E
+sign \x0080 15-136-1235-135	#			x0080
 
-sign ¢ 4-14				cent sign																			x00A2
-sign £ 4-123			pound sign																		x00A3
-sign ¤ 45-15			currency sign																	x00A4
-sign ¥ 45-13456		yen	sign																			x00A5
-sign € 4-15		euro sign																			x20AC
-sign § 346				section sign																	x00A7
-sign © 2356-6-14-2356		copyright																x00A9
-punctuation « 236		left-pointing double angle quotation 		x00AB
-punctuation ¬ 1256		not sign									x00AC
-punctuation \x00AD 36 soft hyphen
-sign ° 356			degree sign																		x00B0
-sign ² 4-6-126		superscript 2 sign														x00B2
-sign ³ 4-6-146		superscript 3 sign														x00B3
-sign µ 46-134			micro sign																		x00B5
-sign ¶ 1456 pilcrow sign (paragraph)											x00B6
-sign ¹ 156				superscript 1 sign														x00B9
-punctuation » 356		right-pointing double angle quotation		x00BB
-math ¼ 6-16-34-1456		vulgar fraction one quarter								x00BC
-math ½ 6-16-34-126		vulgar fraction one half									x00BD
-math ¾ 6-126-34-1456	vulgar fraction 3 quarters								x00BE
+sign ¢ 4-14			# cent sign		x00A2
+sign £ 4-123			# pound sign		x00A3
+sign ¤ 45-15			# currency sign		x00A4
+sign ¥ 45-13456			# yen sign 		x00A5
+sign € 4-15			# euro sign		x20AC
+sign § 346			# section sign		x00A7
+sign © 2356-6-14-2356		# copyright		x00A9
+punctuation « 236		# left-pointing double angle quotation x00AB
+punctuation ¬ 1256		# not sign		x00AC
+punctuation \x00AD 36 		# soft hyphen
+sign ° 356			# degree sign		x00B0
+sign ² 4-6-126			# superscript 2 sign	x00B2
+sign ³ 4-6-146			# superscript 3 sign	x00B3
+sign µ 46-134			# micro sign		x00B5
+sign ¶ 1456 			# pilcrow sign (paragraph) x00B6
+sign ¹ 156			# superscript 1 sign	x00B9
+punctuation » 356		# right-pointing double angle quotation x00BB
+math ¼ 6-16-34-1456		# vulgar fraction one quarter x00BC
+math ½ 6-16-34-126		# vulgar fraction one half    x00BD
+math ¾ 6-126-34-1456		# vulgar fraction 3 quarters  x00BE
 
 
 
-lowercase \x00E0 12356	letter a with grave							00E0
-lowercase \x00E1 16			letter a with acute									x00E1
-lowercase \x00E2 16					letter a with circumflex						x00E2
-lowercase \x00E3 126		letter a with tilde											x00E3
-lowercase ä 1356				A with diaeresis											00E4
-lowercase å 16					A with ring above											00E5
-lowercase \x00E6 456	ae															x00C6
-lowercase ç 12346							letter c with cedilla					00E7
-lowercase è 2346								e with grave									00E8
-lowercase \x00E9 123456			e with acute									x00E9
-lowercase \x00EA 126			e with circumflex							x00EA
-lowercase \x00EB 1246		e with diaeresis								x00EB
-lowercase \x00ED 34			i with acute										x00ED
-lowercase \x00EE 146		i with circumflex								x00EE
-lowercase \x00EF 12456	i with diaeresis								00EF
+lowercase \x00E0 12356		# letter a with grave	00E0
+lowercase \x00E1 16		# letter a with acute	x00E1
+lowercase \x00E2 16		# letter a with circumflex x00E2
+lowercase \x00E3 126		# letter a with tilde	x00E3
+lowercase ä 1356		# A with diaeresis	00E4
+lowercase å 16			# A with ring above	00E5
+lowercase \x00E6 456		# ae			x00C6
+lowercase ç 12346		# letter c with cedilla	00E7
+lowercase è 2346		# e with grave		00E8
+lowercase \x00E9 123456		# e with acute		x00E9
+lowercase \x00EA 126		# e with circumflex	x00EA
+lowercase \x00EB 1246		# e with diaeresis	x00EB
+lowercase \x00ED 34		# i with acute		x00ED
+lowercase \x00EE 146		# i with circumflex	x00EE
+lowercase \x00EF 12456		# i with diaeresis	00EF
 
-lowercase \x00F3	246		O with acute										00F3
-lowercase \x00F4 1456		o with circumflex												x00F4
-lowercase \x00F5 246		o with tilde														x00F5
-lowercase ö 246							O with diaeresis								00F6
-math × 236				multiplication sign											x00D7
-lowercase \x00F8 246		o with stroke										00F8
+lowercase \x00F3 246		# O with acute		00F3
+lowercase \x00F4 1456		# o with circumflex	x00F4
+lowercase \x00F5 246		# o with tilde		x00F5
+lowercase ö 246			# O with diaeresis	00F6
+math × 236			# multiplication sign	x00D7
+lowercase \x00F8 246		# o with stroke		00F8
 
-math ÷ 256				division sign										x00F7
+math ÷ 256			# division sign		x00F7
 
-lowercase \x00FA 346				u with acute							00FA
-lowercase \x00FB 156				u with circumflex					x00FB
-lowercase \x00FC 1256				u with diaeresis					x00FC
-lowercase \x00FD 12346			y with acute							00FD
+lowercase \x00FA 346		# u with acute		00FA
+lowercase \x00FB 156		# u with circumflex	x00FB
+lowercase \x00FC 1256		# u with diaeresis	x00FC
+lowercase \x00FD 12346		# y with acute		00FD
 
-noback sign \x25CF 35-35			black circle
+noback sign \x25CF 35-35	# black circle
 
 # the letter a with ogonek -----------------------------------
 lowercase \x0105 16
 
-# the letter c with acute
+# the letter			# c with acute
 lowercase \x0107 146
 
-lowercase \x010F 1456					D with caron
+lowercase \x010F 1456		# D with caron
 
 
 # the letter e with ogonek
 lowercase \x0119 156
 
-lowercase \x011B 126					E with caron
+lowercase \x011B 126		# E with caron
 
-lowercase \x012F 1246					I with ogonek
+lowercase \x012F 1246		# I with ogonek
 
 # the letter l with stroke
 lowercase \x0142 126
 
 # the letter n with acute
 lowercase \x0144 1456
-lowercase \x0148 1246					N with caron
+lowercase \x0148 1246		# N with caron
 
-lowercase \x0159 2456					R with caron
+lowercase \x0159 2456		# R with caron
 
 # the letter s	with acute
 lowercase \x015B 246
 
-lowercase \x0165 1256						T with caron
-lowercase \x016D 23456						U with breve
-lowercase \x016F 23456					U with ring above
+lowercase \x0165 1256		# T with caron
+lowercase \x016D 23456		# U with breve
+lowercase \x016F 23456		# U with ring above
 
 
 # the letter z	with acute
@@ -195,56 +195,56 @@ lowercase \x017A 2346
 lowercase \x017C 12346
 
 # Uppercase letters
-base uppercase \x0100 \x0101	letter A with macron
-base uppercase \x010C \x010D	letter C with caron
-base uppercase \x0112 \x0113	letter E with macron
-base uppercase \x0122 \x0123	letter g with cedilla
-base uppercase \x012A \x012B	letter I with macron
-base uppercase \x0136 \x0137	letter K with cedilla
-base uppercase \x013B \x013C	letter L with cedilla
-base uppercase \x0145 \x0146	Letter N with cedilla
-base uppercase \x014C \x014D	letter O with macron
-base uppercase \x0156 \x0157	letter R with cedilla
-base uppercase \x0160 \x0161	letter S with caron
-base uppercase \x016A \x016B	letter U with macron
-base uppercase \x017D \x017E	letter Z with caron
-base uppercase \x00C0 \x00E0	letter a with grave							x00C0 / 00E0
-base uppercase \x00C1 \x00E1	letter a with acute									x00E1
-base uppercase \x00C2 \x00E2	letter a with circumflex						x00E2
-base uppercase \x00C3 \x00E3	letter a with tilde											x00E3
-base uppercase Ä ä	A with diaeresis											x00C4 / 00E4
-base uppercase Å å	A with ring above											x00C5 / 00E5
-base uppercase \x00C6 \x00E6	ae															x00C6
-base uppercase Ç ç	letter c with cedilla					x00C7 / 00E7
-base uppercase È è	e with grave									x00C8 / 00E8
-base uppercase \x00C9 \x00E9	e with acute									x00E9
-base uppercase \x00CA \x00EA	e with circumflex							x00EA
-base uppercase \x00CB \x00EB	e with diaeresis								x00EB
-base uppercase \x00CD \x00ED	i with acute										x00ED
-base uppercase \x00CE \x00EE	i with circumflex								x00EE
-base uppercase \x00CF \x00EF	i with diaeresis								x00CF / 00EF
-base uppercase \x00D3 \x00F3		O with acute										x00D3 / 00F3
-base uppercase \x00D4 \x00F4	o with circumflex												x00F4
-base uppercase \x00D5 \x00F5	o with tilde														x00F5
-base uppercase Ö ö	O with diaeresis								x00D6 / 00F6
-base uppercase \x00D8 \x00F8	o with stroke										x00D8 / 00F8
-base uppercase \x00DA \x00FA	u with acute							x00DA / 00FA
-base uppercase \x00DB \x00FB	u with circumflex					x00FB
-base uppercase \x00DC \x00FC	u with diaeresis					x00FC
-base uppercase \x00DD \x00FD	y with acute							x00DD / 00FD
+base uppercase \x0100 \x0101	# letter A with macron
+base uppercase \x010C \x010D	# letter C with caron
+base uppercase \x0112 \x0113	# letter E with macron
+base uppercase \x0122 \x0123	# letter g with cedilla
+base uppercase \x012A \x012B	# letter I with macron
+base uppercase \x0136 \x0137	# letter K with cedilla
+base uppercase \x013B \x013C	# letter L with cedilla
+base uppercase \x0145 \x0146	# Letter N with cedilla
+base uppercase \x014C \x014D	# letter O with macron
+base uppercase \x0156 \x0157	# letter R with cedilla
+base uppercase \x0160 \x0161	# letter S with caron
+base uppercase \x016A \x016B	# letter U with macron
+base uppercase \x017D \x017E	# letter Z with caron
+base uppercase \x00C0 \x00E0	# letter a with grave			x00C0 / 00E0
+base uppercase \x00C1 \x00E1	# letter a with acute			x00E1
+base uppercase \x00C2 \x00E2	# letter a with circumflex		x00E2
+base uppercase \x00C3 \x00E3	# letter a with tilde			x00E3
+base uppercase Ä ä		# A with diaeresis			x00C4 / 00E4
+base uppercase Å å		# A with ring above			x00C5 / 00E5
+base uppercase \x00C6 \x00E6	# ae					x00C6
+base uppercase Ç ç		# letter c with cedilla			x00C7 / 00E7
+base uppercase È è		# e with grave				x00C8 / 00E8
+base uppercase \x00C9 \x00E9	# e with acute				x00E9
+base uppercase \x00CA \x00EA	# e with circumflex			x00EA
+base uppercase \x00CB \x00EB	# e with diaeresis			x00EB
+base uppercase \x00CD \x00ED	# i with acute				x00ED
+base uppercase \x00CE \x00EE	# i with circumflex			x00EE
+base uppercase \x00CF \x00EF	# i with diaeresis			x00CF / 00EF
+base uppercase \x00D3 \x00F3	# O with acute				x00D3 / 00F3
+base uppercase \x00D4 \x00F4	# o with circumflex			x00F4
+base uppercase \x00D5 \x00F5	# o with tilde				x00F5
+base uppercase Ö ö		# O with diaeresis			x00D6 / 00F6
+base uppercase \x00D8 \x00F8	# o with stroke				x00D8 / 00F8
+base uppercase \x00DA \x00FA	# u with acute				x00DA / 00FA
+base uppercase \x00DB \x00FB	# u with circumflex			x00FB
+base uppercase \x00DC \x00FC	# u with diaeresis			x00FC
+base uppercase \x00DD \x00FD	# y with acute				x00DD / 00FD
 base uppercase \x0104 \x0105
 base uppercase \x0106 \x0107
-base uppercase \x010E \x010F	D with caron
+base uppercase \x010E \x010F	# D with caron
 base uppercase \x0118 \x0119
-base uppercase \x011A \x011B	E with caron
+base uppercase \x011A \x011B	# E with caron
 base uppercase \x0141 \x0142
 base uppercase \x0143 \x0144
-base uppercase \x0147 \x0148	N with caron
-base uppercase \x0158 \x0159	R with caron
+base uppercase \x0147 \x0148	# N with caron
+base uppercase \x0158 \x0159	# R with caron
 base uppercase \x015A \x015B
-base uppercase \x0164 \x0165	T with caron
-base uppercase \x016C \x016D	U with breve
-base uppercase \x016E \x016F	U with ring above
+base uppercase \x0164 \x0165	# T with caron
+base uppercase \x016C \x016D	# U with breve
+base uppercase \x016E \x016F	# U with ring above
 base uppercase \x0179 \x017A
 base uppercase \x017B \x017C
 
@@ -370,7 +370,7 @@ letter \x03c9 2456		# 969 greek small letter omega ω
 punctuation	\x2010 36		 # 8208			hyphen
 punctuation	\x2011 36		 # 8209			non-breaking hyphen
 punctuation	\x2013 36		 # 8211			smart minus sign
-punctuation \x2212 36        # 8722			minus sign
+punctuation \x2212 36        		 # 8722			minus sign
 punctuation	\x2014 25		 # 8212			em dash
 punctuation	\x2018 23		 # 8216			smart single left quotation mark
 punctuation	\x2019 56		 # 8217			smart single right quotation mark
@@ -381,7 +381,7 @@ punctuation	\x201E 236		 # 8222			smart double low quotation mark
 punctuation	\x201F 356		 # 8223			smart double high reverse quotation mark
 punctuation	\x2020 126		 # 8224			dagger
 punctuation	\x2022 5		 # 8226			bullet
-punctuation	\x2026 256-256-256 # 8230		smart ellipsis
+punctuation	\x2026 256-256-256 	 # 8230		smart ellipsis
 
 math		\x2030 3456-245-356-356 # 8240	promille
 
@@ -482,7 +482,7 @@ repeated ~~~ 156-156-156
 always \s-\s 36-36
 always \s-\scom 36-36-14-135-134
 always ... 3-3-3
-always .\s.\s. 3-3-3 . . .
+always .\s.\s. 3-3-3	# . . .
 
 always \s­\s 36-36
 
@@ -490,7 +490,7 @@ always \s­\s 36-36
 noback context _","[$s.]$l ?
 
 # special character sequences
-literal :// URLs
+literal ://		# URLs
 literal www.
 
 literal .com

--- a/tables/Pl-Pl-g1.utb
+++ b/tables/Pl-Pl-g1.utb
@@ -30,30 +30,30 @@ include text_nabcc.dis
 
 # ----------- define all chars --------------------------------------
 
-punctuation ! 235			exclamation sign   						x0021
-punctuation " 356			double quote									x0022
-sign # 3456						number sign										x0023
-sign $ 4-145						dollar sign										x0024
-sign % 3456-245-356					percent sign									x0025
-sign & 456-12346			ampersand											z0026
-noback punctuation ' 3				apostrophe										x0027
-nofor punctuation ' 4				apostrophe										x0027
-punctuation ( 2356			left parenthesis						x0028
-punctuation ) 2356			right parenthesis						x0029
-sign * 35						asterisk										x002A
-math + 235							plus												002B
-punctuation , 2					coma												002C
-punctuation - 36				hyphen-minus								002D
-punctuation . 3					point												002E
-math / 256						solidus											002F
+punctuation ! 235    	 # exclamation sign   						x0021
+punctuation " 356	 # double quote									x0022
+sign # 3456   		 # number sign										x0023
+sign $ 4-145		 # dollar sign										x0024
+sign % 3456-245-356	 # percent sign									x0025
+sign & 456-12346	 # ampersand											z0026
+noback punctuation ' 3	 # apostrophe										x0027
+nofor punctuation ' 4	 # apostrophe										x0027
+punctuation ( 2356  	 # left parenthesis						x0028
+punctuation ) 2356	 # right parenthesis						x0029
+sign * 35     		 # asterisk										x002A
+math + 235		 # plus												002B
+punctuation , 2		 # coma												002C
+punctuation - 36	 # hyphen-minus								002D
+punctuation . 3		 # point												002E
+math / 256    		 # solidus											002F
 
-punctuation : 25				colon								x003A
-punctuation ; 23				semicolon						x003B
-punctuation < 5-13			less-than sign			x003C
-math = 2356			equal sign					x003D
-math > 46-2			greater-than sign		x003E
-punctuation ? 26				question mark				x003F
-sign @ 345			commercial at				x0040
+punctuation : 25	 # colon								x003A
+punctuation ; 23	 # semicolon						x003B
+punctuation < 5-13	 # less-than sign			x003C
+math = 2356   		 # equal sign					x003D
+math > 46-2		 # greater-than sign		x003E
+punctuation ? 26	 # question mark				x003F
+sign @ 345    		 # commercial at				x0040
 
 include latinLetterDef6Dots.uti
 
@@ -95,83 +95,83 @@ lowercase \x017A 2346
 lowercase \x017C 12346
 
 
-punctuation [ 12356		left square bracket						x005B
-sign \\ 34				reverse solidus								x005C
-punctuation ] 23456		right square bracket					x005D
-sign ^ 5				circumflex accent							x005E
-sign _ 6				low line											x005F
-sign ` 4				grave accent									x0060
+punctuation [ 12356	# left square bracket						x005B
+sign \\ 34    		# reverse solidus								x005C
+punctuation ] 23456	# right square bracket					x005D
+sign ^ 5      		# circumflex accent							x005E
+sign _ 6		# low line											x005F
+sign ` 4		# grave accent									x0060
 
-# a - z								# 97 - 122								x0061-x007A
+# a - z				# 97 - 122								x0061-x007A
 
-punctuation { 246				left curly bracket					x007B
-sign | 56					vertical line								x007C
-punctuation } 12456			right curly bracket					x007D
-math ~ 256				tilde												x007E
-sign \x0080 15-136-1235-135										x0080
+punctuation { 246		# left curly bracket					x007B
+sign | 56     			# vertical line								x007C
+punctuation } 12456		# right curly bracket					x007D
+math ~ 256    			# tilde												x007E
+sign \x0080 15-136-1235-135	# x0080
 
-sign ¢ 4-14				cent sign																			x00A2
-sign £ 45-123			pound sign																		x00A3
-sign ¤ 45-15			currency sign																	x00A4
-sign ¥ 45-13456		yen	sign																			x00A5
-sign § 346				section sign																	x00A7
-sign © 2356-6-14-2356		copyright																x00A9
-punctuation « 236				left-pointing double angle quotation 		x00AB
-punctuation \x00AD 36 soft hyphen
-sign ° 4-356			degree sign																		x00B0
-sign ² 346-23		superscript 2 sign														x00B2
-sign ³ 346-25		superscript 3 sign														x00B3
-noback sign µ 56-134			micro sign																		x00B5
-sign ¶ 4-1234-345 pilcrow sign (paragraph)											x00B6
-sign ¹ 346-2				superscript 1 sign														x00B9
-punctuation » 356			right-pointing double angle quotation		x00BB
-math ¼ 3456-1-256		vulgar fraction one quarter								x00BC
-math ½ 3456-1-23		vulgar fraction one half									x00BD
-math ¾ 3456-14-256	vulgar fraction 3 quarters								x00BE
+sign ¢ 4-14 			# cent sign					x00A2
+sign £ 45-123			# pound sign					x00A3
+sign ¤ 45-15			# currency sign					x00A4
+sign ¥ 45-13456			# yen sign					x00A5
+sign § 346			# section sign																	x00A7
+sign © 2356-6-14-2356		# copyright																x00A9
+punctuation « 236		# left-pointing double angle quotation 		x00AB
+punctuation \x00AD 36		# soft hyphen
+sign ° 4-356	   		# degree sign																		x00B0
+sign ² 346-23			# superscript 2 sign														x00B2
+sign ³ 346-25			# superscript 3 sign														x00B3
+noback sign µ 56-134		# micro sign																		x00B5
+sign ¶ 4-1234-345		# pilcrow sign (paragraph)											x00B6
+sign ¹ 346-2			# superscript 1 sign														x00B9
+punctuation » 356		# right-pointing double angle quotation		x00BB
+math ¼ 3456-1-256		# vulgar fraction one quarter								x00BC
+math ½ 3456-1-23		# vulgar fraction one half									x00BD
+math ¾ 3456-14-256		# vulgar fraction 3 quarters								x00BE
 
-lowercase å 16					A with ring above											00E5
-lowercase \x00E2 16					letter a with circumflex
+lowercase å 16			# A with ring above											00E5
+lowercase \x00E2 16		# letter a with circumflex
 
-lowercase \x00E0 12356	letter a with grave
-lowercase \x00E1 12356			letter a with acute
-lowercase \x00E3 126		letter a with tilde
-lowercase ä 345				A with diaeresis											00E4
-lowercase \x00E6 6-345	ae
-lowercase ç 12346			letter c with cedilla									00E7
-lowercase è 2346				e with grave													x00C8 / 00E8
-lowercase \x00E9 123456		e with acute
-lowercase \x00EA 126			e with circumflex
-lowercase \x00EB 1246		e with diaeresis
-lowercase \x00ED 34			i with acute
-lowercase \x00EE 146		i with circumflex
-lowercase \x00EF 12456	i with diaeresis
+lowercase \x00E0 12356		# letter a with grave
+lowercase \x00E1 12356		# letter a with acute
+lowercase \x00E3 126		# letter a with tilde
+lowercase ä 345	 		# A with diaeresis											00E4
+lowercase \x00E6 6-345		# ae
+lowercase ç 12346		# letter c with cedilla									00E7
+lowercase è 2346		# e with grave													x00C8 / 00E8
+lowercase \x00E9 123456		# e with acute
+lowercase \x00EA 126		# e with circumflex
+lowercase \x00EB 1246		# e with diaeresis
+lowercase \x00ED 34		# i with acute
+lowercase \x00EE 146		# i with circumflex
+lowercase \x00EF 12456		# i with diaeresis
 
-lowercase \x00F4 1456	o with circumflex
-lowercase \x00F5 246		o with tilde
-lowercase ö 246						O with diaeresis									00F6
-math × 3				multiplication sign											x00D7
-lowercase \x00F8 246		o with stroke
+lowercase \x00F4 1456		# o with circumflex
+lowercase \x00F5 246		# o with tilde
+lowercase ö 246	 		# O with diaeresis									00F6
+math × 3    			# multiplication sign											x00D7
+lowercase \x00F8 246		# o with stroke
 
-math ÷ 256				division sign										x00F7
+math ÷ 256	 		# division sign										x00F7
 
-lowercase \x00FA 23456			u with acute
-lowercase \x00FB 156				u with circumflex
-lowercase \x00FC 1256				u with diaeresis
-lowercase \x00FD 12346			y with acute
+lowercase \x00FA 23456		# u with acute
+lowercase \x00FB 156		# u with circumflex
+lowercase \x00FC 1256		# u with diaeresis
+lowercase \x00FD 12346		# y with acute
 
 
-punctuation	\x2010 36		 # 8208			hyphen
-punctuation	\x2011 36		 # 8209			non-breaking hyphen
-punctuation	\x2013 36		 # 8211			smart minus sign
+punctuation	\x2010 36	# 8208			hyphen
+punctuation	\x2011 36	# 8209			non-breaking hyphen
+punctuation	\x2013 36	# 8211			smart minus sign
 noback punctuation \x2014 36
-punctuation	\x2018 3		 # 8216			smart single left quotation mark
-punctuation	\x2019 3		 # 8217			smart single right quotation mark
+punctuation	\x2018 3	# 8216			smart single left quotation mark
+punctuation	\x2019 3	# 8217			smart single right quotation mark
 
-punctuation	\x201C 236	 # 8220			smart opening double quote
-punctuation	\x201D 356	 # 8221			smart closing double quote
-punctuation	\x201E 236	 # 8222			smart double low quotation mark
-punctuation	\x201F 356	 # 8223			smart double high reverse quotation mark
-punctuation  \x2026 3-3-3 # 8230		smart ellipsis
+punctuation	\x201C 236	# 8220			smart opening double quote
+punctuation	\x201D 356	# 8221			smart closing double quote
+punctuation	\x201E 236	# 8222			smart double low quotation mark
+punctuation	\x201F 356	# 8223			smart double high reverse quotation mark
+punctuation  \x2026 3-3-3 	# 8230		smart ellipsis
 
 noback sign \x25CF 35-35	# 9679 black circle
 
@@ -185,37 +185,37 @@ base uppercase \x00D3 \x00F3
 base uppercase \x015A \x015B
 base uppercase \x0179 \x017A
 base uppercase \x017B \x017C
-base uppercase Å å				A with ring above											x00C5 / 00E5
-base uppercase \x00C2 \x00E2	letter a with circumflex
-base uppercase \x00C0 \x00E0	letter a with grave
-base uppercase \x00C1 \x00E1	letter a with acute
-base uppercase \x00C3 \x00E3	letter a with tilde
-base uppercase Ä ä	A with diaeresis											x00C4 / 00E4
-base uppercase \x00C6 \x00E6	ae
-base uppercase Ç ç	letter c with cedilla									x00C7 / 00E7
-base uppercase È è	e with grave													x00C8 / 00E8
-base uppercase \x00C9 \x00E9	e with acute
-base uppercase \x00CA \x00EA	e with circumflex
-base uppercase \x00CB \x00EB	e with diaeresis
-base uppercase \x00CD \x00ED	i with acute
-base uppercase \x00CE \x00EE	i with circumflex
-base uppercase \x00CF \x00EF	i with diaeresis
-base uppercase \x00D4 \x00F4	o with circumflex
-base uppercase \x00D5 \x00F5	o with tilde
-base uppercase Ö ö	O with diaeresis									x00D6 / 00F6
-base uppercase \x00D8 \x00F8	o with stroke
-base uppercase \x00DA \x00FA	u with acute
-base uppercase \x00DB \x00FB	u with circumflex
-base uppercase \x00DC \x00FC	u with diaeresis
-base uppercase \x00DD \x00FD	y with acute
+base uppercase Å å		# A with ring above											x00C5 / 00E5
+base uppercase \x00C2 \x00E2	# letter a with circumflex
+base uppercase \x00C0 \x00E0	# letter a with grave
+base uppercase \x00C1 \x00E1	# letter a with acute
+base uppercase \x00C3 \x00E3	# letter a with tilde
+base uppercase Ä ä    		# A with diaeresis											x00C4 / 00E4
+base uppercase \x00C6 \x00E6	# ae
+base uppercase Ç ç    		# letter c with cedilla									x00C7 / 00E7
+base uppercase È è		# e with grave													x00C8 / 00E8
+base uppercase \x00C9 \x00E9	# e with acute
+base uppercase \x00CA \x00EA	# e with circumflex
+base uppercase \x00CB \x00EB	# e with diaeresis
+base uppercase \x00CD \x00ED	# i with acute
+base uppercase \x00CE \x00EE	# i with circumflex
+base uppercase \x00CF \x00EF	# i with diaeresis
+base uppercase \x00D4 \x00F4	# o with circumflex
+base uppercase \x00D5 \x00F5	# o with tilde
+base uppercase Ö ö    		# O with diaeresis									x00D6 / 00F6
+base uppercase \x00D8 \x00F8	# o with stroke
+base uppercase \x00DA \x00FA	# u with acute
+base uppercase \x00DB \x00FB	# u with circumflex
+base uppercase \x00DC \x00FC	# u with diaeresis
+base uppercase \x00DD \x00FD	# y with acute
 
 # ------------------------------------------------------
 
 
 capsletter 46			# single capital letter indicator
-begcapsword 46-46			# a block of consecutive capital letters indicator
+begcapsword 46-46		# a block of consecutive capital letters indicator
 
-numsign 3456		#	number sign, just one operand
+numsign 3456			# number sign, just one operand
 midnum , 2
 midnum . 3
 
@@ -242,38 +242,38 @@ repeated === 46-13-46-13-46-13
 repeated ~~~ 4-156-4-156-4-156
 always \s-\scom 36-36-14-135-134
 always ... 3-3-3
-always .\s.\s. 3-3-3 . . .
+always .\s.\s. 3-3-3		# . . .
 
 always \s­\s 36-36
 
 # Greek letters
 
-noback letter \x0391 456-1 # Α
-noback letter \x0392 456-12 # Β
-noback letter \x0393 456-1245 # Γ
-noback letter \x0394 456-145 # Δ
-noback letter \x0395 456-15 # Ε
-noback letter \x0396 456-1356 # Ζ
-noback letter \x0397 456-156 # Η
-noback letter \x0398 456-1456 # Θ
-noback letter \x0399 456-24 # Ι
-noback letter \x039A 456-13 # Κ
-noback letter \x039B 456-123 # Λ
-noback letter \x039C 456-134 # Μ
-noback letter \x039D 456-1345 # Ν
-noback letter \x039E 456-1346 # Ξ
-noback letter \x039F 456-135 # Ο
-noback letter \x03A0 456-1234 # Π
-noback letter \x03A1 456-1235 # Ρ
-noback letter \x03A3 456-234 # Σ
-noback letter \x03A4 456-2345 # Τ
-noback letter \x03A5 456-136 # Υ
-noback letter \x03A6 456-124 # Φ
-noback letter \x03A7 456-12346 # Χ
-noback letter \x03A8 456-13456 # Ψ
-noback letter \x03A9 456-2456 # Ω
+noback letter \x0391 456-1	# Α
+noback letter \x0392 456-12 	# Β
+noback letter \x0393 456-1245 	# Γ
+noback letter \x0394 456-145 	# Δ
+noback letter \x0395 456-15 	# Ε
+noback letter \x0396 456-1356 	# Ζ
+noback letter \x0397 456-156 	# Η
+noback letter \x0398 456-1456 	# Θ
+noback letter \x0399 456-24 	# Ι
+noback letter \x039A 456-13 	# Κ
+noback letter \x039B 456-123 	# Λ
+noback letter \x039C 456-134 	# Μ
+noback letter \x039D 456-1345 	# Ν
+noback letter \x039E 456-1346 	# Ξ
+noback letter \x039F 456-135 	# Ο
+noback letter \x03A0 456-1234 	# Π
+noback letter \x03A1 456-1235 	# Ρ
+noback letter \x03A3 456-234 	# Σ
+noback letter \x03A4 456-2345 	# Τ
+noback letter \x03A5 456-136 	# Υ
+noback letter \x03A6 456-124 	# Φ
+noback letter \x03A7 456-12346 	# Χ
+noback letter \x03A8 456-13456 	# Ψ
+noback letter \x03A9 456-2456 	# Ω
 
-noback letter \x03B1 56-1 # α
+noback letter \x03B1 56-1 	# α
 noback letter \x03B2 56-12 # β
 noback letter \x03B3 56-1245 # γ
 noback letter \x03B4 56-145 # δ
@@ -305,8 +305,8 @@ noback sign \x2192 25-135
 noback sign \x2190 246-25
 
 
-noback sign \x2264 246-2356 # Less than or equal to
-noback sign \x2265 135-2356 #  Greater than or equal to
+noback sign \x2264 246-2356	# Less than or equal to
+noback sign \x2265 135-2356 	# Greater than or equal to
 
 # Unicode minus symbol
 noback sign \x2212 36

--- a/tables/Se-Se-g1.utb
+++ b/tables/Se-Se-g1.utb
@@ -29,110 +29,110 @@ include spaces.uti
 
 # ----------- define all chars --------------------------------------
 
-punctuation ! 235			exclamation mark		x0021
-punctuation " 56			double quote				x0022
-sign # 45-3456				number sign					x0023
-sign $ 4-234					dollar							x0024
-sign % 46-356					percent							x0025
-sign & 5-346					ampersand						x0026
-punctuation ' 5				apostrophe					x0027
-punctuation ( 236			left parenthesis		x0028
-punctuation ) 356			right parenthesis		x0029
-sign * 35							asterisk						x002A
-math + 256						plus								x002B
-punctuation , 2				coma								x002C
-punctuation - 36			hyphen-minus				x002D
-punctuation . 3				point								x002E
-math / 34							solidus							x002F
+punctuation ! 235    # exclamation mark		x0021
+punctuation " 56     # double quote				x0022
+sign # 45-3456 	     # number sign					x0023
+sign $ 4-234 	     # dollar							x0024
+sign % 46-356 	     # percent							x0025
+sign & 5-346 	     # ampersand						x0026
+punctuation ' 5      # apostrophe					x0027
+punctuation ( 236    # left parenthesis		x0028
+punctuation ) 356    # right parenthesis		x0029
+sign * 35     	     # asterisk						x002A
+math + 256  	     # plus								x002B
+punctuation , 2      # coma								x002C
+punctuation - 36     # hyphen-minus				x002D
+punctuation . 3      # point								x002E
+math / 34     	     # solidus							x002F
 
-punctuation : 25			colon								x003A
-punctuation ; 23			semicolon						x003B
-math < 246-3					less-than sign			x003C
-math = 2356						equal sign					x003D
-math > 135-2					greater-than sign		x003E
-punctuation ? 26			question mark				x003F
-sign @ 45-12356				commercial at				x0040
+punctuation : 25     # colon								x003A
+punctuation ; 23     # semicolon						x003B
+math < 246-3  	     # less-than sign			x003C
+math = 2356 	     # equal sign					x003D
+math > 135-2 	     # greater-than sign		x003E
+punctuation ? 26     # question mark				x003F
+sign @ 45-12356      # commercial at				x0040
 
 include latinLetterDef6Dots.uti
 include digits6Dots.uti # must come after letters
 include litdigits6Dots.uti # Must come after letters
 
 
-punctuation [ 12356	left square bracket		x005B
-sign \\ 45-34				reverse solidus				x005C
-punctuation ] 23456	right square bracket	x005D
-sign ^ 4						circumflex accent			x005E
-sign _ 6						low line							x005F
-sign ` 46						grave accent					x0060
+punctuation [ 12356 	   # left square bracket		x005B
+sign \\ 45-34 		   # reverse solidus				x005C
+punctuation ] 23456 	   # right square bracket	x005D
+sign ^ 4      		   # circumflex accent			x005E
+sign _ 6    		   # low line							x005F
+sign ` 46   		   # grave accent					x0060
 
-# a - z								# 97 - 122					x0061-x007A
+# a - z			   97 - 122					x0061-x007A
 
-punctuation { 6-236	left curly bracket		x007B
-sign | 456					vertical line					x007C
-punctuation } 6-356	right curly bracket		x007D
-math ~ 45-2					tilde									x007E
-sign ¢ 4-14					cent sign							x00A2
-sign £ 45-123				pound sign						x00A3
-sign ¤ 45-15				currency sign					x00A4
-sign ¥ 45-13456			yen										x00A5
-sign § 346					paragraph							x00A7
+punctuation { 6-236 	   # left curly bracket 	x007B
+sign | 456    		   # vertical line 		x007C
+punctuation } 6-356 	   # right curly bracket 	x007D
+math ~ 45-2   		   # tilde 	 		x007E
+sign ¢ 4-14   		   # cent sign 			x00A2
+sign £ 45-123 		   # pound sign 		x00A3
+sign ¤ 45-15 		   # currency sign 		x00A4
+sign ¥ 45-13456   	   # yen      			x00A5
+sign § 346 	  	   # paragraph 			x00A7
 
-sign © 6-14-135-1234-13456-1235-24-1245-125-2345		copyright		x00A9
-punctuation « 45-2356	left pointing double angle								x00AB
+sign © 6-14-135-1234-13456-1235-24-1245-125-2345 	# copyright	x00A9
+punctuation « 45-2356	   # left pointing double angle x00AB
 
-sign ° 4-356					degree sign									x00B0
-sign ² 4-6-126				superscript 2								x00B2
-sign ³ 4-6-146				superscript 3								x00B3
-sign ¹ 4-6-16					superscript 1								x00B9
-punctuation » 2356-12	right pointing double angle	x00BB
-math ¼ 6-16-34-1456		vulgar fraction 1 quarter		x00BC
-math ½ 6-16-34-126		vulgar fraction one half		x00BD
-math ¾ 6-126-34-1456	vulgar fraction 3 quarters	x00BE
+sign ° 4-356  		   # degree sign   	  	x00B0
+sign ² 4-6-126 		   # superscript 2 		x00B2
+sign ³ 4-6-146 		   # superscript 3 		x00B3
+sign ¹ 4-6-16 		   # superscript 1 		x00B9
+punctuation » 2356-12 	   # right pointing double angle x00BB
+math ¼ 6-16-34-1456 	   # vulgar fraction 1 quarter 	 x00BC
+math ½ 6-16-34-126 	   # vulgar fraction one half 	 x00BD
+math ¾ 6-126-34-1456 	   # vulgar fraction 3 quarters	 x00BE
 
-lowercase \x00E0 12356			A with grave
-lowercase ä 345							a with diaeresis
-lowercase å 16										A with ring above
-lowercase \x00E8	2346			E with grave above
-lowercase é 123456								E with acute above
+lowercase \x00E0 12356 	   # A with grave
+lowercase ä 345  	   # a with diaeresis
+lowercase å 16 		   # A with ring above
+lowercase \x00E8 2346 	   # E with grave above
+lowercase é 123456 	   # E with acute above
 
 lowercase ö 246
-math × 1346						multiplication sign					x00D7
+math × 1346		# multiplication sign	x00D7
 
-lowercase ü 1256-1256						U with diaeresis
+lowercase ü 1256-1256 	# U with diaeresis
 
-math ÷ 34							division sign								x00F7
+math ÷ 34   		# division sign								x00F7
 
-punctuation	\x2010 46		 # 8208			hyphen
-punctuation	\x2011 46		 # 8209			non-breaking hyphen
-punctuation	\x2013 36		 # 8211			smart minus sign
-punctuation	\x2018 5		 # 8216			smart single left quotation mark
-punctuation	\x2019 5		 # 8217			smart single right quotation mark
+punctuation \x2010 46 	# 8208 hyphen
+punctuation \x2011 46 	# 8209 non-breaking hyphen
+punctuation \x2013 36 	# 8211 smart minus sign
+punctuation \x2018 5 	# 8216 smart single left quotation mark
+punctuation \x2019 5 	# 8217 smart single right quotation mark
 
-punctuation	\x201C 56		# 8220			smart opening double quote
-punctuation	\x201D 56		# 8221			smart closing double quote
-punctuation	\x201E 56		# 8222			smart double low quotation mark
-punctuation	\x201F 56		# 8223			smart double high reverse quotation mark
+punctuation \x201C 56 	# 8220 smart opening double quote
+punctuation \x201D 56 	# 8221 smart closing double quote
+punctuation \x201E 56 	# 8222 smart double low quotation mark
+punctuation \x201F 56 	# 8223 smart double high reverse quotation mark
 
-punctuation \x2026 3-3-3 # 8230			smart ellipsis
+punctuation \x2026 3-3-3 # 8230 smart ellipsis
 
-sign \x20AC 15-136-1235-135					Euro sign
+sign \x20AC 15-136-1235-135 	# Euro sign
 noback sign \x25CF 35	# 9679 black circle
 
 # Uppercase letters
-base uppercase \x00C0 \x00E0	A with grave				x00C0
-base uppercase Ä ä	a with diaeresis		x00C4
-base uppercase Å å	A with ring above		x00C5
-base uppercase \x00C8 \x00E8		E with grave above	x00C8
-base uppercase É é	E with acute above	x00C9
-base uppercase Ö ö	x00D6
-base uppercase Ü ü	U with diaeresis		x00DC
+base uppercase \x00C0 \x00E0	# A with grave x00C0
+base uppercase Ä ä    		# a with diaeresis x00C4
+base uppercase Å å 		# A with ring above x00C5
+base uppercase \x00C8 \x00E8 	# E with grave above x00C8
+base uppercase É é    		# E with acute above x00C9
+base uppercase Ö ö    		# x00D6
+base uppercase Ü ü    		# U with diaeresis x00DC
 
 # -----------------------
 
 capsletter 6
 begcapsword 6-6			# uncomment if you don't want capitalization
 
-sign \x00B7 3456			# so the line below compile
+sign \x00B7 3456 		# so the line below compile
 numsign 3456
 midnum , 2
 midnum . 3
@@ -143,9 +143,8 @@ midnum : 25
 
 endnum # 56-3456
 
-repeated ... 3-3-3		ellipsis
+repeated ... 3-3-3	# ellipsis
 repeated --- 36-36-36
 repeated ___ 6-6-6
 
-always \s--\s 36-36	tiret
-
+always \s--\s 36-36	# tiret

--- a/tables/afr-za-g2.ctb
+++ b/tables/afr-za-g2.ctb
@@ -63,10 +63,10 @@
 # Begin entries
 
 # Some sign definitions which might otherwise conflict with Afrikaans contractions:
-sign \x00b0 56-45-245 °
-sign \x00a7 56-45-234 § section
-sign \x2122 56-45-2345 ™
-sign \x25cb 56-1246-123456 ○   circle
+sign \x00b0 56-45-245 	# °
+sign \x00a7 56-45-234 	# § section
+sign \x2122 56-45-2345 	# ™
+sign \x25cb 56-1246-123456	# ○   circle
 
 include afr-za-g1.ctb
 include IPA-unicode-range.uti
@@ -84,18 +84,18 @@ seqafterchars  )]}"”'’.,;:.!?…
 noback correct "’" "'"
 noback correct "ŉ" "'n"
 
-attribute 1 AEIOUYÊËaeiouyêë vowels
-attribute 2 BCDFGHJKLMNPQRSTVWXZbcdfghjklmnpqrstvwxz consonants
-attribute 3 +=*,.;:?!"'“”‘’  punctuation with only lower dots (except hyphens)
+attribute 1 AEIOUYÊËaeiouyêë	# vowels
+attribute 2 BCDFGHJKLMNPQRSTVWXZbcdfghjklmnpqrstvwxz	# consonants
+attribute 3 +=*,.;:?!"'“”‘’ 				# punctuation with only lower dots (except hyphens)
 
 # Shape symbols require a grade 1 indicator (Section 3.22.1)
-contraction \x25a0 ■ filled (solid) square
-contraction \x25a1 □ square
-contraction \x25a7 ▧ shaded square (upper left to lower right)
-contraction \x25b2 ▲ filled (solid) (equilateral) triangle
-contraction \x25b3 △ regular (equilateral) triangle
-contraction \x25cb ○ circle
-contraction \x25cd ◍ shaded circle
+contraction \x25a0 	# ■ filled (solid) square
+contraction \x25a1 	# □ square
+contraction \x25a7 	# ▧ shaded square (upper left to lower right)
+contraction \x25b2 	# ▲ filled (solid) (equilateral) triangle
+contraction \x25b3 	# △ regular (equilateral) triangle
+contraction \x25cb 	# ○ circle
+contraction \x25cd 	# ◍ shaded circle
 
 # match expressions
 
@@ -596,7 +596,7 @@ word almiskie 1246-134-24-16-1456
 word amerika =
 prfword ana =
 midendword anett 1-45-1345-2345
-always anger 12346-1245-12456 # aanhanger/bangerig/langer/visvangers/sangeres
+always anger 12346-1245-12456	# aanhanger/bangerig/langer/visvangers/sangeres
 always anies 1-1345-1456-234
 always anomalie 12346-135-134-1246-1456
 always arena =
@@ -911,7 +911,7 @@ midendword skeerkring 234-13-156-1235-13-1235-35-1245
 prfword skene 16-15-1345-15
 always skl =
 endword sklere =
-always skomen 234-13-135-134-26 # eerskomende/laaskomende
+always skomen 234-13-135-134-26	# eerskomende/laaskomende
 always skomitee 234-5-13-24-2345-156
 always skommis 234-5-13-134-24-234
 always skontr 234-13-25-2345-1235


### PR DESCRIPTION
i.e. add a '#' even before end comments. This makes parsing easier and removes some irregularities in the grammar (such as no endcomments allowed after multind opcode or # required after the replace opcode)

This patch only fixes four out of around 180 that need to be changed. It was done mostly manually with some Emacs macros. Turns out this approach is way too much work. This change will have to be done in some automated way, i.e. parsing tables with end_comments and emitting fixed tables. 