### PR TITLE
Add a German 6-dot computerbraille table

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ For a detailed list of all the changes refer to [[https://github.com/liblouis/li
 issues]].
 
 ** New features
+- New table for German 6-dot computer braille thanks to the Swiss
+  Library for the Blind, Visually Impaired and Print Disabled
 ** Bug fixes
 - When numeric mode was enabled, i.e. when a table contains any of the
   ~numericmodechars~, ~midnumericmodechars~ or ~numericnocontchars~
@@ -31,7 +33,7 @@ issues]].
 ** Invisible changes
 ** New, renamed or removed tables
 *** New
-None
+- de-comp6.utb
 
 *** Renamed
 None

--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -32,7 +32,8 @@
 * ../../tables/da-dk-g26l.ctb                    Danish, partially contracted, 6-dot                Danish 6-dot partially contracted braille
 * ../../tables/da-dk-g28.ctb                     Danish, contracted, 8-dot                          Danish 8-dot contracted braille
 * ../../tables/da-dk-g28l.ctb                    Danish, partially contracted, 8-dot                Danish 8-dot partially contracted braille
-* ../../tables/de-de-comp8.ctb                   German, computer                                   German computer braille
+* ../../tables/de-de-comp8.ctb                   German, computer, 8-dot                            German 8-dot computer braille
+* ../../tables/de-comp6.ctb                      German, computer, 6-dot                            German 6-dot computer braille
 * ../../tables/de-g0.utb                         German, uncontracted                               German uncontracted braille
   ../../tables/de-g0-bidi.utb                    German, uncontracted, back-translatable            German uncontracted braille (back-translatable)
 * ../../tables/de-g1.ctb                         German, partially contracted                       German partially contracted braille

--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -33,7 +33,7 @@
 * ../../tables/da-dk-g28.ctb                     Danish, contracted, 8-dot                          Danish 8-dot contracted braille
 * ../../tables/da-dk-g28l.ctb                    Danish, partially contracted, 8-dot                Danish 8-dot partially contracted braille
 * ../../tables/de-de-comp8.ctb                   German, computer, 8-dot                            German 8-dot computer braille
-* ../../tables/de-comp6.ctb                      German, computer, 6-dot                            German 6-dot computer braille
+* ../../tables/de-comp6.utb                      German, computer, 6-dot                            German 6-dot computer braille
 * ../../tables/de-g0.utb                         German, uncontracted                               German uncontracted braille
   ../../tables/de-g0-bidi.utb                    German, uncontracted, back-translatable            German uncontracted braille (back-translatable)
 * ../../tables/de-g1.ctb                         German, partially contracted                       German partially contracted braille

--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -70,6 +70,7 @@ table_files = \
 	de-chardefs6.cti \
 	de-chardefs8.cti \
 	de-chess.ctb \
+	de-comp6.utb \
 	de-de-comp8.ctb \
 	de-de.dis \
 	de-eurobrl6.dis \

