### PR TITLE
Only disable contraction in numeric mode if nocontractsign is actually defined

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,13 @@ issues]].
 
 ** New features
 ** Bug fixes
+- When numeric mode was enabled, i.e. when a table contains any of the
+  ~numericmodechars~, ~midnumericmodechars~ or ~numericnocontchars~
+  opcodes, contraction was automatically disabled. This is required
+  for UEB but not necessarily so for other braille systems (as
+  mentioned in [[https://github.com/liblouis/liblouis/issues/615][issue 615]]). This has now been changed so that
+  contraction is only disabled if the ~nocontractsign~ has been
+  defined. Thanks to Christian Egli.
 ** Braille table improvements
 - Fixed emphasis, section sign and dash between numbers in Danish
   tables thanks to Bue Vester-Andersen.

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3490,7 +3490,9 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 	if (!*numericMode) {
 		if (checkCharAttr(input->chars[pos], CTC_Digit | CTC_LitDigit, table)) {
 			*numericMode = 1;
-			*dontContract = 1;
+			/* if the noContractSign is defined disable contraction */
+			if (table->noContractSign)
+			  *dontContract = 1;
 			for_updatePositions(&indicRule->charsdots[0], 0, indicRule->dotslen, 0, pos,
 					input, output, posMapping, cursorPosition, cursorStatus);
 		} else if (checkCharAttr(input->chars[pos], CTC_NumericMode, table)) {

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3491,8 +3491,7 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 		if (checkCharAttr(input->chars[pos], CTC_Digit | CTC_LitDigit, table)) {
 			*numericMode = 1;
 			/* if the noContractSign is defined disable contraction */
-			if (table->noContractSign)
-			  *dontContract = 1;
+			if (table->noContractSign) *dontContract = 1;
 			for_updatePositions(&indicRule->charsdots[0], 0, indicRule->dotslen, 0, pos,
 					input, output, posMapping, cursorPosition, cursorStatus);
 		} else if (checkCharAttr(input->chars[pos], CTC_NumericMode, table)) {

--- a/tests/braille-specs/de-g1-bidi-specs.yaml
+++ b/tests/braille-specs/de-g1-bidi-specs.yaml
@@ -204,9 +204,9 @@ tests:
   - ["11:25 Uhr", "⠼⠁⠁⠠⠒⠃⠑ ⠨⠥⠓⠗", {xfail: "FT: Colon should apparently be 6-25"}]
 
 # Numbers in words
-  - ["8fach", "⠼⠓⠠⠋⠁⠉⠓"]
+  - ["8fach", "⠼⠓⠠⠋⠁⠹"]
   - ["68er", "⠼⠋⠓⠠⠑⠗"]
-  - ["32stel", "⠼⠉⠃⠎⠞⠑⠇"]
+  - ["32stel", "⠼⠉⠃⠾⠑⠇", {xfail: "BT: st backtranslates as }"}]
   - ["5te", "⠼⠑⠞⠑"]
 
 # Capitals

--- a/tests/yaml/issue-615.yaml
+++ b/tests/yaml/issue-615.yaml
@@ -13,9 +13,12 @@ tests:
   - - 4xy
     - .4z
 
-# the presence of the "numericnocontchars" rule enables numeric mode processing
-# contractions are disabled upon entering numeric mode and only enabled again upon reaching the next space
-# so the "xy" is not contracted because there is no space after the "4"
+# The presence of the "numericnocontchars" rule enables numeric mode
+# processing. If the nocontractsign is defined then contractions are
+# disabled upon entering numeric mode and only enabled again upon
+# reaching the next space. In this test the nocontractsign is not
+# defined so the "xy" should be contracted because there is no space
+# after the "4"
 table: |
   letter x 1
   letter y 2
@@ -32,4 +35,4 @@ tests:
     - .4 z
   - - 4xy
     - .4z
-    - xfail: true
+


### PR DESCRIPTION
Fixes #615 