### PR TITLE
Fix the multind opcode handling (or at least try to)

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -736,8 +736,8 @@ back_selectRule(const TranslationTableHeader *table, int pos, int mode,
 							return;
 						break;
 					case CTO_MultInd:
-						*doingMultind = *currentDotslen;
 						*multindRule = *currentRule;
+						*doingMultind = (*multindRule)->charslen;
 						if (handleMultind(table, currentDotslen, currentOpcode,
 									currentRule, doingMultind, *multindRule))
 							return;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -497,7 +497,7 @@ handleMultind(const TranslationTableHeader *table, int *currentDotslen,
 				table->emphRules[MAX_EMPH_CLASSES][begWordOffset], table, currentDotslen,
 				currentOpcode, currentRule);
 		break;
-	case CTO_EndCapsWordRule:
+	case CTO_EndCapsWord:
 		found = findBrailleIndicatorRule(
 				table->emphRules[MAX_EMPH_CLASSES][endWordOffset], table, currentDotslen,
 				currentOpcode, currentRule);

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -476,7 +476,10 @@ handleMultind(const TranslationTableHeader *table, int *currentDotslen,
 	/* Handle multille braille indicators */
 	int found = 0;
 	if (!*doingMultind) return 0;
-	switch (multindRule->charsdots[multindRule->charslen - *doingMultind]) {
+
+	int multindIndex = multindRule->charslen - *doingMultind;
+	TranslationTableOpcode currentMultindOpcode = multindRule->charsdots[multindIndex];
+	switch (currentMultindOpcode) {
 	case CTO_CapsLetterRule:  // FIXME: make sure this works
 		found = findBrailleIndicatorRule(table->emphRules[MAX_EMPH_CLASSES][letterOffset],
 				table, currentDotslen, currentOpcode, currentRule);
@@ -556,6 +559,7 @@ handleMultind(const TranslationTableHeader *table, int *currentDotslen,
 				table->endComp, table, currentDotslen, currentOpcode, currentRule);
 		break;
 	default:
+	  fprintf(stderr, "-- Unknown rule %s (%i)\n", _lou_findOpcodeName(currentMultindOpcode));
 		found = 0;
 		break;
 	}

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1189,20 +1189,23 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 		case CTO_EndCapsWordRule:
 			allUpper = 0;
 			itsANumber = 0;
-			while (currentDotslen-- > 0) posMapping[pos++] = output->length;
+			if (doingMultind < 1)
+			  while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_EndCapsRule:
 			allUpperPhrase = 0;
 			itsANumber = 0;
-			while (currentDotslen-- > 0) posMapping[pos++] = output->length;
+			if (doingMultind < 1)
+			  while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_LetterRule:
 		case CTO_NoContractRule:
 			itsALetter = 1;
 			itsANumber = 0;
-			while (currentDotslen-- > 0) posMapping[pos++] = output->length;
+			if (doingMultind < 1)
+			  while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_NumberRule:

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -559,7 +559,8 @@ handleMultind(const TranslationTableHeader *table, int *currentDotslen,
 				table->endComp, table, currentDotslen, currentOpcode, currentRule);
 		break;
 	default:
-	  fprintf(stderr, "-- Unknown rule %s (%i)\n", _lou_findOpcodeName(currentMultindOpcode));
+		fprintf(stderr, "-- Unknown rule %s (%i)\n",
+				_lou_findOpcodeName(currentMultindOpcode));
 		found = 0;
 		break;
 	}
@@ -1190,14 +1191,14 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 			allUpper = 0;
 			itsANumber = 0;
 			if (doingMultind < 1)
-			  while (currentDotslen-- > 0) posMapping[pos++] = output->length;
+				while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_EndCapsRule:
 			allUpperPhrase = 0;
 			itsANumber = 0;
 			if (doingMultind < 1)
-			  while (currentDotslen-- > 0) posMapping[pos++] = output->length;
+				while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_LetterRule:
@@ -1205,7 +1206,7 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 			itsALetter = 1;
 			itsANumber = 0;
 			if (doingMultind < 1)
-			  while (currentDotslen-- > 0) posMapping[pos++] = output->length;
+				while (currentDotslen-- > 0) posMapping[pos++] = output->length;
 			continue;
 			break;
 		case CTO_NumberRule:


### PR DESCRIPTION
The proposed PR #1166 exposes a bug in backtranslation when `multind` is involved:

``` console
$ cat foo.louis 
  display | 456
  display ; 56
  display # 3456
  include tables/latinLetterDef6Dots.uti
  include tables/digits6Dots.uti
  include tables/litdigits6Dots.uti
  include tables/braille-patterns.cti
  numsign            3456
  begcapsword        456
  multind            56 endcapsword nonumsign nocontractsign
  nocontractsign     56    # nocontractsign before endcapsword
  nonumsign          56
  endcapsword        56
  numericnocontchars abcdefghij
$ echo "|abc;ab" | ./tools/lou_translate --backward foo.louis
ABCAB
```
The indicator doesn't terminate all-caps. With this patch it does:
``` console
$ echo "|abc;ab" | ./tools/lou_translate --backward foo.louis
ABCab
```
This PR changes the following:
1. Make backtranslation go though all opcodes that are specified in the `multind` opcode
2. Fix a problem in `handleMultind` in that it was matching for `CTO_EndCapsWordRule` instead of `CTO_EndCapsWord`. This causes  to not return an opcode and consequently the endcapsword rule is not applied and the backtranslation stays in all-caps mode.
3. Do not advance the position while going through the `multind` opcodes

However a major problem of this PR is that the full test suite doesn't terminate. I think it hangs in `da-dk-g28.yaml`. Do not know why at the moment.