--- a/tables/de-comp6.utb
+++ b/tables/de-comp6.utb
@@ -1,0 +1,227 @@
+# liblouis: German 6 dots computer Braille table
+#
+# Copyright (C) 2022 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte
+#
+# This file is part of liblouis.
+#
+# liblouis is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 2.1 of the
+# License, or (at your option) any later version.
+#
+# liblouis is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with liblouis. If not, see
+# <http://www.gnu.org/licenses/>.
+
+#-name: Deutsches 6-Punkte Computerbraille
+#-index-name: German, computer, 6-dot
+#-display-name: German 6-dot computer braille
+#
+#+language:de
+#+type:computer
+#+contraction:no
+#+grade:0
+#+direction:both
+
+# There is no official standard for German 6 dot computer braille. To
+# my knowledge there is not even an official standard for 8 dot
+# computer braille , see
+# http://www.bskdl.org/braillesysteme.html#computer. There is some
+# definition for 8-dot at http://braille.ch/computer.htm but I do not
+# know how official that is. On the implementation side there is the
+# German Eurobraille table in Liblouis.
+
+# So consider this table as a defacto standard as it is used at SBS to
+# produce books for the German speaking readers.
+
+# SBS Character Definitions für 6-Punkte-Computerbraille
+
+space               \x0020               0 &#32;   SPACE
+punctuation         \x0021               5 &#33;   EXCLAMATION MARK
+punctuation         \x0022             4-4 &#34;   QUOTATION MARK
+sign                \x0023            3456 &#35;   NUMBER SIGN
+sign                \x0024           46-46 &#36;   DOLLAR SIGN
+sign                \x0025          123456 &#37;   PERCENT SIGN
+sign                \x0026           12346 &#38;   AMPERSAND
+punctuation         \x0027             6-6 &#39;   APOSTROPHE APOSTROPHE-QUOTE
+punctuation         \x0028             236 &#40;   LEFT PARENTHESIS
+punctuation         \x0029             356 &#41;   RIGHT PARENTHESIS
+sign		    \x002A              35 &#42;   ASTERISK
+math                \x002B             235 &#43;   PLUS SIGN
+punctuation         \x002C               2 &#44;   COMMA
+punctuation         \x002D              36 &#45;   HYPHEN-MINUS
+punctuation         \x002E               3 &#46;   FULL STOP PERIOD
+punctuation         \x002F             256 &#47;   SOLIDUS SLASH
+
+include digits6DotsPlusDot6.uti
+
+punctuation         \x003A              25 &#58;   COLON
+punctuation         \x003B              23 &#59;   SEMICOLON
+math                \x003C              56 &#60;   LESS-THAN SIGN
+math                \x003D            2356 &#61;   EQUALS SIGN
+math                \x003E              45 &#62;   GREATER-THAN SIGN
+punctuation         \x003F              26 &#63;   QUESTION MARK
+sign                \x0040           4-345 &#64;   COMMERCIAL AT
+uppercase           \x0041             4-1 &#65;   LATIN CAPITAL LETTER A
+uppercase           \x0042            4-12 &#66;   LATIN CAPITAL LETTER B
+uppercase           \x0043            4-14 &#67;   LATIN CAPITAL LETTER C
+uppercase           \x0044           4-145 &#68;   LATIN CAPITAL LETTER D
+uppercase           \x0045            4-15 &#69;   LATIN CAPITAL LETTER E
+uppercase           \x0046           4-124 &#70;   LATIN CAPITAL LETTER F
+uppercase           \x0047          4-1245 &#71;   LATIN CAPITAL LETTER G
+uppercase           \x0048           4-125 &#72;   LATIN CAPITAL LETTER H
+uppercase           \x0049            4-24 &#73;   LATIN CAPITAL LETTER I
+uppercase           \x004A           4-245 &#74;   LATIN CAPITAL LETTER J
+uppercase           \x004B            4-13 &#75;   LATIN CAPITAL LETTER K
+uppercase           \x004C           4-123 &#76;   LATIN CAPITAL LETTER L
+uppercase           \x004D           4-134 &#77;   LATIN CAPITAL LETTER M
+uppercase           \x004E          4-1345 &#78;   LATIN CAPITAL LETTER N
+uppercase           \x004F           4-135 &#79;   LATIN CAPITAL LETTER O
+uppercase           \x0050          4-1234 &#80;   LATIN CAPITAL LETTER P
+uppercase           \x0051         4-12345 &#81;   LATIN CAPITAL LETTER Q
+uppercase           \x0052          4-1235 &#82;   LATIN CAPITAL LETTER R
+uppercase           \x0053           4-234 &#83;   LATIN CAPITAL LETTER S
+uppercase           \x0054          4-2345 &#84;   LATIN CAPITAL LETTER T
+uppercase           \x0055           4-136 &#85;   LATIN CAPITAL LETTER U
+uppercase           \x0056          4-1236 &#86;   LATIN CAPITAL LETTER V
+uppercase           \x0057          4-2456 &#87;   LATIN CAPITAL LETTER W
+uppercase           \x0058          4-1346 &#88;   LATIN CAPITAL LETTER X
+uppercase           \x0059         4-13456 &#89;   LATIN CAPITAL LETTER Y
+uppercase           \x005A          4-1356 &#90;   LATIN CAPITAL LETTER Z
+punctuation         \x005B         4-12356 &#91;   LEFT SQUARE BRACKET
+sign                \x005C            4-34 &#92;   REVERSE SOLIDUS
+punctuation         \x005D         4-23456 &#93;   RIGHT SQUARE BRACKET
+sign                \x005E          4-2346 &#94;   CIRCUMFLEX ACCENT
+sign                \x005F           4-456 &#95;   LOW LINE
+sign                \x0060             345 &#96;   GRAVE ACCENT
+lowercase           \x0061               1 &#97;   LATIN SMALL LETTER A
+lowercase           \x0062              12 &#97;   LATIN SMALL LETTER B
+lowercase           \x0063              14 &#97;   LATIN SMALL LETTER C
+lowercase           \x0064             145 &#97;   LATIN SMALL LETTER D
+lowercase           \x0065              15 &#97;   LATIN SMALL LETTER E
+lowercase           \x0066             124 &#97;   LATIN SMALL LETTER F
+lowercase           \x0067            1245 &#97;   LATIN SMALL LETTER G
+lowercase           \x0068             125 &#97;   LATIN SMALL LETTER H
+lowercase           \x0069              24 &#97;   LATIN SMALL LETTER I
+lowercase           \x006A             245 &#97;   LATIN SMALL LETTER J
+lowercase           \x006B              13 &#97;   LATIN SMALL LETTER K
+lowercase           \x006C             123 &#97;   LATIN SMALL LETTER L
+lowercase           \x006D             134 &#97;   LATIN SMALL LETTER M
+lowercase           \x006E            1345 &#97;   LATIN SMALL LETTER N
+lowercase           \x006F             135 &#111;  LATIN SMALL LETTER O
+lowercase           \x0070            1234 &#112;  LATIN SMALL LETTER P
+lowercase           \x0071           12345 &#113;  LATIN SMALL LETTER Q
+lowercase           \x0072            1235 &#114;  LATIN SMALL LETTER R
+lowercase           \x0073             234 &#115;  LATIN SMALL LETTER S
+lowercase           \x0074            2345 &#116;  LATIN SMALL LETTER T
+lowercase           \x0075             136 &#117;  LATIN SMALL LETTER U
+lowercase           \x0076            1236 &#118;  LATIN SMALL LETTER V
+lowercase           \x0077            2456 &#119;  LATIN SMALL LETTER W
+lowercase           \x0078            1346 &#120;  LATIN SMALL LETTER X
+lowercase           \x0079           13456 &#121;  LATIN SMALL LETTER Y
+lowercase           \x007A            1356 &#122;  LATIN SMALL LETTER Z
+punctuation         \x007B           12356 &#123;  LEFT CURLY BRACKET
+sign                \x007C              34 &#124;  VERTICAL LINE
+punctuation         \x007D           23456 &#125;  RIGHT CURLY BRACKET
+sign                \x007E            2346 &#126;  TILDE
+punctuation          \x00A1           4-36 &#161;  INVERTED EXCLAMATION MARK
+sign                \x00A2             6-5 &#162;  CENT SIGN
+sign                \x00A3            4-46 &#163;  POUND SIGN
+sign                \x00A4           46-46 &#164;  CURRENCY SIGN
+sign                \x00A5            6-46 &#165;  YEN SIGN
+sign                \x00A6            6-15 &#166;  BROKEN BAR
+sign                \x00A7            4-35 &#167;  SECTION SIGN
+sign                \x00A8             6-4 &#168;  DIAERESIS
+sign                \x00A9         6-12346 &#169;  COPYRIGHT SIGN
+sign                \x00AA           6-125 &#170;  FEMININE ORDINAL INDICATOR
+punctuation         \x00AB           46-56 &#171;  LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+sign                \x00AC          46-256 &#172;  NOT SIGN
+sign                \x00AD            6-36 &#173;  SOFT HYPHEN
+sign                \x00AE          6-1235 &#174;  REGISTERED SIGN
+sign                \x00AF            6-45 &#175;  MACRON
+sign                \x00B0           6-456 &#176;  DEGREE SIGN
+math                \x00B1          46-235 &#177;  PLUS-MINUS SIGN
+sign                \x00B2            6-12 &#178;  SUPERSCRIPT TWO
+sign                \x00B3           6-14  &#179;  SUPERSCRIPT THREE
+sign                \x00B4            6-56 &#180;  ACUTE ACCENT
+sign                \x00B5           6-134 &#181;  MICRO SIGN
+sign                \x00B6           6-145 &#182;  PILCROW SIGN
+sign                \x00B7             4-3 &#183;  MIDDLE DOT
+sign                \x00B8             6-6 &#184;  CEDILLA
+sign                \x00B9             6-1 &#185;  SUPERSCRIPT ONE
+sign                \x00BA           6-245 &#186;  MASCULINE ORDINAL INDICATOR
+punctuation         \x00BB           46-45 &#187;  RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+math                \x00BC           6-136 &#188;  VULGAR FRACTION ONE QUARTER
+math                \x00BD           6-1236 &#189;  VULGAR FRACTION ONE HALF
+math                \x00BE           6-1346 &#190;  VULGAR FRACTION THREE QUARTERS
+punctuation        \x00BF               6-3 &#191;  INVERTED QUESTION MARK
+uppercase          \x00C0            46-236 &#192;  LATIN CAPITAL LETTER A WITH GRAVE
+uppercase          \x00C1               6-2 &#193;  LATIN CAPITAL LETTER A WITH ACUTE
+uppercase          \x00C2              4-16 &#194;  LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+uppercase          \x00C3             4-346 &#195;  LATIN CAPITAL LETTER A WITH TILDE
+uppercase          \x00C4              4-56 &#196;  LATIN CAPITAL LETTER A WITH DIAERESIS
+uppercase          \x00C5            4-3456 &#197;  LATIN CAPITAL LETTER A WITH RING ABOVE
+uppercase          \x00C6               4-4 &#198;  LATIN CAPITAL LETTER AE
+uppercase          \x00C7           4-12346 &#199;  LATIN CAPITAL LETTER C WITH CEDILLA
+uppercase          \x00C8             46-35 &#200;  LATIN CAPITAL LETTER E WITH GRAVE
+uppercase          \x00C9          4-123456 &#201;  LATIN CAPITAL LETTER E WITH ACUTE
+uppercase          \x00CA             4-126 &#202;  LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+uppercase          \x00CB             6-235 &#203;  LATIN CAPITAL LETTER E WITH DIAERESIS
+uppercase          \x00CC               4-5 &#204;  LATIN CAPITAL LETTER I WITH GRAVE
+uppercase          \x00CD              6-25 &#205;  LATIN CAPITAL LETTER I WITH ACUTE
+uppercase          \x00CE             4-146 &#206;  LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+uppercase          \x00CF            6-2356 &#207;  LATIN CAPITAL LETTER I WITH DIAERESIS
+uppercase          \x00D0             4-356 &#208;  LATIN CAPITAL LETTER ETH
+uppercase          \x00D1             4-256 &#209;  LATIN CAPITAL LETTER N WITH TILDE
+uppercase          \x00D2              46-5 &#210;  LATIN CAPITAL LETTER O WITH GRAVE
+uppercase          \x00D3             6-256 &#211;  LATIN CAPITAL LETTER O WITH ACUTE
+uppercase          \x00D4            4-1456 &#212;  LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+uppercase          \x00D5              4-26 &#213;  LATIN CAPITAL LETTER O WITH TILDE
+uppercase          \x00D6              6-35 &#214;  LATIN CAPITAL LETTER O WITH DIAERESIS
+math               \x00D7             6-234 &#215;  MULTIPLICATION SIGN
+uppercase          \x00D8             4-246 &#216;  LATIN CAPITAL LETTER O WITH STROKE
+uppercase          \x00D9            46-356 &#217;  LATIN CAPITAL LETTER U WITH GRAVE
+uppercase          \x00DA              6-26 &#218;  LATIN CAPITAL LETTER U WITH ACUTE
+uppercase          \x00DB             4-156 &#219;  LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+uppercase          \x00DC             6-236 &#220;  LATIN CAPITAL LETTER U WITH DIAERESIS
+uppercase          \x00DD             6-356 &#221;  LATIN CAPITAL LETTER Y WITH ACUTE
+uppercase          \x00DE             4-235 &#222;  LATIN CAPITAL LETTER THORN
+lowercase          \x00DF            6-3456 &#223;  LATIN SMALL LETTER SHARP S
+lowercase          \x00E0           6-12356 &#224;  LATIN SMALL LETTER A WITH GRAVE
+lowercase          \x00E1              6-16 &#225;  LATIN SMALL LETTER A WITH ACUTE
+lowercase          \x00E2             46-16 &#226;  LATIN SMALL LETTER A WITH CIRCUMFLEX
+lowercase          \x00E3            46-346 &#227;  LATIN SMALL LETTER A WITH TILDE
+lowercase          \x00E4             6-345 &#228;  LATIN SMALL LETTER A WITH DIAERESIS
+lowercase          \x00E5           46-3456 &#229;  LATIN SMALL LETTER A WITH RING ABOVE
+lowercase          \x00E6              46-4 &#230;  LATIN SMALL LETTER AE
+lowercase          \x00E7          46-12346 &#231;  LATIN SMALL LETTER C WITH CEDILLA
+lowercase          \x00E8            6-2346 &#232;  LATIN SMALL LETTER E WITH GRAVE
+lowercase          \x00E9          6-123456 &#233;  LATIN SMALL LETTER E WITH ACUTE
+lowercase          \x00EA            46-126 &#234;  LATIN SMALL LETTER E WITH CIRCUMFLEX
+lowercase          \x00EB            6-1246 &#235;  LATIN SMALL LETTER E WITH DIAERESIS
+lowercase          \x00EC              6-34 &#236;  LATIN SMALL LETTER I WITH GRAVE
+lowercase          \x00ED             6-146 &#237;  LATIN SMALL LETTER I WITH ACUTE
+lowercase          \x00EE            46-146 &#238;  LATIN SMALL LETTER I WITH CIRCUMFLEX
+lowercase          \x00EF           6-12456 &#239;  LATIN SMALL LETTER I WITH DIAERESIS
+lowercase          \x00F0            6-2345 &#240;  LATIN SMALL LETTER ETH
+lowercase          \x00F1            6-1345 &#241;  LATIN SMALL LETTER N WITH TILDE
+lowercase          \x00F2             6-346 &#242;  LATIN SMALL LETTER O WITH GRAVE
+lowercase          \x00F3            6-1456 &#243;  LATIN SMALL LETTER O WITH ACUTE
+lowercase          \x00F4           46-1456 &#244;  LATIN SMALL LETTER O WITH CIRCUMFLEX
+lowercase          \x00F5             6-135 &#245;  LATIN SMALL LETTER O WITH TILDE
+lowercase          \x00F6             6-246 &#246;  LATIN SMALL LETTER O WITH DIAERESIS
+math               \x00F7           46-1256 &#247;  DIVISION SIGN
+lowercase          \x00F8            46-246 &#248;  LATIN SMALL LETTER O WITH STROKE
+lowercase          \x00F9           6-23456 &#249;  LATIN SMALL LETTER U WITH GRAVE
+lowercase          \x00FA             6-156 &#250;  LATIN SMALL LETTER U WITH ACUTE
+lowercase          \x00FB            46-156 &#251;  LATIN SMALL LETTER U WITH CIRCUMFLEX
+lowercase          \x00FC            6-1256 &#252;  LATIN SMALL LETTER U WITH DIAERESIS
+lowercase          \x00FD            6-2456 &#253;  LATIN SMALL LETTER Y WITH ACUTE
+lowercase          \x00FE            6-1234 &#254;  LATIN SMALL LETTER THORN
+lowercase          \x00FF           6-13456 &#255;  LATIN SMALL LETTER Y WITH DIAERESIS
+

