### PR TITLE
Replace `#+locale` metadata tag with `#+language` and `#+region`

### DIFF
--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -120,8 +120,8 @@
 * ../../tables/no-no-g2.ctb                      Norwegian, contracted, grade 2                     Norwegian grade 2 contracted braille
 * ../../tables/no.tbl                            Norwegian, contracted, grade 3                     Norwegian grade 3 contracted braille
 * ../../tables/ne.tbl                            Nepali                                             Nepali braille
-  ../../tables/nl.tbl                            Dutch                                              Dutch braille
-  ../../tables/nl-comp8.utb                      Dutch, computer                                    Dutch computer braille
+* ../../tables/nl.tbl                            Dutch                                              Dutch braille
+* ../../tables/nl-comp8.utb                      Dutch, computer                                    Dutch computer braille
   ../../tables/nso-za-g1.utb                     Sepedi, uncontracted                               Sepedi uncontracted braille
   ../../tables/nso-za-g2.ctb                     Sepedi, contracted                                 Sepedi contracted braille
 * ../../tables/or.tbl                            Oriya                                              Oriya braille

--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -45,15 +45,15 @@
 * ../../tables/fa-ir-g1.utb                      Persian                                            Persian braille
   ../../tables/en-ueb-g1.ctb                     English, unified, uncontracted                     Unified English uncontracted braille
   ../../tables/en-ueb-g2.ctb                     English, unified, contracted                       Unified English contracted braille
-  ../../tables/en_CA.tbl                         English, Canada, computer                          English computer braille as used in Canada
-  ../../tables/en-gb-g1.utb                      English, U.K., uncontracted                        English uncontracted braille as used in the U.K.
-  ../../tables/en_GB.tbl                         English, U.K., contracted                          English contracted braille as used in the U.K.
-  ../../tables/en-gb-comp8.ctb                   English, U.K., computer                            English computer braille as used in the U.K.
+* ../../tables/en_CA.tbl                         English, Canada, computer                          English computer braille as used in Canada
+* ../../tables/en-gb-g1.utb                      English, U.K., uncontracted                        English uncontracted braille as used in the U.K.
+* ../../tables/en_GB.tbl                         English, U.K., contracted                          English contracted braille as used in the U.K.
+* ../../tables/en-gb-comp8.ctb                   English, U.K., computer                            English computer braille as used in the U.K.
   ../../tables/en-nabcc.utb                      English, U.S., computer, NABCC                     North American Braille Computer Code
-  ../../tables/en-us-g1.ctb                      English, U.S., uncontracted                        English uncontracted braille as used in the U.S.
-  ../../tables/en-us-comp6.ctb                   English, U.S., computer, 6-dot                     English 6-dot computer braille as used in the U.S.
-  ../../tables/en_US-comp8-ext.tbl               English, U.S., computer, 8-dot                     English 8-dot computer braille as used in the U.S.
-  ../../tables/en_US.tbl                         English, U.S., contracted                          English contracted braille as used in the U.S.
+* ../../tables/en-us-g1.ctb                      English, U.S., uncontracted                        English uncontracted braille as used in the U.S.
+* ../../tables/en-us-comp6.ctb                   English, U.S., computer, 6-dot                     English 6-dot computer braille as used in the U.S.
+* ../../tables/en_US-comp8-ext.tbl               English, U.S., computer, 8-dot                     English 8-dot computer braille as used in the U.S.
+* ../../tables/en_US.tbl                         English, U.S., contracted                          English contracted braille as used in the U.S.
 * ../../tables/eo.tbl                            Esperanto                                          Esperanto braille
 * ../../tables/eo-g1-x-system.ctb                Esperanto x-system                                 Esperanto x-system braille
 * ../../tables/es.tbl                            Spanish, uncontracted                              Spanish uncontracted braille

--- a/extra/generate-display-names/displayLanguage.go
+++ b/extra/generate-display-names/displayLanguage.go
@@ -85,5 +85,27 @@ func NativeLanguage(lang_c *C.char) *C.char {
 	return C.CString(ret)
 }
 
+//export DisplayRegion
+func DisplayRegion(region_c *C.char) *C.char {
+	var region string
+	var ret string
+	region = C.GoString(region_c)
+	switch (region) {
+	case "CA":
+		ret = "Canada";
+		break;
+	case "GB":
+		ret = "the U.K.";
+		break;
+	case "US":
+		ret = "the U.S.";
+		break;
+	default:
+		ret = "";
+		break;
+	}
+	return C.CString(ret)
+}
+
 // main function required for interfacing with C
 func main() {}

--- a/extra/generate-display-names/generate.c
+++ b/extra/generate-display-names/generate.c
@@ -11,11 +11,16 @@ displayLanguage(const char *lang) {
 	return DisplayLanguage((char *)lang);
 }
 
