### PR TITLE
Fix memory leak on table compilation error

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4670,6 +4670,16 @@ compileFile(const char *fileName, TranslationTableHeader **table,
 	return !errorCount;
 }
 
+static void
+freeTranslationTable(TranslationTableHeader *t) {
+	for (int i = 0; i < MAX_EMPH_CLASSES && t->emphClassNames[i]; i++)
+		free(t->emphClassNames[i]);
+	for (int i = 0; t->sourceFiles[i]; i++) free(t->sourceFiles[i]);
+	if (t->characterClasses) deallocateCharacterClasses(t);
+	if (t->ruleNames) deallocateRuleNames(t);
+	free(t);
+}
+
 /**
  * Free a char** array
  */
@@ -4798,7 +4808,7 @@ cleanup:
 	} else {
 		_lou_logMessage(LOU_LOG_ERROR, "%d errors found.", errorCount);
 		if (translationTable) {
-			if (*translationTable) free(*translationTable);
+			if (*translationTable) freeTranslationTable(*translationTable);
 			*translationTable = NULL;
 		}
 		if (displayTable) {
@@ -5106,13 +5116,7 @@ lou_free(void) {
 	if (translationTableChain != NULL) {
 		currentEntry = translationTableChain;
 		while (currentEntry) {
-			TranslationTableHeader *t = (TranslationTableHeader *)currentEntry->table;
-			for (int i = 0; i < MAX_EMPH_CLASSES && t->emphClassNames[i]; i++)
-				free(t->emphClassNames[i]);
-			for (int i = 0; t->sourceFiles[i]; i++) free(t->sourceFiles[i]);
-			if (t->characterClasses) deallocateCharacterClasses(t);
-			if (t->ruleNames) deallocateRuleNames(t);
-			free(t);
+			freeTranslationTable(currentEntry->table);
 			previousEntry = currentEntry;
 			currentEntry = currentEntry->next;
 			free(previousEntry);


### PR DESCRIPTION
Otherwise we get

/home/samy/brl/translation/liblouis-git/tests/tables/bad.ctb:1: error: opcode 'bad' not defined.
1 errors found.
tests/tables/bad.ctb could not be compiled

=================================================================
==3022215==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 61 byte(s) in 1 object(s) allocated from:
    #0 0x7f67684e0545 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x7f676831b31a in __GI___strdup string/strdup.c:42
    #2 0x7f676849d47e in compileFile /home/samy/brl/translation/liblouis-git/liblouis/compileTranslationTable.c:4650
    #3 0x7f676849d9b1 in compileTable /home/samy/brl/translation/liblouis-git/liblouis/compileTranslationTable.c:4767
    #4 0x7f676849e011 in getTable /home/samy/brl/translation/liblouis-git/liblouis/compileTranslationTable.c:4939
    #5 0x7f676849dcb0 in _lou_getTable /home/samy/brl/translation/liblouis-git/liblouis/compileTranslationTable.c:4848
    #6 0x7f676849dd0e in lou_getTable /home/samy/brl/translation/liblouis-git/liblouis/compileTranslationTable.c:4860
    #7 0x7f676849e165 in lou_checkTable /home/samy/brl/translation/liblouis-git/liblouis/compileTranslationTable.c:4978
    #8 0x55e477d791c2 in main /home/samy/brl/translation/liblouis-git/tests/checkTable.c:29
    #9 0x7f67682b47fc in __libc_start_main ../csu/libc-start.c:332
    #10 0x55e477d79099 in _start (/home/samy/ens/projet/1/translation/liblouis-git/tests/.libs/checkTable+0x1099)

SUMMARY: LeakSanitizer: 61 byte(s) leaked in 1 allocation(s).
FAIL checkTable (exit status: 23)