--- a/tables/de-comp6.utb
+++ b/tables/de-comp6.utb
@@ -24,8 +24,7 @@
 #
 #+language:de
 #+type:computer
-#+contraction:no
-#+grade:0
+#+dots:6
 #+direction:both
 
 # There is no official standard for German 6 dot computer braille. To

--- a/tables/de-de-comp8.ctb
+++ b/tables/de-de-comp8.ctb
@@ -24,8 +24,8 @@
 
 # -----------
 #-name: Eurobraille
-#-index-name: German, computer
-#-display-name: German computer braille
+#-index-name: German, computer, 8-dot
+#-display-name: German 8-dot computer braille
 #
 #+language: de
 #+type: computer

--- a/tables/de-de-comp8.ctb
+++ b/tables/de-de-comp8.ctb
@@ -29,6 +29,7 @@
 #
 #+language: de
 #+type: computer
+#+dots:8
 #+direction: both
 # ------------
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -92,6 +92,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/da-dk-g28-dictionary_harness.yaml	  \
 	braille-specs/da-dk-g28.yaml			  \
 	braille-specs/da-dk-g28l.yaml			  \
+	braille-specs/de-comp6.yaml			  \
 	braille-specs/de-de-comp8.yaml 			  \
 	braille-specs/de-eurobrl6.yaml			  \
 	braille-specs/de-g0-bidi-dictionary.yaml	  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST =					\
 	da-dk-g28-dictionary_harness.yaml	\
 	da-dk-g28.yaml				\
 	da-dk-g28l.yaml				\