+static const char *
+displayRegion(const char *region) {
+	return DisplayRegion((char *)region);
+}
+
 static char *
 generateDisplayName(const char *table) {
 	char *name;
 	char *language;
-	char *locale;
+	char *region;
 	char *type;
 	char *dots;
 	char *contraction;
@@ -30,12 +35,12 @@ generateDisplayName(const char *table) {
 	n = name;
 	query = (char *)malloc(100 * sizeof(*query));
 	q = query;
-	locale = lou_getTableInfo(table, "locale");
-	if (!locale) return NULL;
-	language = displayLanguage(locale);
-	n += sprintf(n, "%s", language);
-	q += sprintf(q, "locale:%s", locale);
-	// free(locale);
+	language = lou_getTableInfo(table, "language");
+	if (!language) return NULL;
+	n += sprintf(n, "%s", displayLanguage(language));
+	q += sprintf(q, "language:%s", language);
+	region = lou_getTableInfo(table, "region");
+	if (region) q += sprintf(q, " region:%s", region);
 	type = lou_getTableInfo(table, "type");
 	if (type) {
 		q += sprintf(q, " type:%s", type);
@@ -162,12 +167,19 @@ generateDisplayName(const char *table) {
 		// free(type);
 	}
 	n += sprintf(n, " braille");
+	if (region && strlen(region) > strlen(language) &&
+			!strncmp(language, region, strlen(language)) &&
+			region[strlen(language)] == '-') {
+		char *r = displayRegion(&region[strlen(language) + 1]);
+		if (r && *r) n += sprintf(n, " as used in %s", r);
+	}
+	// free(region);
+	// free(language);
 	version = lou_getTableInfo(table, "version");
 	if (version) {
 		matches = lou_findTables(query);
 		if (matches) {
-			if (matches[0] && matches[1])
-			n += sprintf(n, " (%s standard)", version);
+			if (matches[0] && matches[1]) n += sprintf(n, " (%s standard)", version);
 			// free(matches);
 		}
 		// free(version);

--- a/extra/generate-display-names/generate.c
+++ b/extra/generate-display-names/generate.c
@@ -164,7 +164,12 @@ generateDisplayName(const char *table) {
 	n += sprintf(n, " braille");
 	version = lou_getTableInfo(table, "version");
 	if (version) {
-		n += sprintf(n, " (%s standard)", version);
+		matches = lou_findTables(query);
+		if (matches) {
+			if (matches[0] && matches[1])
+			n += sprintf(n, " (%s standard)", version);
+			// free(matches);
+		}
 		// free(version);
 	}
 	return name;

--- a/extra/generate-display-names/generate.c
+++ b/extra/generate-display-names/generate.c
@@ -31,12 +31,11 @@ generateDisplayName(const char *table) {
 	query = (char *)malloc(100 * sizeof(*query));
 	q = query;
 	locale = lou_getTableInfo(table, "locale");
-	if (!locale)
-		return NULL;
+	if (!locale) return NULL;
 	language = displayLanguage(locale);
 	n += sprintf(n, "%s", language);
 	q += sprintf(q, "locale:%s", locale);
-	//free(locale);
+	// free(locale);
 	type = lou_getTableInfo(table, "type");
 	if (type) {
 		q += sprintf(q, " type:%s", type);
@@ -51,13 +50,13 @@ generateDisplayName(const char *table) {
 					matches = lou_findTables(query);
 					if (matches) {
 						n += sprintf(n, " %s-dot", dots);
-						//for (m = matches; *m; m++) free(*m);
-						//free(matches);
+						// for (m = matches; *m; m++) free(*m);
+						// free(matches);
 					}
 					q = q_save;
 				}
 				q += sprintf(q, " dots:%s", dots);
-				//free(dots);
+				// free(dots);
 			}
 			n += sprintf(n, " %s", type);
 		} else if (!strcmp(type, "literary")) {
@@ -78,10 +77,9 @@ generateDisplayName(const char *table) {
 				q += sprintf(q, " contraction:no");
 				matches = lou_findTables(query);
 				if (matches) {
-					if (!uncontracted || matches[0] && matches[1])
-						otherUncontracted = 1;
-					//for (m = matches; *m; m++) free(*m);
-					//free(matches);
+					if (!uncontracted || matches[0] && matches[1]) otherUncontracted = 1;
+					// for (m = matches; *m; m++) free(*m);
+					// free(matches);
 				}
 				q = q_save;
 				otherPartiallyContracted = 0;
@@ -100,9 +98,9 @@ generateDisplayName(const char *table) {
 									twoOrMorePartiallyContracted = 1;
 							}
 						}
-						//free(*m);
+						// free(*m);
 					}
-					//free(matches);
+					// free(matches);
 					if (!partiallyContracted || twoOrMorePartiallyContracted)
 						otherPartiallyContracted = 1;
 					if (twoOrMorePartiallyContracted)
@@ -117,12 +115,12 @@ generateDisplayName(const char *table) {
 				if (matches) {
 					if (!fullyContracted || matches[0] && matches[1])
 						otherFullyContracted = 1;
-					//for (m = matches; *m; m++) free(*m);
-					//free(matches);
+					// for (m = matches; *m; m++) free(*m);
+					// free(matches);
 				}
 				q = q_save;
 				q += sprintf(q, " contraction:%s", contraction);
-				//free(contraction);
+				// free(contraction);
 			}
 			dots = lou_getTableInfo(table, "dots");
 			if (dots) {
@@ -132,16 +130,14 @@ generateDisplayName(const char *table) {
 					for (m = matches; *m; m++) {
 						if (!otherDots) {
 							char *d = lou_getTableInfo(*m, "dots");
-							if (d && strcmp(dots, d))
-								otherDots = 1;
+							if (d && strcmp(dots, d)) otherDots = 1;
 						}
-						//free(*m);
+						// free(*m);
 					}
-					//free(matches);
+					// free(matches);
 				}
-				if (otherDots)
-					n += sprintf(n, " %s-dot", dots);
-				//free(dots);
+				if (otherDots) n += sprintf(n, " %s-dot", dots);
+				// free(dots);
 			}
 			if (uncontracted) {
 				if (otherFullyContracted || otherPartiallyContracted)
@@ -161,20 +157,21 @@ generateDisplayName(const char *table) {
 				else
 					n += sprintf(n, " partially contracted");
 			}
-			//free(grade);
+			// free(grade);
 		}
-		//free(type);
+		// free(type);
 	}
 	n += sprintf(n, " braille");
 	version = lou_getTableInfo(table, "version");
 	if (version) {
 		n += sprintf(n, " (%s standard)", version);
-		//free(version);
+		// free(version);
 	}
 	return name;
 }
 
-int main(int argc, char **argv) {
+int
+main(int argc, char **argv) {
 	int COLUMN_INDEX_NAME = -1;
 	int COLUMN_DISPLAY_NAME = -1;
 	int result = 0;
@@ -205,7 +202,7 @@ int main(int argc, char **argv) {
 	int tablePathLen = strlen(tablePath);
 	char **tables = lou_listTables();
 	int tableCount = 0;
-	for (char** t = tables; *t; t++) {
+	for (char **t = tables; *t; t++) {
 		tableCount++;
 		if (strncmp(tablePath, *t, tablePathLen) || (*t)[tablePathLen] != '/') {
 			fprintf(stderr, "Unexpected table location: %s\n", *t);
@@ -220,8 +217,7 @@ int main(int argc, char **argv) {
 			generate = 1;
 			cp++;
 		}
-		while (*cp == ' ')
-			cp++;
+		while (*cp == ' ') cp++;
 		if (*cp == '\0' || *cp == '\n' || *cp == '#') {
 			if (!generate)
 				continue;
@@ -230,16 +226,12 @@ int main(int argc, char **argv) {
 		}
 		char *table = cp;
 		cp++;
-		while (*cp != ' ' && *cp != '\0' && *cp != '\n' && *cp != '#')
-			cp++;
-		if (*cp != ' ')
-			goto parse_error;
+		while (*cp != ' ' && *cp != '\0' && *cp != '\n' && *cp != '#') cp++;
+		if (*cp != ' ') goto parse_error;
 		*cp = '\0';
 		cp++;
-		while (*cp == ' ')
-			cp++;
-		if (*cp == '\0' || *cp == '\n' || *cp == '#')
-			goto parse_error;
+		while (*cp == ' ') cp++;
+		if (*cp == '\0' || *cp == '\n' || *cp == '#') goto parse_error;
 		char *expectedIndexName = cp;
 		if (COLUMN_INDEX_NAME < 0)
 			COLUMN_INDEX_NAME = expectedIndexName - line;
@@ -253,20 +245,16 @@ int main(int argc, char **argv) {
 			}
 			cp++;
 		}
-		if (*cp != ' ')
-			goto parse_error;
-		while (*cp == ' ')
-			cp++;
-		if (*cp == '\0' || *cp == '\n' || *cp == '#')
-			goto parse_error;
+		if (*cp != ' ') goto parse_error;
+		while (*cp == ' ') cp++;
+		if (*cp == '\0' || *cp == '\n' || *cp == '#') goto parse_error;
 		char *expectedDisplayName = cp;
 		if (COLUMN_DISPLAY_NAME < 0)
 			COLUMN_DISPLAY_NAME = expectedDisplayName - line;
 		else if (expectedDisplayName != line + COLUMN_DISPLAY_NAME)
 			goto parse_error;
 		while (*cp != '\0' && *cp != '\n' && *cp != '#') {
-			if (*cp == ' ' && cp[1] == ' ')
-				break;
+			if (*cp == ' ' && cp[1] == ' ') break;
 			cp++;
 		}
 		*cp = '\0';
@@ -290,8 +278,12 @@ int main(int argc, char **argv) {
 			result = 1;
 		} else {
 			if (strcmp(actualIndexName, expectedIndexName) != 0) {
-				fprintf(stderr, "%s: %s != %s\n", table, actualIndexName, expectedIndexName);
-				fprintf(stderr, "   cat %s | sed 's/^\\(#-index-name: *\\).*$/\\1%s/g' > %s.tmp\n", table, expectedIndexName, table);
+				fprintf(stderr, "%s: %s != %s\n", table, actualIndexName,
+						expectedIndexName);
+				fprintf(stderr,
+						"   cat %s | sed 's/^\\(#-index-name: *\\).*$/\\1%s/g' > "
+						"%s.tmp\n",
+						table, expectedIndexName, table);
 				fprintf(stderr, "   mv %s.tmp %s\n", table, table);
 				result = 1;
 			}
@@ -302,31 +294,38 @@ int main(int argc, char **argv) {
 			result = 1;
 		} else {
 			if (strcmp(actualDisplayName, expectedDisplayName) != 0) {
-				fprintf(stderr, "%s: %s != %s\n", table, actualDisplayName, expectedDisplayName);
-				fprintf(stderr, "   cat %s | sed 's/^\\(#-display-name: *\\).*$/\\1%s/g' > %s.tmp\n", table, expectedDisplayName, table);
+				fprintf(stderr, "%s: %s != %s\n", table, actualDisplayName,
+						expectedDisplayName);
+				fprintf(stderr,
+						"   cat %s | sed 's/^\\(#-display-name: *\\).*$/\\1%s/g' > "
+						"%s.tmp\n",
+						table, expectedDisplayName, table);
 				fprintf(stderr, "   mv %s.tmp %s\n", table, table);
 				result = 1;
 			}
 			const char *generatedDisplayName = generateDisplayName(table);
 			if (!generatedDisplayName || !*generatedDisplayName) {
 				if (generate) {
-					fprintf(stderr, "No display-name could be generated for table %s\n", table);
+					fprintf(stderr, "No display-name could be generated for table %s\n",
+							table);
 					result = 1;
 				}
 			} else if (strcmp(actualDisplayName, generatedDisplayName) != 0) {
 				if (generate) {
-					fprintf(stderr, "%s: %s != %s\n", table, actualDisplayName, generatedDisplayName);
+					fprintf(stderr, "%s: %s != %s\n", table, actualDisplayName,
+							generatedDisplayName);
 					result = 1;
 				}
 			} else {
 				if (!generate) {
-					fprintf(stderr, "%s: %s == %s\n", table, actualDisplayName, generatedDisplayName);
+					fprintf(stderr, "%s: %s == %s\n", table, actualDisplayName,
+							generatedDisplayName);
 					result = 1;
 				}
 			}
 		}
 		continue;
-	  parse_error:
+	parse_error:
 		fprintf(stderr, "Could not parse line: %s\n", line);
 		exit(EXIT_FAILURE);
 	}

--- a/tables/Es-Es-G0.utb
+++ b/tables/Es-Es-G0.utb
@@ -4,7 +4,7 @@
 #-index-name: Spanish, computer
 #-display-name: Spanish computer braille
 #
-#+locale:es
+#+language:es
 #+type:computer
 # Marked as "direction:both" by Bue Vester-Andersen
 # as it is a computer Braille table.

--- a/tables/afr-za-g1.ctb
+++ b/tables/afr-za-g1.ctb
@@ -7,7 +7,7 @@
 #-index-name: Afrikaans, uncontracted
 #-display-name: Afrikaans uncontracted braille
 #
-#+locale:af
+#+language:af
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/afr-za-g2.ctb
+++ b/tables/afr-za-g2.ctb
@@ -5,7 +5,7 @@
 #-index-name: Afrikaans, contracted
 #-display-name: Afrikaans contracted braille
 #
-#+locale:af
+#+language:af
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/ar-ar-comp8.utb
+++ b/tables/ar-ar-comp8.utb
@@ -29,7 +29,7 @@
 #-author-email: ikrami.ahmad@gmail.com
 # with assistance from Hatoon Felemban <h.felemban@hotmail.com>
 
-#+locale: ar
+#+language: ar
 #+type: computer
 #+dots: 8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/ar-ar-g2.ctb
+++ b/tables/ar-ar-g2.ctb
@@ -25,7 +25,7 @@
 
 #-index-name: Arabic, contracted
 #-display-name: Arabic contracted braille
-#+locale: ar
+#+language: ar
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/ar.tbl
+++ b/tables/ar.tbl
@@ -1,7 +1,7 @@
 #-index-name: Arabic, uncontracted
 #-display-name: Arabic uncontracted braille
 
-#+locale:ar
+#+language:ar
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/as.tbl
+++ b/tables/as.tbl
@@ -1,7 +1,7 @@
 #-index-name: Assamese
 #-display-name: Assamese braille
 
-#+locale:as
+#+language:as
 #+type:literary
 #+grade:1
 

--- a/tables/awa.tbl
+++ b/tables/awa.tbl
@@ -1,7 +1,7 @@
 #-index-name: Awadhi
 #-display-name: Awadhi braille
 
-#+locale:awa
+#+language:awa
 #+type:literary
 #+grade:1
 

--- a/tables/ba.utb
+++ b/tables/ba.utb
@@ -1,7 +1,7 @@
 #-index-name: Bashkir
 #-display-name: Bashkir braille
 
-#+locale: ba
+#+language: ba
 #+type: literary
 #+direction: forward
 

--- a/tables/bel-comp.utb
+++ b/tables/bel-comp.utb
@@ -1,7 +1,7 @@
 #-index-name: Belarusian, computer
 #-display-name: Belarusian computer braille
 
-#+locale: be
+#+language: be
 #+type: computer
 #+dots: 8
 #+direction: both

--- a/tables/bel.utb
+++ b/tables/bel.utb
@@ -1,7 +1,7 @@
 #-index-name: Belarusian
 #-display-name: Belarusian braille
 
-#+locale: be
+#+language: be
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/bg.tbl
+++ b/tables/bg.tbl
@@ -1,7 +1,7 @@
 #-index-name: Bulgarian, computer
 #-display-name: Bulgarian computer braille
 
-#+locale:bg
+#+language:bg
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/bg.utb
+++ b/tables/bg.utb
@@ -21,7 +21,7 @@
 #-index-name: Bulgarian
 #-display-name: Bulgarian braille
 #
-#+locale: bg
+#+language: bg
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/bh.tbl
+++ b/tables/bh.tbl
@@ -1,7 +1,7 @@
 #-index-name: Bihari
 #-display-name: Bihari braille
 
-#+locale:bh
+#+language:bh
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/bn.tbl
+++ b/tables/bn.tbl
@@ -1,7 +1,7 @@
 #-index-name: Bengali
 #-display-name: Bengali braille
 
-#+locale:bn
+#+language:bn
 #+type:literary
 #+grade:1
 

--- a/tables/bo.tbl
+++ b/tables/bo.tbl
@@ -1,7 +1,7 @@
 #-index-name: Tibetan, computer
 #-display-name: Tibetan computer braille
 
-#+locale:bo
+#+language:bo
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/bra.tbl
+++ b/tables/bra.tbl
@@ -1,7 +1,7 @@
 #-index-name: Braj
 #-display-name: Braj braille
 
-#+locale:bra
+#+language:bra
 #+type:literary
 #+grade:1
 

--- a/tables/ca.tbl
+++ b/tables/ca.tbl
@@ -1,7 +1,7 @@
 #-index-name: Catalan
 #-display-name: Catalan braille
 
-#+locale:ca
+#+language:ca
 #+type:literary
 #+grade:1
 

--- a/tables/chr-us-g1.ctb
+++ b/tables/chr-us-g1.ctb
@@ -5,7 +5,7 @@
 #-index-name: Cherokee
 #-display-name: Cherokee braille
 #
-#+locale:chr
+#+language:chr
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ckb.tbl
+++ b/tables/ckb.tbl
@@ -1,7 +1,7 @@
 #-index-name: Kurdish
 #-display-name: Kurdish braille
 
-#+locale:ckb
+#+language:ckb
 #+type:literary
 #+grade:1
 

--- a/tables/cop-eg-comp8.utb
+++ b/tables/cop-eg-comp8.utb
@@ -24,7 +24,7 @@
 #-author-name: Ibraam Nasif 
 #-author-email: ibraam.wahib@gmail.com
 
-#+locale: cop
+#+language: cop
 #+type: computer
 #+dots: 8
 #+direction: forward

--- a/tables/cs-comp8.utb
+++ b/tables/cs-comp8.utb
@@ -3,7 +3,7 @@
 #-index-name: Czech, computer
 #-display-name: Czech computer braille
 #
-#+locale:cs
+#+language:cs
 #+type:computer
 #+grade:0
 #+dots:8

--- a/tables/cs.tbl
+++ b/tables/cs.tbl
@@ -1,7 +1,7 @@
 #-index-name: Czech
 #-display-name: Czech braille
 
-#+locale:cs
+#+language:cs
 #+type:literary
 #+grade:1
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/cy-cy-g1.utb
+++ b/tables/cy-cy-g1.utb
@@ -4,7 +4,7 @@
 #-index-name: Welsh, uncontracted
 #-display-name: Welsh uncontracted braille
 #
-#+locale:cy
+#+language:cy
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/cy.tbl
+++ b/tables/cy.tbl
@@ -1,7 +1,7 @@
 #-index-name: Welsh, contracted
 #-display-name: Welsh contracted braille
 
-#+locale:cy
+#+language:cy
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/da-dk-g08.ctb
+++ b/tables/da-dk-g08.ctb
@@ -31,7 +31,7 @@
 #-index-name: Danish, computer
 #-display-name: Danish computer braille
 
-#+locale: da
+#+language: da
 #+type: computer
 #+contraction: no
 #+grade: 0

--- a/tables/da-dk-g16-lit.ctb
+++ b/tables/da-dk-g16-lit.ctb
@@ -32,7 +32,7 @@
 #-index-name: Danish, uncontracted, 6-dot
 #-display-name: Danish 6-dot uncontracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/da-dk-g16.ctb
+++ b/tables/da-dk-g16.ctb
@@ -26,7 +26,7 @@
 #-index-name: Danish, uncontracted, 6-dot
 #-display-name: Danish 6-dot uncontracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/da-dk-g18.ctb
+++ b/tables/da-dk-g18.ctb
@@ -31,7 +31,7 @@
 #-index-name: Danish, uncontracted, 8-dot
 #-display-name: Danish 8-dot uncontracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/da-dk-g26-lit.ctb
+++ b/tables/da-dk-g26-lit.ctb
@@ -27,7 +27,7 @@
 #-index-name: Danish, contracted, 6-dot
 #-display-name: Danish 6-dot contracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/da-dk-g26.ctb
+++ b/tables/da-dk-g26.ctb
@@ -26,7 +26,7 @@
 #-index-name: Danish, contracted, 6-dot
 #-display-name: Danish 6-dot contracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/da-dk-g26l-lit.ctb
+++ b/tables/da-dk-g26l-lit.ctb
@@ -25,7 +25,7 @@
 #-index-name: Danish, partially contracted, 6-dot
 #-display-name: Danish 6-dot partially contracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: partial
 #+grade: 1.5

--- a/tables/da-dk-g26l.ctb
+++ b/tables/da-dk-g26l.ctb
@@ -25,7 +25,7 @@
 #-index-name: Danish, partially contracted, 6-dot
 #-display-name: Danish 6-dot partially contracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: partial
 #+grade: 1.5

--- a/tables/da-dk-g28.ctb
+++ b/tables/da-dk-g28.ctb
@@ -31,7 +31,7 @@
 #-index-name: Danish, contracted, 8-dot
 #-display-name: Danish 8-dot contracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/da-dk-g28l.ctb
+++ b/tables/da-dk-g28l.ctb
@@ -31,7 +31,7 @@
 #-index-name: Danish, partially contracted, 8-dot
 #-display-name: Danish 8-dot partially contracted braille
 
-#+locale: da
+#+language: da
 #+type: literary
 #+contraction: partial
 #+grade: 1.5

--- a/tables/de-de-comp8.ctb
+++ b/tables/de-de-comp8.ctb
@@ -27,7 +27,7 @@
 #-index-name: German, computer
 #-display-name: German computer braille
 #
-#+locale: de
+#+language: de
 #+type: computer
 #+direction: both
 # ------------

--- a/tables/de-g0-bidi.utb
+++ b/tables/de-g0-bidi.utb
@@ -21,7 +21,7 @@
 #-index-name: German, uncontracted, back-translatable
 #-display-name: German uncontracted braille (back-translatable)
 #
-#+locale:de
+#+language:de
 #+type:literary
 #+contraction:no
 #+grade:0

--- a/tables/de-g0.utb
+++ b/tables/de-g0.utb
@@ -21,7 +21,7 @@
 #-index-name: German, uncontracted
 #-display-name: German uncontracted braille
 #
-#+locale:de
+#+language:de
 #+type:literary
 #+contraction:no
 #+grade:0

--- a/tables/de-g1-bidi.ctb
+++ b/tables/de-g1-bidi.ctb
@@ -21,7 +21,7 @@
 #-index-name: German, partially contracted, back-translatable
 #-display-name: German partially contracted braille (back-translatable)
 #
-#+locale: de
+#+language: de
 #+type: literary
 #+contraction: partial
 #+grade: 1

--- a/tables/de-g1.ctb
+++ b/tables/de-g1.ctb
@@ -21,7 +21,7 @@
 #-index-name: German, partially contracted
 #-display-name: German partially contracted braille
 #
-#+locale: de
+#+language: de
 #+type: literary
 #+contraction: partial
 #+grade: 1

--- a/tables/de-g2.ctb
+++ b/tables/de-g2.ctb
@@ -9,7 +9,7 @@
 #-index-name: German, contracted
 #-display-name: German contracted braille
 #
-#+locale:de
+#+language:de
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/dra.tbl
+++ b/tables/dra.tbl
@@ -1,7 +1,7 @@
 #-index-name: Dravidian, computer
 #-display-name: Dravidian computer braille
 
-#+locale:dra
+#+language:dra
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/el.ctb
+++ b/tables/el.ctb
@@ -7,7 +7,7 @@
 #-index-name: Greek
 #-display-name: Greek braille
 #
-#+locale: el
+#+language: el
 #+type: literary
 #+dots: 6
 #+contraction: full

--- a/tables/en-gb-comp8.ctb
+++ b/tables/en-gb-comp8.ctb
@@ -4,7 +4,8 @@
 #-index-name: English, U.K., computer
 #-display-name: English computer braille as used in the U.K.
 #
-#+locale:en-GB
+#+language:en
+#+region:en-GB
 #+type:computer
 #+dots:8
 #+system:bauk

--- a/tables/en-gb-g1.utb
+++ b/tables/en-gb-g1.utb
@@ -5,7 +5,8 @@
 #-index-name: English, U.K., uncontracted
 #-display-name: English uncontracted braille as used in the U.K.
 #
-#+locale:en-GB
+#+language:en
+#+region:en-GB
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/en-nabcc.utb
+++ b/tables/en-nabcc.utb
@@ -4,7 +4,7 @@
 #-index-name: English, U.S., computer, NABCC
 #-display-name: North American Braille Computer Code
 #
-#+locale: en
+#+language: en
 #+type: computer
 #+dots: 8
 #+system: nabcc

--- a/tables/en-ueb-g1.ctb
+++ b/tables/en-ueb-g1.ctb
@@ -5,7 +5,7 @@
 #-index-name: English, unified, uncontracted
 #-display-name: Unified English uncontracted braille
 #
-#+locale:en
+#+language:en
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -5,7 +5,7 @@
 #-index-name: English, unified, contracted
 #-display-name: Unified English contracted braille
 #
-#+locale:en
+#+language:en
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/en-us-comp6.ctb
+++ b/tables/en-us-comp6.ctb
@@ -4,7 +4,8 @@
 #-index-name: English, U.S., computer, 6-dot
 #-display-name: English 6-dot computer braille as used in the U.S.
 #
-#+locale: en-US
+#+language: en
+#+region: en-US
 #+type: computer
 #+dots: 6
 #+system: ebae

--- a/tables/en-us-g1.ctb
+++ b/tables/en-us-g1.ctb
@@ -5,7 +5,8 @@
 #-index-name: English, U.S., uncontracted
 #-display-name: English uncontracted braille as used in the U.S.
 #
-#+locale:en-US
+#+language:en
+#+region:en-US
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/en_CA.tbl
+++ b/tables/en_CA.tbl
@@ -1,7 +1,8 @@
 #-index-name: English, Canada, computer
 #-display-name: English computer braille as used in Canada
 
-#+locale:en-CA
+#+language:en
+#+region:en-CA
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/en_GB.tbl
+++ b/tables/en_GB.tbl
@@ -2,7 +2,8 @@
 #-index-name: English, U.K., contracted
 #-display-name: English contracted braille as used in the U.K.
 
-#+locale:en-GB
+#+language:en
+#+region:en-GB
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/en_US-comp8-ext.tbl
+++ b/tables/en_US-comp8-ext.tbl
@@ -2,7 +2,8 @@
 #-index-name: English, U.S., computer, 8-dot
 #-display-name: English 8-dot computer braille as used in the U.S.
 
-#+locale:en-US
+#+language:en
+#+region:en-US
 #+type:computer
 #+dots:8
 #+direction:both

--- a/tables/en_US.tbl
+++ b/tables/en_US.tbl
@@ -2,7 +2,8 @@
 #-index-name: English, U.S., contracted
 #-display-name: English contracted braille as used in the U.S.
 
-#+locale:en-US
+#+language:en
+#+region:en-US
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/eo-g1-x-system.ctb
+++ b/tables/eo-g1-x-system.ctb
@@ -4,7 +4,7 @@
 #-index-name: Esperanto x-system
 #-display-name: Esperanto x-system braille
 #
-#+locale:eo-xsistemo
+#+language:eo-xsistemo
 #+type:literary
 #+grade:1
 #

--- a/tables/eo.tbl
+++ b/tables/eo.tbl
@@ -1,7 +1,7 @@
 #-index-name: Esperanto
 #-display-name: Esperanto braille
 
-#+locale:eo
+#+language:eo
 #+type:literary
 #+grade:1
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/es-g2.ctb
+++ b/tables/es-g2.ctb
@@ -4,7 +4,7 @@
 #-index-name: Spanish, contracted
 #-display-name: Spanish contracted braille
 #
-#+locale:es
+#+language:es
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/es.tbl
+++ b/tables/es.tbl
@@ -1,7 +1,7 @@
 #-index-name: Spanish, uncontracted
 #-display-name: Spanish uncontracted braille
 
-#+locale:es
+#+language:es
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/et.tbl
+++ b/tables/et.tbl
@@ -1,7 +1,7 @@
 #-index-name: Estonian, computer
 #-display-name: Estonian computer braille
 
-#+locale:et
+#+language:et
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/fa-ir-comp8.ctb
+++ b/tables/fa-ir-comp8.ctb
@@ -4,7 +4,7 @@
 #-index-name: Persian, computer
 #-display-name: Persian computer braille
 #
-#+locale:fa
+#+language:fa
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/fa-ir-g1.utb
+++ b/tables/fa-ir-g1.utb
@@ -4,7 +4,7 @@
 #-index-name: Persian
 #-display-name: Persian braille
 #
-#+locale:fa
+#+language:fa
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/fi-fi-8dot.ctb
+++ b/tables/fi-fi-8dot.ctb
@@ -4,7 +4,7 @@
 #-index-name: Finnish, computer
 #-display-name: Finnish computer braille
 #
-#+locale:fi
+#+language:fi
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/fi.utb
+++ b/tables/fi.utb
@@ -4,7 +4,7 @@
 #-index-name: Finnish
 #-display-name: Finnish braille
 #
-#+locale:fi
+#+language:fi
 #+type:literary
 #+contraction:no
 #+dots:6

--- a/tables/fr-bfu-comp6.utb
+++ b/tables/fr-bfu-comp6.utb
@@ -1,4 +1,4 @@
-#+locale:fr
+#+language:fr
 #+type:literary
 #+contraction:no
 #+dots:6

--- a/tables/fr-bfu-comp8.utb
+++ b/tables/fr-bfu-comp8.utb
@@ -1,4 +1,4 @@
-#+locale:fr
+#+language:fr
 #+type:computer
 #+dots:8
 #+system:bfu

--- a/tables/fr-bfu-g2.ctb
+++ b/tables/fr-bfu-g2.ctb
@@ -1,4 +1,4 @@
-#+locale:fr
+#+language:fr
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/ga-g1.utb
+++ b/tables/ga-g1.utb
@@ -4,7 +4,7 @@
 #-index-name: Irish, uncontracted
 #-display-name: Irish uncontracted braille
 #
-#+locale:ga
+#+language:ga
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ga-g2.ctb
+++ b/tables/ga-g2.ctb
@@ -5,7 +5,7 @@
 #-index-name: Irish, contracted
 #-display-name: Irish contracted braille
 #
-#+locale:ga
+#+language:ga
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/gd.tbl
+++ b/tables/gd.tbl
@@ -1,7 +1,7 @@
 #-index-name: Scottish Gaelic, computer
 #-display-name: Scottish Gaelic computer braille
 
-#+locale:gd
+#+language:gd
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/gez.tbl
+++ b/tables/gez.tbl
@@ -1,7 +1,7 @@
 #-index-name: Ethiopic
 #-display-name: Ethiopic braille
 
-#+locale:gez
+#+language:gez
 #+type:literary
 #+grade:1
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/gon.tbl
+++ b/tables/gon.tbl
@@ -1,7 +1,7 @@
 #-index-name: Gondi
 #-display-name: Gondi braille
 
-#+locale:gon
+#+language:gon
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/grc-international-en.utb
+++ b/tables/grc-international-en.utb
@@ -4,7 +4,7 @@
 #-index-name: Greek, international, English
 #-display-name: Greek internationalized braille as used by English speakers
 #
-#+locale: grc
+#+language: grc
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/gu.tbl
+++ b/tables/gu.tbl
@@ -1,7 +1,7 @@
 #-index-name: Gujarati
 #-display-name: Gujarati braille
 
-#+locale:gu
+#+language:gu
 #+type:literary
 #+grade:1
 

--- a/tables/haw-us-g1.ctb
+++ b/tables/haw-us-g1.ctb
@@ -5,7 +5,7 @@
 #-index-name: Hawaiian
 #-display-name: Hawaiian braille
 #
-#+locale:haw
+#+language:haw
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/he-IL-comp8.utb
+++ b/tables/he-IL-comp8.utb
@@ -2,7 +2,7 @@
 #
 #-index-name: Hebrew, computer
 #-display-name: Hebrew computer braille
-#+locale: he
+#+language: he
 #+type: computer
 #+dots: 8
 #

--- a/tables/he-IL.utb
+++ b/tables/he-IL.utb
@@ -22,7 +22,10 @@
 #-index-name: Hebrew, Israel
 #-display-name: Israeli braille
 
-#+locale: mul-IL
+#+language: he
+#+language: ar
+#+language: en
+#+region:mul-IL
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/hi.tbl
+++ b/tables/hi.tbl
@@ -1,7 +1,7 @@
 #-index-name: Hindi
 #-display-name: Hindi braille
 
-#+locale:hi
+#+language:hi
 #+type:literary
 #+grade:1
 

--- a/tables/hr-comp8.tbl
+++ b/tables/hr-comp8.tbl
@@ -1,7 +1,7 @@
 #-index-name: Croatian, computer
 #-display-name: Croatian computer braille
 
-#+locale:hr
+#+language:hr
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/hr-g1.tbl
+++ b/tables/hr-g1.tbl
@@ -1,7 +1,7 @@
 #-index-name: Croatian
 #-display-name: Croatian braille
 
-#+locale: hr
+#+language: hr
 #+type: literary
 #+grade: 1
 

--- a/tables/hu-hu-comp8.ctb
+++ b/tables/hu-hu-comp8.ctb
@@ -4,7 +4,7 @@
 #-index-name: Hungarian, computer
 #-display-name: Hungarian computer braille
 #
-#+locale:hu
+#+language:hu
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/hu-hu-g2.ctb
+++ b/tables/hu-hu-g2.ctb
@@ -4,7 +4,7 @@
 #-index-name: Hungarian, contracted
 #-display-name: Hungarian contracted braille
 #
-#+locale:hu
+#+language:hu
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/hu.tbl
+++ b/tables/hu.tbl
@@ -1,7 +1,7 @@
 #-index-name: Hungarian, partially contracted
 #-display-name: Hungarian partially contracted braille
 
-#+locale:hu
+#+language:hu
 #+type:literary
 #+contraction:partial
 #+grade:1

--- a/tables/hy.tbl
+++ b/tables/hy.tbl
@@ -1,7 +1,7 @@
 #-index-name: Armenian, computer
 #-display-name: Armenian computer braille
 
-#+locale:hy
+#+language:hy
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/is.tbl
+++ b/tables/is.tbl
@@ -1,7 +1,7 @@
 #-index-name: Icelandic
 #-display-name: Icelandic braille
 
-#+locale:is
+#+language:is
 #+type:literary
 #+dots:6
 

--- a/tables/it-it-comp8.utb
+++ b/tables/it-it-comp8.utb
@@ -4,7 +4,7 @@
 #-index-name: Italian, computer
 #-display-name: Italian computer braille
 #
-#+locale:it
+#+language:it
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/it.tbl
+++ b/tables/it.tbl
@@ -1,7 +1,7 @@
 #-index-name: Italian
 #-display-name: Italian braille
 
-#+locale:it
+#+language:it
 #+type:literary
 #+dots:6
 

--- a/tables/iu-ca-g1.ctb
+++ b/tables/iu-ca-g1.ctb
@@ -4,7 +4,7 @@
 #-index-name: Inuktitut
 #-display-name: Inuktitut braille
 #
-#+locale:iu
+#+language:iu
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ja-kantenji.utb
+++ b/tables/ja-kantenji.utb
@@ -3,7 +3,7 @@
 #-index-name: Japanese, Kantenji
 #-display-name: Kantenji
 
-#+locale:ja
+#+language:ja
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/kha.tbl
+++ b/tables/kha.tbl
@@ -1,7 +1,7 @@
 #-index-name: Khasi
 #-display-name: Khasi braille
 
-#+locale:kha
+#+language:kha
 #+type:literary
 #+grade:1
 

--- a/tables/kk.utb
+++ b/tables/kk.utb
@@ -1,7 +1,7 @@
 #-index-name: Kazakh
 #-display-name: Kazakh braille
 
-#+locale: kk
+#+language: kk
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/km-g1.utb
+++ b/tables/km-g1.utb
@@ -1,7 +1,7 @@
 #-index-name: Khmer
 #-display-name: Khmer braille
 #
-#+locale: km
+#+language: km
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/kmr.tbl
+++ b/tables/kmr.tbl
@@ -4,7 +4,7 @@
 #-display-name: Northern Kurdish braille
 #-index-name: Northern Kurdish
 
-#+locale:kmr
+#+language:kmr
 #+type:literary
 #+dots:6
 #+contraction:no

--- a/tables/kn.tbl
+++ b/tables/kn.tbl
@@ -1,7 +1,7 @@
 #-index-name: Kannada
 #-display-name: Kannada braille
 
-#+locale:kn
+#+language:kn
 #+type:literary
 #+grade:1
 

--- a/tables/ko-2006-g1.ctb
+++ b/tables/ko-2006-g1.ctb
@@ -4,7 +4,7 @@
 #-index-name: Korean, uncontracted, 2006
 #-display-name: Korean uncontracted braille (2006 standard)
 #
-#+locale:ko
+#+language:ko
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ko-2006-g2.ctb
+++ b/tables/ko-2006-g2.ctb
@@ -4,7 +4,7 @@
 #-index-name: Korean, contracted, 2006
 #-display-name: Korean contracted braille (2006 standard)
 #
-#+locale:ko
+#+language:ko
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/ko-g1.ctb
+++ b/tables/ko-g1.ctb
@@ -4,7 +4,7 @@
 #-index-name: Korean, uncontracted
 #-display-name: Korean uncontracted braille
 #
-#+locale:ko
+#+language:ko
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ko-g2.ctb
+++ b/tables/ko-g2.ctb
@@ -4,7 +4,7 @@
 #-index-name: Korean, contracted
 #-display-name: Korean contracted braille
 #
-#+locale:ko
+#+language:ko
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/kok.tbl
+++ b/tables/kok.tbl
@@ -1,7 +1,7 @@
 #-index-name: Konkani
 #-display-name: Konkani braille
 
-#+locale:kok
+#+language:kok
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/kru.tbl
+++ b/tables/kru.tbl
@@ -1,7 +1,7 @@
 #-index-name: Kurukh
 #-display-name: Kurukh braille
 
-#+locale:kru
+#+language:kru
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/lt-6dot.tbl
+++ b/tables/lt-6dot.tbl
@@ -1,7 +1,7 @@
 #-index-name: Lithuanian, 6-dot
 #-display-name: Lithuanian 6-dot braille
 
-#+locale:lt
+#+language:lt
 #+type:literary
 #+contraction:no
 #+dots:6

--- a/tables/lt.tbl
+++ b/tables/lt.tbl
@@ -1,7 +1,7 @@
 #-index-name: Lithuanian, 8-dot
 #-display-name: Lithuanian 8-dot braille
 
-#+locale:lt
+#+language:lt
 #+type:literary
 #+contraction:no
 #+dots:8

--- a/tables/lv.tbl
+++ b/tables/lv.tbl
@@ -1,7 +1,7 @@
 #-index-name: Latvian
 #-display-name: Latvian braille
 
-#+locale:lv
+#+language:lv
 #+type:literary
 #+dots:6
 #+grade:1

--- a/tables/mao-nz-g1.ctb
+++ b/tables/mao-nz-g1.ctb
@@ -5,7 +5,7 @@
 #-index-name: Maori
 #-display-name: Maori braille
 #
-#+locale:mi
+#+language:mi
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ml.tbl
+++ b/tables/ml.tbl
@@ -1,7 +1,7 @@
 #-index-name: Malayalam
 #-display-name: Malayalam braille
 
-#+locale:ml
+#+language:ml
 #+type:literary
 #+grade:1
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/mn-MN-g1.utb
+++ b/tables/mn-MN-g1.utb
@@ -2,7 +2,7 @@
 #-index-name: Mongolian, uncontracted
 #-display-name: Mongolian uncontracted braille
 #
-#+locale:mn
+#+language:mn
 #+type:literary
 #+contraction:no
 #+dots:8

--- a/tables/mn-MN-g2.ctb
+++ b/tables/mn-MN-g2.ctb
@@ -2,7 +2,7 @@
 #-index-name: Mongolian, contracted
 #-display-name: Mongolian contracted braille
 #
-#+locale:mn
+#+language:mn
 #+type:literary
 #+contraction:full
 #+dots:8

--- a/tables/mni.tbl
+++ b/tables/mni.tbl
@@ -1,7 +1,7 @@
 #-index-name: Manipuri
 #-display-name: Manipuri braille
 
-#+locale:mni
+#+language:mni
 #+type:literary
 #+grade:1
 

--- a/tables/mr.tbl
+++ b/tables/mr.tbl
@@ -1,7 +1,7 @@
 #-index-name: Marathi
 #-display-name: Marathi braille
 
-#+locale:mr
+#+language:mr
 #+type:literary
 #+grade:1
 

--- a/tables/ms-my-g2.ctb
+++ b/tables/ms-my-g2.ctb
@@ -3,7 +3,7 @@
 #-display-name: Malay braille
 #-index-name: Malay
 #
-#+locale:ms
+#+language:ms
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/mt.tbl
+++ b/tables/mt.tbl
@@ -1,7 +1,7 @@
 #-index-name: Maltese, computer
 #-display-name: Maltese computer braille
 
-#+locale:mt
+#+language:mt
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/mun.tbl
+++ b/tables/mun.tbl
@@ -1,7 +1,7 @@
 #-index-name: Munda
 #-display-name: Munda braille
 
-#+locale:mun
+#+language:mun
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/mwr.tbl
+++ b/tables/mwr.tbl
@@ -1,7 +1,7 @@
 #-index-name: Marwari
 #-display-name: Marwari braille
 
-#+locale:mwr
+#+language:mwr
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/my-g1.utb
+++ b/tables/my-g1.utb
@@ -1,7 +1,7 @@
 #-index-name: Burmese, uncontracted
 #-display-name: Burmese uncontracted braille
 #
-#+locale: my
+#+language: my
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/my-g2.ctb
+++ b/tables/my-g2.ctb
@@ -1,7 +1,7 @@
 #-index-name: Burmese, contracted
 #-display-name: Burmese contracted braille
 #
-#+locale: my
+#+language: my
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/ne.tbl
+++ b/tables/ne.tbl
@@ -1,7 +1,7 @@
 #-index-name: Nepali
 #-display-name: Nepali braille
 
-#+locale:ne
+#+language:ne
 #+type:literary
 #+grade:1
 

--- a/tables/nl-comp8.utb
+++ b/tables/nl-comp8.utb
@@ -31,7 +31,7 @@
 #-index-name: Dutch, computer
 #-display-name: Dutch computer braille
 
-#+locale:nl
+#+language:nl
 #+type:computer
 #+dots:8
 #+direction:both

--- a/tables/nl.tbl
+++ b/tables/nl.tbl
@@ -1,7 +1,7 @@
 #-index-name: Dutch
 #-display-name: Dutch braille
 
-#+locale:nl
+#+language:nl
 #+type:literary
 #+contraction:no
 #+grade:0

--- a/tables/no-no-8dot-fallback-6dot-g0.utb
+++ b/tables/no-no-8dot-fallback-6dot-g0.utb
@@ -4,9 +4,9 @@
 #-index-name: Norwegian, uncontracted, 8-dot, 6-dot fallback
 #-display-name: Norwegian 8-dot uncontracted braille with 6-dot fallback
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:literary
 #+contraction:no
 #+dots:8

--- a/tables/no-no-8dot.utb
+++ b/tables/no-no-8dot.utb
@@ -4,9 +4,9 @@
 #-index-name: Norwegian, uncontracted, 8-dot
 #-display-name: Norwegian 8-dot uncontracted braille
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:literary
 #+contraction:no
 #+dots:8

--- a/tables/no-no-comp8.ctb
+++ b/tables/no-no-comp8.ctb
@@ -4,9 +4,9 @@
 #-index-name: Norwegian, computer
 #-display-name: Norwegian computer braille
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:computer
 #+dots:8
 #+grade:0

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -4,9 +4,9 @@
 #-index-name: Norwegian, uncontracted, 6-dot
 #-display-name: Norwegian 6-dot uncontracted braille
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:literary
 #+direction:both
 #+contraction:no

--- a/tables/no-no-g1.ctb
+++ b/tables/no-no-g1.ctb
@@ -4,9 +4,9 @@
 #-index-name: Norwegian, contracted, grade 1
 #-display-name: Norwegian grade 1 contracted braille
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:literary
 #+direction:both
 #+contraction:partial

--- a/tables/no-no-g2.ctb
+++ b/tables/no-no-g2.ctb
@@ -4,9 +4,9 @@
 #-index-name: Norwegian, contracted, grade 2
 #-display-name: Norwegian grade 2 contracted braille
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:literary
 #+direction:both
 #+dots:6

--- a/tables/no.tbl
+++ b/tables/no.tbl
@@ -2,9 +2,9 @@
 #-index-name: Norwegian, contracted, grade 3
 #-display-name: Norwegian grade 3 contracted braille
 #
-#+locale:no
-#+locale:nb
-#+locale:nn
+#+language:no
+#+language:nb
+#+language:nn
 #+type:literary
 #+direction:both
 #+dots:6

--- a/tables/nso-za-g1.utb
+++ b/tables/nso-za-g1.utb
@@ -8,7 +8,7 @@
 # choose to name this table "Sepedi" because that is the language that
 # is mentioned in the South African constitution.
 
-#+locale: nso
+#+language: nso
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/nso-za-g2.ctb
+++ b/tables/nso-za-g2.ctb
@@ -8,7 +8,7 @@
 # choose to name this table "Sepedi" because that is the language that
 # is mentioned in the South African constitution.
 
-#+locale: nso
+#+language: nso
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/or.tbl
+++ b/tables/or.tbl
@@ -1,7 +1,7 @@
 #-index-name: Oriya
 #-display-name: Oriya braille
 
-#+locale:or
+#+language:or
 #+type:literary
 #+grade:1
 

--- a/tables/pa.tbl
+++ b/tables/pa.tbl
@@ -1,7 +1,7 @@
 #-index-name: Punjabi
 #-display-name: Punjabi braille
 
-#+locale:pa
+#+language:pa
 #+type:literary
 #+grade:1
 

--- a/tables/pi.tbl
+++ b/tables/pi.tbl
@@ -1,7 +1,7 @@
 #-index-name: Pali
 #-display-name: Pali braille
 
-#+locale:pi
+#+language:pi
 #+type:literary
 
 # TODO: Please correct the metadata above. It is not meant to be

--- a/tables/pl-pl-comp8.ctb
+++ b/tables/pl-pl-comp8.ctb
@@ -5,7 +5,7 @@
 #-index-name: Polish, computer
 #-display-name: Polish computer braille
 #
-#+locale:pl
+#+language:pl
 #+type:computer
 #+dots:8
 #

--- a/tables/pl.tbl
+++ b/tables/pl.tbl
@@ -2,7 +2,7 @@
 #-index-name: Polish
 #-display-name: Polish braille
 
-#+locale:pl
+#+language:pl
 #+type:literary
 #+direction:both
 #+contraction: no

--- a/tables/pt-pt-comp8.ctb
+++ b/tables/pt-pt-comp8.ctb
@@ -2,7 +2,7 @@
 #-index-name: Portuguese, computer
 #-display-name: Portuguese computer braille
 #
-#+locale:pt
+#+language:pt
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/pt-pt-g1.utb
+++ b/tables/pt-pt-g1.utb
@@ -4,7 +4,7 @@
 #-index-name: Portuguese, uncontracted
 #-display-name: Portuguese uncontracted braille
 #
-#+locale:pt
+#+language:pt
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/pt.tbl
+++ b/tables/pt.tbl
@@ -1,7 +1,7 @@
 #-index-name: Portuguese, contracted
 #-display-name: Portuguese contracted braille
 
-#+locale:pt
+#+language:pt
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/ro.tbl
+++ b/tables/ro.tbl
@@ -1,7 +1,7 @@
 #-index-name: Romanian, computer
 #-display-name: Romanian computer braille
 
-#+locale:ro
+#+language:ro
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/ru-compbrl.ctb
+++ b/tables/ru-compbrl.ctb
@@ -4,7 +4,7 @@
 #-index-name: Russian, for program sources
 #-display-name: Russian braille for program sources
 #
-#+locale:ru
+#+language:ru
 #+type:literary
 #+contraction:no
 #+grade:0

--- a/tables/ru-litbrl-detailed.utb
+++ b/tables/ru-litbrl-detailed.utb
@@ -5,7 +5,7 @@
 #-index-name: Russian, with capitals
 #-display-name: Russian braille with indication of capitals
 #
-#+locale: ru
+#+language: ru
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/ru-litbrl.ctb
+++ b/tables/ru-litbrl.ctb
@@ -7,7 +7,7 @@
 #-index-name: Russian
 #-display-name: Russian braille
 #
-#+locale: ru
+#+language: ru
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/ru-ru-g1.ctb
+++ b/tables/ru-ru-g1.ctb
@@ -3,7 +3,7 @@
 #-index-name: Russian, contracted
 #-display-name: Russian contracted braille
 #
-#+locale: ru
+#+language: ru
 #+type: literary
 #+dots: 6
 #+contraction: partial

--- a/tables/ru.ctb
+++ b/tables/ru.ctb
@@ -1,7 +1,7 @@
 #-index-name: Russian, computer
 #-display-name: Russian computer braille
 
-#+locale: ru
+#+language: ru
 #+type: computer
 #+dots: 8
 #+direction: both

--- a/tables/sa.tbl
+++ b/tables/sa.tbl
@@ -1,7 +1,7 @@
 #-index-name: Sanskrit
 #-display-name: Sanskrit braille
 
-#+locale:sa
+#+language:sa
 #+type:literary
 #+grade:1
 

--- a/tables/sah.utb
+++ b/tables/sah.utb
@@ -1,7 +1,7 @@
 #-index-name: Yakut
 #-display-name: Yakut braille
 #
-#+locale: sah
+#+language: sah
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/sd.tbl
+++ b/tables/sd.tbl
@@ -1,7 +1,7 @@
 #-index-name: Sindhi
 #-display-name: Sindhi braille
 
-#+locale:sd
+#+language:sd
 #+type:literary
 #+grade:1
 

--- a/tables/sk.tbl
+++ b/tables/sk.tbl
@@ -1,7 +1,7 @@
 #-index-name: Slovak
 #-display-name: Slovak braille
 
-#+locale:sk
+#+language:sk
 #+type:literary
 #+grade:1
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/sl-si-comp8.ctb
+++ b/tables/sl-si-comp8.ctb
@@ -2,7 +2,7 @@
 #-index-name: Slovenian, computer
 #-display-name: Slovenian computer braille
 #
-#+locale:sl
+#+language:sl
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/sl.tbl
+++ b/tables/sl.tbl
@@ -1,7 +1,7 @@
 #-index-name: Slovenian
 #-display-name: Slovenian braille
 
-#+locale:sl
+#+language:sl
 #+type:literary
 #+grade:1
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/sot-za-g1.ctb
+++ b/tables/sot-za-g1.ctb
@@ -24,7 +24,7 @@
 # License along with liblouis. If not, see
 # <http://www.gnu.org/licenses/>.
 
-#+locale: st
+#+language: st
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/sot-za-g2.ctb
+++ b/tables/sot-za-g2.ctb
@@ -26,7 +26,7 @@
 # License along with liblouis. If not, see
 # <http://www.gnu.org/licenses/>.
 
-#+locale: st
+#+language: st
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/sr.tbl
+++ b/tables/sr.tbl
@@ -1,7 +1,7 @@
 #-index-name: Serbian
 #-display-name: Serbian braille
 
-#+locale:sr
+#+language:sr
 #+type:literary
 #+grade:1
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/sv-1989.ctb
+++ b/tables/sv-1989.ctb
@@ -2,7 +2,7 @@
 #-index-name: Swedish, computer, 1989
 #-display-name: Swedish computer braille (1989 standard)
 #
-#+locale:sv
+#+language:sv
 #+type:computer
 #+dots:8
 #+version:1989

--- a/tables/sv-1996.ctb
+++ b/tables/sv-1996.ctb
@@ -2,7 +2,7 @@
 #-index-name: Swedish, computer, 1996
 #-display-name: Swedish computer braille (1996 standard)
 #
-#+locale:sv
+#+language:sv
 #+type:computer
 #+dots:8
 #+version:1996

--- a/tables/sv.tbl
+++ b/tables/sv.tbl
@@ -1,7 +1,7 @@
 #-index-name: Swedish
 #-display-name: Swedish braille
 
-#+locale:sv
+#+language:sv
 #+type:literary
 #+grade:1
 

--- a/tables/ta-ta-g1.ctb
+++ b/tables/ta-ta-g1.ctb
@@ -2,7 +2,7 @@
 #-index-name: Tamil
 #-display-name: Tamil braille
 #
-#+locale:ta
+#+language:ta
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ta.tbl
+++ b/tables/ta.tbl
@@ -1,7 +1,7 @@
 #-index-name: Tamil, computer
 #-display-name: Tamil computer braille
 
-#+locale:ta
+#+language:ta
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/te.tbl
+++ b/tables/te.tbl
@@ -1,7 +1,7 @@
 #-index-name: Telugu
 #-display-name: Telugu braille
 
-#+locale:te
+#+language:te
 #+type:literary
 #+grade:1
 

--- a/tables/tr-g2.tbl
+++ b/tables/tr-g2.tbl
@@ -1,7 +1,7 @@
 #-index-name: Turkish
 #-display-name: Turkish braille
 #
-#+locale:tr
+#+language:tr
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/tr.tbl
+++ b/tables/tr.tbl
@@ -1,7 +1,7 @@
 #-index-name: Turkish, computer
 #-display-name: Turkish computer braille
 
-#+locale:tr
+#+language:tr
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/tsn-za-g1.ctb
+++ b/tables/tsn-za-g1.ctb
@@ -3,7 +3,7 @@
 #-display-name: Setswana uncontracted braille
 #-index-name: Setswana, uncontracted
 
-#+locale: tn
+#+language: tn
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/tsn-za-g2.ctb
+++ b/tables/tsn-za-g2.ctb
@@ -3,7 +3,7 @@
 #-display-name: Setswana contracted braille
 #-index-name: Setswana, contracted
 
-#+locale: tn
+#+language: tn
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/tt.utb
+++ b/tables/tt.utb
@@ -1,7 +1,7 @@
 #-index-name: Tatar
 #-display-name: Tatar braille
 #
-#+locale: tt
+#+language: tt
 #+type: literary
 #+dots: 6
 #+contraction: no

--- a/tables/uk-comp.utb
+++ b/tables/uk-comp.utb
@@ -1,7 +1,7 @@
 #-index-name: Ukrainian, computer
 #-display-name: Ukrainian computer braille
 
-#+locale: uk
+#+language: uk
 #+type: computer
 #+dots: 8
 #+direction: both

--- a/tables/uk.utb
+++ b/tables/uk.utb
@@ -1,7 +1,7 @@
 #-index-name: Ukrainian
 #-display-name: Ukrainian braille
 
-#+locale: uk
+#+language: uk
 #+type: literary
 #+direction: forward
 

--- a/tables/ur-pk-g1.utb
+++ b/tables/ur-pk-g1.utb
@@ -3,7 +3,7 @@
 #-index-name: Urdu, uncontracted
 #-display-name: Urdu uncontracted braille
 #
-#+locale:ur
+#+language:ur
 #+type:literary
 #+contraction:no
 #+grade:1

--- a/tables/ur-pk-g2.ctb
+++ b/tables/ur-pk-g2.ctb
@@ -3,7 +3,7 @@
 #-index-name: Urdu, contracted
 #-display-name: Urdu contracted braille
 #
-#+locale:ur
+#+language:ur
 #+type:literary
 #+contraction:full
 #+grade:2

--- a/tables/uz-g1.utb
+++ b/tables/uz-g1.utb
@@ -21,7 +21,7 @@
 #-index-name: Uzbek
 #-display-name: Uzbek braille
 
-#+locale:uz
+#+language:uz
 #+type:literary
 # Marked as "direction:forward" by Bue Vester-Andersen
 # Literary table without caps.

--- a/tables/ve-za-g1.utb
+++ b/tables/ve-za-g1.utb
@@ -24,7 +24,7 @@
 # License along with liblouis. If not, see
 # <http://www.gnu.org/licenses/>.
 
-#+locale: ve
+#+language: ve
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/ve-za-g2.ctb
+++ b/tables/ve-za-g2.ctb
@@ -24,7 +24,7 @@
 # License along with liblouis. If not, see
 # <http://www.gnu.org/licenses/>.
 
-#+locale: ve
+#+language: ve
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/vi-saigon-g1.ctb
+++ b/tables/vi-saigon-g1.ctb
@@ -1,7 +1,7 @@
 #-index-name: Vietnamese, Saigon, contracted
 #-display-name: Southern Vietnamese braille
 #
-#+locale: vi
+#+language: vi
 #+type: literary
 #+contraction: full
 #+grade: 1

--- a/tables/vi-vn-g0.utb
+++ b/tables/vi-vn-g0.utb
@@ -1,7 +1,7 @@
 #-index-name: Vietnamese, uncontracted
 #-display-name: Vietnamese uncontracted braille
 #
-#+locale: vi
+#+language: vi
 #+type: literary
 #+contraction: no
 #+grade: 0

--- a/tables/vi-vn-g1.ctb
+++ b/tables/vi-vn-g1.ctb
@@ -1,7 +1,7 @@
 #-index-name: Vietnamese, partially contracted
 #-display-name: Vietnamese partially contracted braille
 #
-#+locale: vi
+#+language: vi
 #+type: literary
 #+contraction: partial
 #+grade: 1

--- a/tables/vi-vn-g2.ctb
+++ b/tables/vi-vn-g2.ctb
@@ -1,7 +1,7 @@
 #-index-name: Vietnamese, contracted
 #-display-name: Vietnamese contracted braille
 #
-#+locale: vi
+#+language: vi
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/vi.ctb
+++ b/tables/vi.ctb
@@ -2,7 +2,7 @@
 #-index-name: Vietnamese, computer
 #-display-name: Vietnamese computer braille
 #
-#+locale:vi
+#+language:vi
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/xh-za-g1.utb
+++ b/tables/xh-za-g1.utb
@@ -24,7 +24,7 @@
 # License along with liblouis. If not, see
 # <http://www.gnu.org/licenses/>.
 
-#+locale: xh
+#+language: xh
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/xh-za-g2.ctb
+++ b/tables/xh-za-g2.ctb
@@ -24,7 +24,7 @@
 # License along with liblouis. If not, see
 # <http://www.gnu.org/licenses/>.
 
-#+locale: xh
+#+language: xh
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tables/zh_CHN.tbl
+++ b/tables/zh_CHN.tbl
@@ -1,7 +1,8 @@
 #-index-name: Mandarin, mainland China, without tones
 #-display-name: Chinese braille without tones, for simplified Chinese characters
 
-#+locale:cmn-Hans-CN
+#+language:cmn-Hans
+#+region:cmn-CN
 #+type:literary
 #+system:cmn-traditional
 #+variant:no-tone

--- a/tables/zh_HK.tbl
+++ b/tables/zh_HK.tbl
@@ -1,7 +1,8 @@
 #-index-name: Cantonese
 #-display-name: Cantonese braille
 
-#+locale:yue-HK
+#+language:yue
+#+region:yue-HK
 #+type:literary
 
 # TODO: Please add a reference to official documentation about

--- a/tables/zh_TW.tbl
+++ b/tables/zh_TW.tbl
@@ -1,7 +1,8 @@
 #-index-name: Mandarin, Taiwan
 #-display-name: Taiwanese braille
 
-#+locale:cmn-TW
+#+language:cmn
+#+region:cmn-TW
 #+type:literary
 # Marked as "direction:forward" by Bue Vester-Andersen
 # as there are only very few backward tests.

--- a/tables/zhcn-g1.ctb
+++ b/tables/zhcn-g1.ctb
@@ -3,7 +3,8 @@
 #-index-name: Mandarin, mainland China, with tones
 #-display-name: Chinese braille with tones
 #
-#+locale:cmn-CN
+#+language:cmn
+#+region:cmn-CN
 #+type:literary
 #+system:cmn-traditional
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/zhcn-g2.ctb
+++ b/tables/zhcn-g2.ctb
@@ -3,7 +3,8 @@
 #-index-name:  Mandarin, mainland China, 2-cell
 #-display-name: Two-cell Chinese braille
 #
-#+locale:cmn-CN
+#+language:cmn
+#+region:cmn-CN
 #+type:literary
 #+system:cmn-two-cell
 # Marked as "direction:forward" by Bue Vester-Andersen

--- a/tables/zu-za-g1.utb
+++ b/tables/zu-za-g1.utb
@@ -3,7 +3,7 @@
 #-display-name: isiZulu uncontracted braille
 #-index-name: isiZulu, uncontracted
 
-#+locale: zu
+#+language: zu
 #+type: literary
 #+contraction: no
 #+grade: 1

--- a/tables/zu-za-g2.ctb
+++ b/tables/zu-za-g2.ctb
@@ -3,7 +3,7 @@
 #-display-name: isiZulu contracted braille
 #-index-name: isiZulu, contracted
 
-#+locale: zu
+#+language: zu
 #+type: literary
 #+contraction: full
 #+grade: 2

--- a/tests/braille-specs/afr-za-g2.yaml
+++ b/tests/braille-specs/afr-za-g2.yaml
@@ -10,7 +10,7 @@
 
 display: unicode.dis
 table:
-  locale: af
+  language: af
   grade: 2
   __assert-match: afr-za-g2.ctb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/ar-ar-comp8.yaml
+++ b/tests/braille-specs/ar-ar-comp8.yaml
@@ -10,7 +10,7 @@
 
 display: unicode.dis
 table:
-  locale: ar
+  language: ar
   type: computer
   dots: 8
   __assert-match: ar-ar-comp8.utb

--- a/tests/braille-specs/ar-ar-g1.yaml
+++ b/tests/braille-specs/ar-ar-g1.yaml
@@ -13,7 +13,7 @@
 
 display: unicode.dis
 table:
-  locale: ar
+  language: ar
   grade: 1
   __assert-match: ar.tbl
 

--- a/tests/braille-specs/ar-ar-g1_harness.yaml
+++ b/tests/braille-specs/ar-ar-g1_harness.yaml
@@ -8,7 +8,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: ar
+  language: ar
   grade: 1
   __assert-match: ar.tbl # ar-ar-g1.utb
 

--- a/tests/braille-specs/ar-ar-g2.yaml
+++ b/tests/braille-specs/ar-ar-g2.yaml
@@ -8,7 +8,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: ar
+  language: ar
   grade: 2
   __assert-match: ar-ar-g2.ctb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/ba.yaml
+++ b/tests/braille-specs/ba.yaml
@@ -18,7 +18,7 @@
 
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: ba
+  language: ba
   type: literary
   __assert-match: ba.utb
 tests:
@@ -46,8 +46,8 @@ display: |
   display 9 9
   display a a
 table:
-  # locale: ba
-  locale: ru
+  # language: ba
+  language: ru
   type: computer
 flags: {testmode: bothDirections}
 tests:

--- a/tests/braille-specs/bel.yaml
+++ b/tests/braille-specs/bel.yaml
@@ -14,7 +14,7 @@
 # literary braille
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: be
+  language: be
   type: literary
   __assert-match: bel.utb
   contraction: no
@@ -47,7 +47,7 @@ display: |
   display 9 9
   display a a
 table:
-  locale: be
+  language: be
   type: computer
   __assert-match: bel-comp.utb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/bg.yaml
+++ b/tests/braille-specs/bg.yaml
@@ -13,7 +13,7 @@ display: |
   display \s 0
   include bg.dis
 table:
-  locale: bg
+  language: bg
   type: literary
   contraction: no
   dots: 6

--- a/tests/braille-specs/chr-us-g1_harness.yaml
+++ b/tests/braille-specs/chr-us-g1_harness.yaml
@@ -1,6 +1,6 @@
 display: text_nabcc.dis
 table:
-  locale: chr
+  language: chr
   grade: 1
   __assert-match: chr-us-g1.ctb
 tests:

--- a/tests/braille-specs/cs-comp8_harness.yaml
+++ b/tests/braille-specs/cs-comp8_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: cs
+  language: cs
   type: computer
   __assert-match: cs-comp8.utb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/cs_harness.yaml
+++ b/tests/braille-specs/cs_harness.yaml
@@ -1,6 +1,6 @@
 ﻿display: unicode-without-blank.dis
 table:
-  locale: cs
+  language: cs
   type: literary
   grade: 1
 tests:

--- a/tests/braille-specs/da-dk-g08.yaml
+++ b/tests/braille-specs/da-dk-g08.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 0
   dots: 8
   __assert-match: da-dk-g08.ctb

--- a/tests/braille-specs/da-dk-g16-lit.yaml
+++ b/tests/braille-specs/da-dk-g16-lit.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 1
   dots: 6
   direction: forward

--- a/tests/braille-specs/da-dk-g16.yaml
+++ b/tests/braille-specs/da-dk-g16.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 1
   dots: 6
   direction: both

--- a/tests/braille-specs/da-dk-g18.yaml
+++ b/tests/braille-specs/da-dk-g18.yaml
@@ -3,7 +3,7 @@
 # translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,da-dk-g18.ctb
 table:
-  locale: da
+  language: da
   grade: 1
   dots: 8
   __assert-match: da-dk-g18.ctb

--- a/tests/braille-specs/da-dk-g26-lit.yaml
+++ b/tests/braille-specs/da-dk-g26-lit.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 2
   dots: 6
   direction: forward

--- a/tests/braille-specs/da-dk-g26.yaml
+++ b/tests/braille-specs/da-dk-g26.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 2
   dots: 6
   direction: both

--- a/tests/braille-specs/da-dk-g26l-lit.yaml
+++ b/tests/braille-specs/da-dk-g26l-lit.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 1.5
   dots: 6
   direction: forward

--- a/tests/braille-specs/da-dk-g26l.yaml
+++ b/tests/braille-specs/da-dk-g26l.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 1.5
   dots: 6
   direction: both

--- a/tests/braille-specs/da-dk-g28.yaml
+++ b/tests/braille-specs/da-dk-g28.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 2
   dots: 8
   __assert-match: da-dk-g28.ctb

--- a/tests/braille-specs/da-dk-g28l.yaml
+++ b/tests/braille-specs/da-dk-g28l.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: da
+  language: da
   grade: 1.5
   dots: 8
   __assert-match: da-dk-g28l.ctb

--- a/tests/braille-specs/de-de-comp8.yaml
+++ b/tests/braille-specs/de-de-comp8.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   type: computer
   __assert-match: de-de-comp8.ctb
 tests:

--- a/tests/braille-specs/de-eurobrl6.yaml
+++ b/tests/braille-specs/de-eurobrl6.yaml
@@ -9,9 +9,9 @@
 # ----------------------------------------------------------------------------------------------
 
 table: de-eurobrl6.dis
-table: {locale: de, grade: 0}
-table: {locale: de, grade: 1}
-table: {locale: de, grade: 2}
+table: {language: de, grade: 0}
+table: {language: de, grade: 1}
+table: {language: de, grade: 2}
 flags: {testmode: display}
 tests:
   - - " abcdefghijklmnopqrstuvxyz"
@@ -28,9 +28,9 @@ tests:
   - - "_"
     - ⠸
 
-table: {locale: de, grade: 0}
-table: {locale: de, grade: 1}
-table: {locale: de, grade: 2}
+table: {language: de, grade: 0}
+table: {language: de, grade: 1}
+table: {language: de, grade: 2}
 flags: {testmode: display}
 tests:
   - - "\\x007F"

--- a/tests/braille-specs/de-g0-bidi-dictionary.yaml
+++ b/tests/braille-specs/de-g0-bidi-dictionary.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 0
   type: literary
   dots: 6

--- a/tests/braille-specs/de-g0-bidi-specs.yaml
+++ b/tests/braille-specs/de-g0-bidi-specs.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 0
   type: literary
   dots: 6

--- a/tests/braille-specs/de-g0.yaml
+++ b/tests/braille-specs/de-g0.yaml
@@ -12,7 +12,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 0
   type: literary
   dots: 6
@@ -516,7 +516,7 @@ tests:
 
 display: de-eurobrl6.dis
 table:
-  locale: de
+  language: de
   grade: 0
   type: literary
   dots: 6

--- a/tests/braille-specs/de-g1-bidi-dictionary.yaml
+++ b/tests/braille-specs/de-g1-bidi-dictionary.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 1
   type: literary
   dots: 6

--- a/tests/braille-specs/de-g1-bidi-specs.yaml
+++ b/tests/braille-specs/de-g1-bidi-specs.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 1
   type: literary
   dots: 6

--- a/tests/braille-specs/de-g1-dictionary.yaml
+++ b/tests/braille-specs/de-g1-dictionary.yaml
@@ -20,7 +20,7 @@
 
 display: de-eurobrl6u.dis
 table:
-  locale: de
+  language: de
   grade: 1
   __assert-match: de-g1.ctb 
 tests:

--- a/tests/braille-specs/de-g1.yaml
+++ b/tests/braille-specs/de-g1.yaml
@@ -12,7 +12,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 1
   type: literary
   dots: 6
@@ -474,7 +474,7 @@ tests:
 
 display: de-eurobrl6.dis
 table:
-  locale: de
+  language: de
   grade: 1
   type: literary
   dots: 6

--- a/tests/braille-specs/de-g2-dictionary.yaml
+++ b/tests/braille-specs/de-g2-dictionary.yaml
@@ -24,7 +24,7 @@
 
 display: de-eurobrl6u.dis
 table:
-  locale: de
+  language: de
   grade: 2
   __assert-match: de-g2.ctb
 tests:
@@ -9930,7 +9930,7 @@ tests:
 # translation issues identified by blista
 display: unicode.dis
 table:
-  locale: de
+  language: de
   grade: 2
   __assert-match: de-g2.ctb
 tests:

--- a/tests/braille-specs/de-g2.yaml
+++ b/tests/braille-specs/de-g2.yaml
@@ -12,7 +12,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: de
+  language: de
   grade: 2
   type: literary
   dots: 6
@@ -472,7 +472,7 @@ tests:
 
 display: de-eurobrl6.dis
 table:
-  locale: de
+  language: de
   grade: 2
   type: literary
   dots: 6

--- a/tests/braille-specs/el-backward.yaml
+++ b/tests/braille-specs/el-backward.yaml
@@ -7,7 +7,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: el
+  language: el
   __assert-match: el.ctb
 flags: {testmode: backward}
 tests:

--- a/tests/braille-specs/el-forward.yaml
+++ b/tests/braille-specs/el-forward.yaml
@@ -7,7 +7,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: el
+  language: el
   __assert-match: el.ctb
 flags: {testmode: forward}
 tests:

--- a/tests/braille-specs/en-GB-g2.yaml
+++ b/tests/braille-specs/en-GB-g2.yaml
@@ -15,7 +15,8 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: en-GB
+  language: en
+  region: en-GB
   grade: 2
   __assert-match: en_GB.tbl # en-GB-g2.ctb
 

--- a/tests/braille-specs/en-gb-g1_harness.yaml
+++ b/tests/braille-specs/en-gb-g1_harness.yaml
@@ -1,6 +1,7 @@
 display: unicode-without-blank.dis
 table:
-  locale: en-GB
+  language: en
+  region: en-GB
   grade: 1
   __assert-match: en-gb-g1.utb
 tests:

--- a/tests/braille-specs/en-ueb-02-stand_alone.yaml
+++ b/tests/braille-specs/en-ueb-02-stand_alone.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-03-symbols.yaml
+++ b/tests/braille-specs/en-ueb-03-symbols.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-05-grade_1_mode.yaml
+++ b/tests/braille-specs/en-ueb-05-grade_1_mode.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-06-numeric_mode.yaml
+++ b/tests/braille-specs/en-ueb-06-numeric_mode.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-08-capitalization.yaml
+++ b/tests/braille-specs/en-ueb-08-capitalization.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-09-typeforms.yaml
+++ b/tests/braille-specs/en-ueb-09-typeforms.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-10-07-contractions.yaml
+++ b/tests/braille-specs/en-ueb-10-07-contractions.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-10-13-contractions.yaml
+++ b/tests/braille-specs/en-ueb-10-13-contractions.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-computer-code.yaml
+++ b/tests/braille-specs/en-ueb-computer-code.yaml
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------------------------
 
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-g1_backward.yaml
+++ b/tests/braille-specs/en-ueb-g1_backward.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: en
+  language: en
   grade: 1
   system: ueb
   __assert-match: en-ueb-g1.ctb

--- a/tests/braille-specs/en-ueb-g1_harness.yaml
+++ b/tests/braille-specs/en-ueb-g1_harness.yaml
@@ -9,7 +9,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: en
+  language: en
   grade: 1
   system: ueb
   __assert-match: en-ueb-g1.ctb

--- a/tests/braille-specs/en-ueb-g2-dictionary_harness.yaml
+++ b/tests/braille-specs/en-ueb-g2-dictionary_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-g2_backward.yaml
+++ b/tests/braille-specs/en-ueb-g2_backward.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-g2_backward_no_dis.yaml
+++ b/tests/braille-specs/en-ueb-g2_backward_no_dis.yaml
@@ -1,6 +1,6 @@
 # Tests for en-ueb-g2.ctb back-translation with no additional display table.
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-math.yaml
+++ b/tests/braille-specs/en-ueb-math.yaml
@@ -1,5 +1,5 @@
 table:
-  locale: en
+  language: en
   grade: 1
   system: ueb
   __assert-match: en-ueb-g1.ctb

--- a/tests/braille-specs/en-ueb-repeated-underscores.yaml
+++ b/tests/braille-specs/en-ueb-repeated-underscores.yaml
@@ -10,7 +10,7 @@
 # See https://www.freelists.org/post/liblouis-liblouisxml/FW-UEB-grade-2-with-repeated-underscores-as-one-or-two-cells-instead-of-full-cells
 # See https://github.com/liblouis/liblouis/pull/792 which contains a related change but did not fix the test
 table:
-  locale: en
+  language: en
   grade: 2
   system: ueb
   __assert-match: en-ueb-g2.ctb

--- a/tests/braille-specs/en-ueb-symbols_harness.yaml
+++ b/tests/braille-specs/en-ueb-symbols_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: en
+  language: en
   grade: 1
   system: ueb
   __assert-match: en-ueb-g1.ctb

--- a/tests/braille-specs/en-us-comp6.yaml
+++ b/tests/braille-specs/en-us-comp6.yaml
@@ -12,7 +12,8 @@
 
 display: unicode.dis
 table:
-  locale: en-US
+  language: en
+  region: en-US
   type: computer
   dots: 6
   __assert-match: en-us-comp6.ctb

--- a/tests/braille-specs/en-us-comp8-ext-back_harness.yaml
+++ b/tests/braille-specs/en-us-comp8-ext-back_harness.yaml
@@ -1,6 +1,7 @@
 display: unicode-without-blank.dis
 table:
-  locale: en-US
+  language: en
+  region: en-US
   type: computer
   dots: 8
   __assert-match: en_US-comp8-ext.tbl # en-us-comp8-ext.utb

--- a/tests/braille-specs/en-us-comp8-ext-for_harness.yaml
+++ b/tests/braille-specs/en-us-comp8-ext-for_harness.yaml
@@ -1,6 +1,7 @@
 display: unicode-without-blank.dis
 table:
-  locale: en-US
+  language: en
+  region: en-US
   type: computer
   dots: 8
   __assert-match: en_US-comp8-ext.tbl # en-us-comp8-ext.utb

--- a/tests/braille-specs/en-us-g2-dictionary_harness.yaml
+++ b/tests/braille-specs/en-us-g2-dictionary_harness.yaml
@@ -1,6 +1,7 @@
 display: unicode-without-blank.dis
 table:
-  locale: en-US
+  language: en
+  region: en-US
   grade: 2
   __assert-match: en_US.tbl # en-us-g2.ctb
 tests:

--- a/tests/braille-specs/en-us-g2.yaml
+++ b/tests/braille-specs/en-us-g2.yaml
@@ -1,6 +1,7 @@
 display: unicode-without-blank.dis
 table:
-  locale: en-US
+  language: en
+  region: en-US
   grade: 2
   __assert-match: en_US.tbl # en-us-g2.ctb
 

--- a/tests/braille-specs/eo-g1_harness.yaml
+++ b/tests/braille-specs/eo-g1_harness.yaml
@@ -1,6 +1,6 @@
 display: en-us-brf.dis
 table:
-  locale: eo
+  language: eo
   grade: 1
   __assert-match: eo.tbl # eo-g1.ctb
 tests:

--- a/tests/braille-specs/es-comp.yaml
+++ b/tests/braille-specs/es-comp.yaml
@@ -4,7 +4,7 @@
 # The issue was fixed by https://github.com/liblouis/liblouis/pull/477.
 display: unicode-without-blank.dis
 table:
-  locale: es
+  language: es
   type: computer
   __assert-match: Es-Es-G0.utb
 flags: {testmode: forward}

--- a/tests/braille-specs/es-g2.yaml
+++ b/tests/braille-specs/es-g2.yaml
@@ -7,7 +7,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: es
+  language: es
   grade: 2
   __assert-match: es-g2.ctb
 

--- a/tests/braille-specs/ethio-g1_harness.yaml
+++ b/tests/braille-specs/ethio-g1_harness.yaml
@@ -8,7 +8,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: gez
+  language: gez
   grade: 1
   __assert-match: gez.tbl # ethio-g1.ctb
 

--- a/tests/braille-specs/fa-ir-comp8-harness.yaml
+++ b/tests/braille-specs/fa-ir-comp8-harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: fa
+  language: fa
   type: computer
   dots: 8
   __assert-match: fa-ir-comp8.ctb

--- a/tests/braille-specs/fa-ir-g1-harness.yaml
+++ b/tests/braille-specs/fa-ir-g1-harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: fa
+  language: fa
   grade: 1
   __assert-match: fa-ir-g1.utb
 tests:

--- a/tests/braille-specs/fi_harness.yaml
+++ b/tests/braille-specs/fi_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: fi
+  language: fi
   type: literary
   __assert-match: fi.utb
 tests:

--- a/tests/braille-specs/fr-bfu-comp6.yaml
+++ b/tests/braille-specs/fr-bfu-comp6.yaml
@@ -11,7 +11,7 @@
 # translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,fr-bfu-comp6.utb
 table:
-  locale: fr
+  language: fr
   type: literary
   dots: 6
   system: bfu
@@ -165,7 +165,7 @@ tests:
 
 
 table:
-  locale: fr
+  language: fr
   type: literary
   dots: 6
   system: bfu

--- a/tests/braille-specs/fr-bfu-comp8.yaml
+++ b/tests/braille-specs/fr-bfu-comp8.yaml
@@ -7,7 +7,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: fr
+  language: fr
   type: computer
   dots: 8
   system: bfu
@@ -48,7 +48,7 @@ tests:
   - ["ƒŠšŽžŸÿµÃãÅÅÆæÌìÐðÒòÕõØøÝýÞþ", "⢋⣮⢮⣵⢵⣹⢲⡒⣁⢁⡂⡂⡜⢜⣊⢊⣃⢃⣕⢕⣅⣨⣼⢰⣽⢽⣚⢚"]
 
 table:
-  locale: fr
+  language: fr
   type: computer
   dots: 8
   system: bfu

--- a/tests/braille-specs/fr-bfu-g2.yaml
+++ b/tests/braille-specs/fr-bfu-g2.yaml
@@ -11,7 +11,7 @@
 # translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,fr-bfu-g2.ctb
 table:
-  locale: fr
+  language: fr
   grade: 2
   system: bfu
   __assert-match: fr-bfu-g2.ctb
@@ -1110,7 +1110,7 @@ tests:
     - ["[(1+1)-(34+14)]", "⠠⠷⠦⠡⠖⠡⠴⠤⠦⠩⠹⠖⠡⠹⠴⠾"]
 
 table:
-  locale: fr
+  language: fr
   grade: 2
   system: bfu
   __assert-match: fr-bfu-g2.ctb

--- a/tests/braille-specs/fr-bfu-g2_harness.yaml
+++ b/tests/braille-specs/fr-bfu-g2_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: fr
+  language: fr
   grade: 2
   system: bfu
   __assert-match: fr-bfu-g2.ctb

--- a/tests/braille-specs/ga-g1_harness.yaml
+++ b/tests/braille-specs/ga-g1_harness.yaml
@@ -11,7 +11,7 @@
 
 display: unicode.dis
 table:
-  locale: ga
+  language: ga
   grade: 1
   system: INBAF
   __assert-match: ga-g1.utb

--- a/tests/braille-specs/ga-g2_harness.yaml
+++ b/tests/braille-specs/ga-g2_harness.yaml
@@ -11,7 +11,7 @@
 
 display: unicode.dis
 table:
-  locale: ga
+  language: ga
   grade: 2
   system: INBAF
   __assert-match: ga-g2.ctb

--- a/tests/braille-specs/grc-international-common.yaml
+++ b/tests/braille-specs/grc-international-common.yaml
@@ -10,7 +10,7 @@ table: spaces.uti,grc-international-common.uti
 table: spaces.uti,grc-international-decomposed.uti
 table: spaces.uti,grc-international-composed.uti
 table:
-  locale: grc
+  language: grc
   region: en
   __assert-match: grc-international-en.utb
 flags: {testmode: forward}

--- a/tests/braille-specs/grc-international-decomposed.yaml
+++ b/tests/braille-specs/grc-international-decomposed.yaml
@@ -8,7 +8,7 @@
 display: unicode-without-blank.dis
 table: spaces.uti,grc-international-decomposed.uti
 table:
-  locale: grc
+  language: grc
   region: en
   __assert-match: grc-international-en.utb
 flags: {testmode: forward}

--- a/tests/braille-specs/he-IL.yaml
+++ b/tests/braille-specs/he-IL.yaml
@@ -23,7 +23,7 @@ display: unicode-without-blank.dis
 
 # Test for uncontracted braille
 table:
-  locale: mul-IL
+  region: mul-IL
   grade: 1
   dots: 6
   __assert-match: he-IL.utb
@@ -61,7 +61,7 @@ tests:
 
 # Test for computer braille
 table:
-  locale: he
+  language: he
   type: computer
   __assert-match: he-IL-comp8.utb
 tests:

--- a/tests/braille-specs/hi_harness.yaml
+++ b/tests/braille-specs/hi_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode.dis
 table:
-  locale: hi
+  language: hi
   type: literary
   grade: 1
   __assert-match: hi.tbl # hi-in-g1.utb

--- a/tests/braille-specs/hr-8dots_harness.yaml
+++ b/tests/braille-specs/hr-8dots_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: hr
+  language: hr
   type: computer
   dots: 8
   __assert-match: hr-comp8.tbl # hr-comp8.utb

--- a/tests/braille-specs/hu-hu-comp8_backward.yaml
+++ b/tests/braille-specs/hu-hu-comp8_backward.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: hu
+  language: hu
   type: computer
   dots: 8
   __assert-match: hu-hu-comp8.ctb

--- a/tests/braille-specs/hu-hu-comp8_harness.yaml
+++ b/tests/braille-specs/hu-hu-comp8_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: hu
+  language: hu
   type: computer
   dots: 8
   __assert-match: hu-hu-comp8.ctb

--- a/tests/braille-specs/hu-hu-g1_backward.yaml
+++ b/tests/braille-specs/hu-hu-g1_backward.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: hu
+  language: hu
   grade: 1
   __assert-match: hu.tbl # hu-hu-g1.ctb
 flags: {testmode: backward}

--- a/tests/braille-specs/hu-hu-g1_harness.yaml
+++ b/tests/braille-specs/hu-hu-g1_harness.yaml
@@ -3,7 +3,7 @@ display: |
   display 9 9
   display a a
 table:
-  locale: hu
+  language: hu
   grade: 1
   __assert-match: hu.tbl # hu-hu-g1.ctb
 tests:

--- a/tests/braille-specs/hu-hu-g2_backward.yaml
+++ b/tests/braille-specs/hu-hu-g2_backward.yaml
@@ -1,6 +1,6 @@
 display: unicode.dis
 table:
-  locale: hu
+  language: hu
   grade: 2
   __assert-match: hu-hu-g2.ctb
 flags: {testmode: backward}

--- a/tests/braille-specs/hu-hu-g2_harness.yaml
+++ b/tests/braille-specs/hu-hu-g2_harness.yaml
@@ -3,7 +3,7 @@ display: |
   display 9 9
   display a a
 table:
-  locale: hu
+  language: hu
   grade: 2
   __assert-match: hu-hu-g2.ctb
 flags: {testmode: forward}

--- a/tests/braille-specs/iu-ca-g1_harness.yaml
+++ b/tests/braille-specs/iu-ca-g1_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: iu
+  language: iu
   grade: 1
   __assert-match: iu-ca-g1.ctb
 tests:

--- a/tests/braille-specs/ja-kantenji.yaml
+++ b/tests/braille-specs/ja-kantenji.yaml
@@ -3,7 +3,7 @@
 #
 display: unicode-without-blank.dis
 table:
-  locale: ja
+  language: ja
   type: literary
   __assert-match: ja-kantenji.utb
   contraction: no

--- a/tests/braille-specs/kk.yaml
+++ b/tests/braille-specs/kk.yaml
@@ -11,7 +11,7 @@
 
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: kk
+  language: kk
   type: literary
   __assert-match: kk.utb
   contraction: no

--- a/tests/braille-specs/kmr.yaml
+++ b/tests/braille-specs/kmr.yaml
@@ -10,7 +10,7 @@
 
 display: unicode.dis
 table:
-  locale: kmr
+  language: kmr
   grade: 0
   __assert-match: kmr.tbl
 flags: {testmode: forward}

--- a/tests/braille-specs/ko-2006-g2_harness.yaml
+++ b/tests/braille-specs/ko-2006-g2_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: ko
+  language: ko
   grade: 2
   version: 2006
   __assert-match: ko-2006-g2.ctb

--- a/tests/braille-specs/ko-g2_harness.yaml
+++ b/tests/braille-specs/ko-g2_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: ko
+  language: ko
   grade: 2
   __assert-match: ko-g2.ctb
 tests:

--- a/tests/braille-specs/litdigits6Dots_backward.yaml
+++ b/tests/braille-specs/litdigits6Dots_backward.yaml
@@ -2,32 +2,33 @@ display: unicode-without-blank.dis
 
 # Tests for tables that use literary 6 dots notation for numbers, e.g. [⠼⠁, 1]
 table:
-  locale: en
+  language: en
   grade: 1
   system: ueb
   __assert-match: en-ueb-g1.ctb
 table:
-  locale: en-US
+  language: en
+  region: en-US
   grade: 1
   __assert-match: en-us-g1.ctb
 table:
-  locale: fi
+  language: fi
   type: literary
   __assert-match: fi.utb
 table:
-  locale: nl
+  language: nl
   grade: 0
   __assert-match: nl.tbl # nl-NL-g0.utb
 table:
-  locale: pl
+  language: pl
   type: literary
   __assert-match: pl.tbl # Pl-Pl-g1.utb
 table:
-  locale: sr
+  language: sr
   grade: 1
   __assert-match: sr.tbl # sr-g1.ctb
 table:
-  locale: sv
+  language: sv
   grade: 1
   __assert-match: sv.tbl # Se-Se-g1.utb
 flags: {testmode: backward}
@@ -42,7 +43,7 @@ tests:
 # LV uses different letter definitions,
 # so run separately.
 table:
-  locale: lv
+  language: lv
   grade: 1
   __assert-match: lv.tbl # Lv-Lv-g1.utb
 flags: {testmode: backward}
@@ -57,7 +58,7 @@ tests:
 # pt-pt-g1.utb passes digits test, but fails
 # the small letters test.
 table:
-  locale: pt
+  language: pt
   grade: 1
   __assert-match: pt-pt-g1.utb
 flags: {testmode: backward}

--- a/tests/braille-specs/lt-6dot_harness.yaml
+++ b/tests/braille-specs/lt-6dot_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: lt
+  language: lt
   dots: 6
   __assert-match: lt-6dot.tbl # lt-6dot.utb
   
@@ -40,7 +40,7 @@ tests:
     - ⠸⠁⠃⠉⠼⠁⠰⠁⠃⠉ ⠸⠁⠃⠉⠆⠁⠃⠉
 
 table:
-  locale: lt
+  language: lt
   dots: 6
   __assert-match: lt-6dot.tbl # lt-6dot.utb
 flags: {testmode: backward} 

--- a/tests/braille-specs/lt_harness.yaml
+++ b/tests/braille-specs/lt_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: lt
+  language: lt
   dots: 8
   __assert-match: lt.tbl # lt.ctb
 tests:

--- a/tests/braille-specs/lv_harness.yaml
+++ b/tests/braille-specs/lv_harness.yaml
@@ -12,7 +12,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: lv
+  language: lv
   grade: 1
   __assert-match: lv.tbl # Lv-Lv-g1.utb
 

--- a/tests/braille-specs/ml.yaml
+++ b/tests/braille-specs/ml.yaml
@@ -9,7 +9,7 @@
 display: unicode.dis
 
 table:
-  locale: ml
+  language: ml
   grade: 1
   __assert-match: ml.tbl
 

--- a/tests/braille-specs/mn-MN_harness.yaml
+++ b/tests/braille-specs/mn-MN_harness.yaml
@@ -4,7 +4,7 @@ display: |
   display a a
 
 table:
-  locale: mn
+  language: mn
   contraction: no
   __assert-match: mn-MN-g1.utb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/ms-my-g2.yaml
+++ b/tests/braille-specs/ms-my-g2.yaml
@@ -7,7 +7,7 @@
 
 display: ms-my-g2.ctb
 table:
-  locale: ms
+  language: ms
   __assert-match: ms-my-g2.ctb
 tests:
 

--- a/tests/braille-specs/nl-comp8_harness.yaml
+++ b/tests/braille-specs/nl-comp8_harness.yaml
@@ -17,7 +17,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: nl
+  language: nl
   type: computer
   dots: 8
   __assert-match: nl-comp8.utb

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -20,7 +20,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: nl
+  language: nl
   grade: 0
   __assert-match: nl.tbl # nl-NL-g0.utb
 tests:

--- a/tests/braille-specs/no_8dot_harness.yaml
+++ b/tests/braille-specs/no_8dot_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: no
+  language: no
   type: literary
   grade: 0
   dots: 8

--- a/tests/braille-specs/no_backward.yaml
+++ b/tests/braille-specs/no_backward.yaml
@@ -1,6 +1,6 @@
 display: unicode.dis
 table:
-  locale: no
+  language: no
   grade: 1
   __assert-match: no-no-g1.ctb
 flags: {testmode: backward}

--- a/tests/braille-specs/no_g1_harness.yaml
+++ b/tests/braille-specs/no_g1_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: no
+  language: no
   grade: 1
   __assert-match: no-no-g1.ctb
 tests:

--- a/tests/braille-specs/no_g2_harness.yaml
+++ b/tests/braille-specs/no_g2_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: no
+  language: no
   grade: 2
   __assert-match: no-no-g2.ctb
 tests:

--- a/tests/braille-specs/no_harness.yaml
+++ b/tests/braille-specs/no_harness.yaml
@@ -3,7 +3,7 @@
 # translation table. That is why we have to include it here.
 display: unicode-without-blank.dis,no-no-g0.utb
 table:
-  locale: no
+  language: no
   grade: 0
   dots: 6
   __assert-match: no-no-g0.utb

--- a/tests/braille-specs/no_typeform_harness.yaml
+++ b/tests/braille-specs/no_typeform_harness.yaml
@@ -11,7 +11,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: no
+  language: no
   grade: 0
   dots: 6
   __assert-match: no-no-g0.utb

--- a/tests/braille-specs/pl-g1.yaml
+++ b/tests/braille-specs/pl-g1.yaml
@@ -11,7 +11,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: pl
+  language: pl
   type: literary
   __assert-match: pl.tbl
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/pl-pl-comp8_harness.yaml
+++ b/tests/braille-specs/pl-pl-comp8_harness.yaml
@@ -7,7 +7,7 @@
 #
 display: unicode-without-blank.dis
 table:
-  locale: pl
+  language: pl
   type: computer
   dots: 8
   __assert-match: pl-pl-comp8.ctb

--- a/tests/braille-specs/pt-g1.yaml
+++ b/tests/braille-specs/pt-g1.yaml
@@ -8,7 +8,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: pt
+  language: pt
   grade: 1
   __assert-match: pt-pt-g1.utb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/ru.yaml
+++ b/tests/braille-specs/ru.yaml
@@ -17,7 +17,7 @@ display: |
   display 9 9
   display a a
 table:
-  locale: ru
+  language: ru
   type: computer
   __assert-match: ru.ctb
 flags: {testmode: bothDirections}
@@ -51,7 +51,7 @@ display: |
   display \s 0
   include ru-unicode.dis
 table:
-  locale: ru
+  language: ru
   type: literary
   contraction: no
   dots: 6
@@ -252,7 +252,7 @@ tests:
 
 # Without indication of capital letters
 table:
-  locale: ru
+  language: ru
   type: literary
   contraction: no
   dots: 6
@@ -316,7 +316,7 @@ tests:
 # Grade 1
 
 table:
-  locale: ru
+  language: ru
   type: literary
   contraction: partial
   dots: 6
@@ -339,7 +339,7 @@ tests:
 # Display table can distinguish between Latin and Cyrillic letters
 display: ru-letters.dis,ru-litbrl.ctb
 table:
-  locale: ru
+  language: ru
   type: literary
   contraction: no
   dots: 6
@@ -355,7 +355,7 @@ display: |
   include ru-brf.dis
 
 table:
-  locale: ru
+  language: ru
   type: literary
   contraction: no
   dots: 6

--- a/tests/braille-specs/sah.yaml
+++ b/tests/braille-specs/sah.yaml
@@ -14,7 +14,7 @@
 
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: sah
+  language: sah
   type: literary
   __assert-match: sah.utb
   contraction: no

--- a/tests/braille-specs/sk-g1_harness.yaml
+++ b/tests/braille-specs/sk-g1_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: sk
+  language: sk
   grade: 1
   __assert-match: sk.tbl # sk-g1.ctb
 tests:

--- a/tests/braille-specs/sl-g1.yaml
+++ b/tests/braille-specs/sl-g1.yaml
@@ -11,7 +11,7 @@
 
 display: unicode-without-blank.dis
 table:
-  locale: sl
+  language: sl
   type: literary
   grade: 1
   __assert-match: sl.tbl

--- a/tests/braille-specs/spaces.yaml
+++ b/tests/braille-specs/spaces.yaml
@@ -796,8 +796,8 @@ tests:
   - ['\x000a', '\x0020']
   - ['\x000c', '\x0020']
   - ['\x000d', '\x0020']
-table: {locale: ga, grade: 1}
-table: {locale: ga, grade: 2}
+table: {language: ga, grade: 1}
+table: {language: ga, grade: 2}
 flags: {testmode: bothDirections}
 tests:
   - ['\x0020', '\x0020']

--- a/tests/braille-specs/sr-g1_harness.yaml
+++ b/tests/braille-specs/sr-g1_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: sr
+  language: sr
   grade: 1
   __assert-match: sr.tbl # sr-g1.ctb
 tests:

--- a/tests/braille-specs/st-g2.yaml
+++ b/tests/braille-specs/st-g2.yaml
@@ -18,15 +18,15 @@
 
 display: unicode.dis
 table:
-  locale: st
+  language: st
   grade: 2
   __assert-match: sot-za-g2.ctb
 table:
-  locale: tn
+  language: tn
   grade: 2
   __assert-match: tsn-za-g2.ctb
 table:
-  locale: nso
+  language: nso
   grade: 2
   __assert-match: nso-za-g2.ctb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/ta-ta-g1_harness.yaml
+++ b/tests/braille-specs/ta-ta-g1_harness.yaml
@@ -1,6 +1,6 @@
 display: unicode-without-blank.dis
 table:
-  locale: ta
+  language: ta
   grade: 1
   __assert-match: ta-ta-g1.ctb
 tests:

--- a/tests/braille-specs/tt.yaml
+++ b/tests/braille-specs/tt.yaml
@@ -14,7 +14,7 @@
 
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: tt
+  language: tt
   type: literary
   __assert-match: tt.utb
   contraction: no

--- a/tests/braille-specs/uk.yaml
+++ b/tests/braille-specs/uk.yaml
@@ -14,7 +14,7 @@
 #literary braille
 display: unicode-without-blank.dis,ru-unicode.dis
 table:
-  locale: uk
+  language: uk
   type: literary
   __assert-match: uk.utb
 tests:
@@ -43,7 +43,7 @@ display: |
   display 9 9
   display a a
 table:
-  locale: uk
+  language: uk
   type: computer
   __assert-match: uk-comp.utb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/ur-pk-g2.yaml
+++ b/tests/braille-specs/ur-pk-g2.yaml
@@ -9,7 +9,7 @@
 
 display: unicode.dis
 table:
-  locale: ur
+  language: ur
   type: literary
   contraction: full
   __assert-match: ur-pk-g2.ctb

--- a/tests/braille-specs/uz.yaml
+++ b/tests/braille-specs/uz.yaml
@@ -16,7 +16,7 @@
 
 display: ru-unicode.dis
 table:
-  locale: uz
+  language: uz
   type: literary
 tests:
   - # Sample for testing "ғ" and "ў"

--- a/tests/braille-specs/ve-g2.yaml
+++ b/tests/braille-specs/ve-g2.yaml
@@ -19,7 +19,7 @@
 
 display: unicode.dis
 table:
-  locale: ve
+  language: ve
   grade: 2
   __assert-match: ve-za-g2.ctb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/vi.yaml
+++ b/tests/braille-specs/vi.yaml
@@ -16,7 +16,7 @@ display: |
   display a a
 
 table:
-  locale: vi
+  language: vi
   contraction: no
   grade: 0
   system: vietnam

--- a/tests/braille-specs/xh-g2.yaml
+++ b/tests/braille-specs/xh-g2.yaml
@@ -19,11 +19,11 @@
 
 display: unicode.dis
 table:
-  locale: xh
+  language: xh
   grade: 2
   __assert-match: xh-za-g2.ctb
 table:
-  locale: zu
+  language: zu
   grade: 2
   __assert-match: zu-za-g2.ctb
 flags: {testmode: bothDirections}

--- a/tests/braille-specs/zh-chn.yaml
+++ b/tests/braille-specs/zh-chn.yaml
@@ -1,6 +1,7 @@
 display: unicode-without-blank.dis
 table:
-  locale: cmn-Hans-CN
+  language: cmn-Hans
+  region: cmn-CN
   system: cmn-traditional
   variant: no-tone
   __assert-match: zh_CHN.tbl # zh-chn.ctb

--- a/tests/braille-specs/zh-tw.yaml
+++ b/tests/braille-specs/zh-tw.yaml
@@ -16,7 +16,8 @@
 # translation table. That is why we have to include it here.
 display: unicode.dis,zh_TW.tbl
 table:
-  locale: cmn-TW
+  language: cmn
+  region: cmn-TW
   __assert-match: zh_TW.tbl # zh-tw.ctb
 flags: {testmode: bothDirections}
 tests:
@@ -27,7 +28,8 @@ tests:
   - ['\x00A0', '\x00A0']
 display: unicode.dis
 table:
-  locale: cmn-TW
+  language: cmn
+  region: cmn-TW
   __assert-match: zh_TW.tbl # zh-tw.ctb
 flags: {testmode: forward}
 tests:

--- a/tests/braille-specs/zhcn-g1.yaml
+++ b/tests/braille-specs/zhcn-g1.yaml
@@ -1,7 +1,8 @@
 # encoding: utf-8 
 display: unicode-without-blank.dis
 table:
-  locale: cmn-CN
+  language: cmn
+  region: cmn-CN
   system: cmn-traditional
   __assert-match: zhcn-g1.ctb
 tests:

--- a/tests/braille-specs/zhcn-g2.yaml
+++ b/tests/braille-specs/zhcn-g2.yaml
@@ -1,7 +1,8 @@
 # encoding: utf-8 
 display: unicode-without-blank.dis
 table:
-  locale: cmn-CN
+  language: cmn
+  region: cmn-CN
   system: cmn-two-cell
   __assert-match: zhcn-g2.ctb
 tests:


### PR DESCRIPTION
Things are explained on https://github.com/liblouis/liblouis/wiki/Table-discovery-based-on-table-metadata#standard-metadata-tags.

Commit [`f129b2a`](https://github.com/liblouis/liblouis/commit/f129b2a0dddb40a83bf6e62200dfb242c9fe3e35) is not really related.