### PR TITLE
Various fixes to mode indicators

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3134,9 +3134,11 @@ doOpcode:
 					if (!characterClass) return 0;
 				}
 				mode = characterClass->attribute;
-				if (mode != CTC_UpperCase && mode >= CTC_Space && mode <= CTC_LitDigit) {
+				if (!(mode == CTC_UpperCase || mode == CTC_Digit) && mode >= CTC_Space &&
+						mode <= CTC_LitDigit) {
 					compileError(file,
-							"mode must be \"uppercase\" or a custom attribute name.");
+							"mode must be \"uppercase\", \"digit\", or a custom "
+							"attribute name.");
 					return 0;
 				}
 				/* check if this mode is already defined and if the number of modes does
@@ -4123,11 +4125,11 @@ doOpcode:
 				mode = addCharacterClass(file, token.chars, token.length, *table, 1);
 				if (!mode) return 0;
 			}
-			if (mode->attribute != CTC_UpperCase && mode->attribute >= CTC_Space &&
-					mode->attribute <= CTC_LitDigit) {
+			if (!(mode->attribute == CTC_UpperCase || mode->attribute == CTC_Digit) &&
+					mode->attribute >= CTC_Space && mode->attribute <= CTC_LitDigit) {
 				compileError(file,
-						"base opcode must be followed by \"uppercase\" or a custom "
-						"attribute name.");
+						"base opcode must be followed by \"uppercase\", \"digit\", or a "
+						"custom attribute name.");
 				return 0;
 			}
 			if (!getRuleCharsText(file, &token)) return 0;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2528,18 +2528,15 @@ isEmphasizable(
 		widechar c, const TranslationTableHeader *table, const EmphasisClass *emphClass) {
 	/* Whether emphasis is indicated on a character or not. */
 	if (emphClass->mode) {
-		/* a letter is emphasizable if it has the attribute or if another character that
-		 * has the attribute is based on it */
+		/* a character is emphasizable if it belongs to the mode or if it has the same base
+		 * as a character that belongs to the mode */
 		const TranslationTableCharacter *chardef = getChar(c, table);
+		if (chardef->basechar)
+			chardef = (TranslationTableCharacter *)&table->ruleArea[chardef->basechar];
 		if (chardef->attributes & emphClass->mode) return 1;
-		const TranslationTableCharacter *ch = chardef;
-		if (ch->basechar)
-			ch = (TranslationTableCharacter *)&table->ruleArea[ch->basechar];
-		while (ch->linked) {
-			ch = (TranslationTableCharacter *)&table->ruleArea[ch->linked];
-			if ((ch->mode & chardef->mode) == chardef->mode &&
-					ch->attributes & emphClass->mode)
-				return 1;
+		while (chardef->linked) {
+			chardef = (TranslationTableCharacter *)&table->ruleArea[chardef->linked];
+			if (chardef->attributes & emphClass->mode) return 1;
 		}
 		return 0;
 	} else {

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3263,6 +3263,21 @@ markEmphases(const TranslationTableHeader *table, const InString *input,
 				resolveEmphasisAllSymbols(
 						emphasisBuffer, emphClass, table, typebuf, input, wordBuffer);
 		}
+		if (emphClass->mode) {
+			/* only mark if actually a capital letter (don't mark spaces or punctuation).
+			 */
+			for (int i = 0; i < input->length; i++) {
+				if (emphasisBuffer[i].symbol & emphClass->value) {
+					if (emphClass->mode == CTC_UpperCase) {
+						if (!(typebuf[i] & CAPSEMPH))
+							emphasisBuffer[i].symbol &= ~emphClass->value;
+					} else {
+						if (!checkCharAttr(input->chars[i], emphClass->mode, table))
+							emphasisBuffer[i].symbol &= ~emphClass->value;
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -3272,12 +3287,6 @@ insertEmphasisSymbol(const EmphasisInfo *buffer, formtype *typebuf, const int at
 		const InString *input, OutString *output, int *posMapping, int *cursorPosition,
 		int *cursorStatus) {
 	if (buffer[at].symbol & class->value) {
-		/* only mark if actually a capital letter (don't mark spaces or punctuation). */
-		if (class->mode == CTC_UpperCase) {
-			if (!(typebuf[pos] & CAPSEMPH)) return;
-		} else if (class->mode) {
-			if (!checkCharAttr(input->chars[pos], class->mode, table)) return;
-		}
 		const TranslationTableRule *indicRule;
 		if (brailleIndicatorDefined(
 					table->emphRules[class->rule][letterOffset], table, &indicRule))

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2525,6 +2525,12 @@ resetsEmphMode(
 			/* characters that are not letter and not capsmodechars cancel capsword mode
 			 */
 			return !checkCharAttr(c, CTC_Letter | CTC_CapsMode, table);
+		} else if (emphClass->mode == CTC_Digit) {
+			/* characters that are not digit or litdigit or numericmodechars cancel
+			 * numeric mode */
+			return !checkCharAttr(c,
+					CTC_Digit | CTC_LitDigit | CTC_NumericMode | CTC_MidEndNumericMode,
+					table);
 		} else {
 			/* characters that are not letter cancel other word modes */
 			return !checkCharAttr(c, CTC_Letter, table);
@@ -2546,8 +2552,8 @@ isEmphasizable(
 		widechar c, const TranslationTableHeader *table, const EmphasisClass *emphClass) {
 	/* Whether emphasis is indicated on a character or not. */
 	if (emphClass->mode) {
-		/* a character is emphasizable if it belongs to the mode or if it has the same base
-		 * as a character that belongs to the mode */
+		/* a character is emphasizable if it belongs to the mode or if it has the same
+		 * base as a character that belongs to the mode */
 		const TranslationTableCharacter *chardef = getChar(c, table);
 		if (chardef->basechar)
 			chardef = (TranslationTableCharacter *)&table->ruleArea[chardef->basechar];

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2504,6 +2504,23 @@ resetsEmphMode(
 		widechar c, const TranslationTableHeader *table, const EmphasisClass *emphClass) {
 	/* Whether a character cancels word emphasis mode or not. */
 	if (emphClass->mode) {
+		const TranslationTableCharacter *chardef = getChar(c, table);
+		/* the base character of a character belonging to a mode can never cancel the mode
+		 */
+		if (chardef->attributes & emphClass->mode)
+			return 0;
+		else {
+			const TranslationTableCharacter *ch = chardef;
+			if (ch->basechar)
+				ch = (TranslationTableCharacter *)&table->ruleArea[ch->basechar];
+			while (ch->linked) {
+				ch = (TranslationTableCharacter *)&table->ruleArea[ch->linked];
+				if ((ch->mode & chardef->mode) == chardef->mode &&
+						ch->attributes & emphClass->mode) {
+					return 0;
+				}
+			}
+		}
 		if (emphClass->mode == CTC_UpperCase) {
 			/* characters that are not letter and not capsmodechars cancel capsword mode
 			 */

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2503,17 +2503,18 @@ static int
 resetsEmphMode(
 		widechar c, const TranslationTableHeader *table, const EmphasisClass *emphClass) {
 	/* Whether a character cancels word emphasis mode or not. */
-	if (checkCharAttr(c, CTC_Letter, table)) /* a letter never cancels emphasis */
-		return 0;
 	if (emphClass->mode) {
-		if (emphClass->mode == CTC_UpperCase)
+		if (emphClass->mode == CTC_UpperCase) {
 			/* characters that are not letter and not capsmodechars cancel capsword mode
 			 */
-			return !checkCharAttr(c, CTC_CapsMode, table);
-		else
+			return !checkCharAttr(c, CTC_Letter | CTC_CapsMode, table);
+		} else {
 			/* characters that are not letter cancel other word modes */
-			return 1;
+			return !checkCharAttr(c, CTC_Letter, table);
+		}
 	} else {
+		if (checkCharAttr(c, CTC_Letter, table)) /* a letter never cancels emphasis */
+			return 0;
 		const widechar *emphmodechars = table->emphModeChars[emphClass->rule];
 		/* by default (if emphmodechars is not declared) only space cancels emphasis */
 		if (!emphmodechars[0]) return checkCharAttr(c, CTC_Space, table);

--- a/tests/yaml/numericmode.yaml
+++ b/tests/yaml/numericmode.yaml
@@ -149,3 +149,88 @@ tests:
   # it shouldn't cause issues though
   - - "#abc;kabc"
     - "123kabc"
+
+# Numeric mode can also be implemented using the generic mode feature,
+# but only for forward translation, and some things are not supported
+# yet.
+table: |
+  display # 3456
+  display , 6
+  display ; 56
+  display - 36
+  include tables/latinLetterDef6Dots.uti
+  base digit 1 a
+  base digit 2 b
+  base digit 3 c
+  base digit 4 d
+  base digit 5 e
+  base digit 6 f
+  base digit 7 g
+  base digit 8 h
+  base digit 9 i
+  base digit 0 j
+  capsletter 6
+  begmodeword digit 3456
+  endmodeword digit 56
+  include tables/spaces.uti
+  punctuation , 6
+  punctuation - 36
+  punctuation . 46
+  numericmodechars .
+  midendnumericmodechars -
+flags: {testmode: forward}
+tests:
+  - - "1"
+    - "#a"
+  - - "1a"
+    - "#a;a"
+  - - "1A"
+    - "#a,a"
+  - - "1t"
+    - "#at"
+  - - "a1"
+    - "a#a"
+  - - "t1"
+    - "t#a"
+  - - "1t1"
+    - "#at#a"
+# repeat forward tests from above
+tests:
+  - - "123abc"
+    - "#abc;abc"
+  - - "123kabc"
+    - "#abckabc"
+  - - "123 abc"
+    - "#abc abc"
+  - - "123Abc"
+    - "#abc,abc"
+  - - "123Kabc"
+    - "#abc,kabc"
+  - - "123-123"
+    - "#abc-abc"
+  - - "123-abc"
+    - "#abc-;abc"
+  - - "123-Abc"
+    - "#abc-,abc"
+  - - "123Abckabc"
+    - "#abc,abckabc"
+  - - "123Abcabc"
+    - "#abc,abcabc"
+  - - "-1 .1"
+    - "-#a #.a"
+    - xfail: number sign comes after "."
+  - - "123-456 123.456"
+    - "#abc-def #abc.def"
+  - - "-123-456-789 .123.456.789"
+    - "-#abc-def-ghi #.abc.def.ghi"
+    - xfail: number sign comes after "."
+  - - "-123-abc .123.abc"
+    - "-#abc-;abc #.abc.;abc"
+    - xfail: number sign comes after "."
+  - - "-123-Abc .123.Abc"
+    - "-#abc-,abc #.abc.,abc"
+    - xfail: number sign comes after "."
+  - - "abc-123 abc.123"
+    - "abc-#abc abc#.abc"
+    - xfail: number sign comes after "."
+


### PR DESCRIPTION
Various fixes to the new mode indicators introduced in version 3.20 (https://github.com/liblouis/liblouis/pull/1123):

- Fix regression https://github.com/liblouis/liblouis/issues/1152.
- Fix the problem that @Futyn-Maker had when trying to use the new feature in the Russian table
- Allow implementing numeric mode using the generic mode feature