+	de-comp6.yaml				\
 	de-de-comp8.yaml			\
 	de-eurobrl6.yaml			\
 	de-g0-bidi-dictionary.yaml		\

--- a/tests/braille-specs/de-comp6.yaml
+++ b/tests/braille-specs/de-comp6.yaml
@@ -1,0 +1,37 @@
+# Deutsches 6-Punkte Computerbraille
+#
+# Copyright © 2022 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+# ----------------------------------------------------------------------------------------------
+
+display: de-eurobrl6.dis
+table:
+  language: de
+  grade: 0
+  type: computer
+  dots: 6
+  direction: both
+  __assert-match: de-comp6.utb
+tests:
+  - - www.xyz.ch
+    - www.xyz.ch
+  - - www.e-text.ch
+    - www.e-text.ch
+  - - meier_alex@ubs.com
+    - 'meier"_alex"`ubs.com'
+  - - http://www.google-test.ch/test?=:;+%#$
+    - http://www.google-test.ch/test?=:;+%#$$
+  - - peter34@gmx.net
+    - "peter34\"`gmx.net"
+  - - "@peter34"
+    - "\"`peter34"
+  - # Filenames
+    - C:/ordner/inhalt_version_1
+    - "\"c:/ordner/inhalt\"_version\"_1"
+  - # Code
+    - "for(i=0;i<=12; i++ { blabla }"
+    - "for(i=0;i<=12; i++ { blabla }"

--- a/tests/braille-specs/de-de-comp8.yaml
+++ b/tests/braille-specs/de-de-comp8.yaml
@@ -2,6 +2,7 @@ display: unicode-without-blank.dis
 table:
   language: de
   type: computer
+  dots: 8
   __assert-match: de-de-comp8.ctb
 tests:
   # standard definitions from Eurobraille

--- a/tests/braille-specs/de-eurobrl6.yaml
+++ b/tests/braille-specs/de-eurobrl6.yaml
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------------------------
 
 table: de-eurobrl6.dis
-table: {language: de, grade: 0, type: literary}
+table: {language: de, grade: 0}
 table: {language: de, grade: 1}
 table: {language: de, grade: 2}
 flags: {testmode: display}

--- a/tests/braille-specs/de-eurobrl6.yaml
+++ b/tests/braille-specs/de-eurobrl6.yaml
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------------------------
 
 table: de-eurobrl6.dis
-table: {language: de, grade: 0}
+table: {language: de, grade: 0, type: literary}
 table: {language: de, grade: 1}
 table: {language: de, grade: 2}
 flags: {testmode: display}
@@ -28,7 +28,7 @@ tests:
   - - "_"
     - ⠸
 
-table: {language: de, grade: 0}
+table: {language: de, grade: 0, type: literary}
 table: {language: de, grade: 1}
 table: {language: de, grade: 2}
 flags: {testmode: display}


### PR DESCRIPTION
From the comments in the new table:

```
# There is no official standard for German 6 dot computer braille. To
# my knowledge there is not even an official standard for 8 dot
# computer braille , see
# http://www.bskdl.org/braillesysteme.html#computer. There is some
# definition for 8-dot at http://braille.ch/computer.htm but I do not
# know how official that is. On the implementation side there is the
# German Eurobraille table in Liblouis.

# So consider this table as a defacto standard as it is used at SBS to
# produce books for the German speaking readers.
```