### PR TITLE
lou_findTables: Fix memleak

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -773,8 +773,8 @@ lou_findTables(const char *query) {
 		_lou_logMessage(LOU_LOG_INFO, "%d matches found", list_size(matches));
 		int i = 0;
 		tablesArray = malloc((1 + list_size(matches)) * sizeof(void *));
-		for (; matches; matches = matches->tail)
-			tablesArray[i++] = ((TableMatch *)matches->head)->name;
+		for (List *elem = matches; elem; elem = elem->tail)
+			tablesArray[i++] = ((TableMatch *)elem->head)->name;
 		tablesArray[i] = NULL;
 		list_free(matches);
 		return tablesArray;


### PR DESCRIPTION
Since the "for" loop would always make "matches" NULL.

Otherwise we get in tests/findTable.log:

[...]
2 matches found

=================================================================
==3029162==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f6433b92545 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x7f6433b636cc in list_conj /home/samy/brl/translation/liblouis-git/liblouis/metadata.c:58
    #2 0x7f6433b652c7 in lou_findTables /home/samy/brl/translation/liblouis-git/liblouis/metadata.c:767
    #3 0x55c2bddf4291 in main /home/samy/brl/translation/liblouis-git/tests/findTable.c:33
    #4 0x7f64339667fc in __libc_start_main ../csu/libc-start.c:332
    #5 0x55c2bddf40d9 in _start (/home/samy/ens/projet/1/translation/liblouis-git/tests/.libs/findTable+0x10d9)

Indirect leak of 32 byte(s) in 2 object(s) allocated from:
    #0 0x7f6433b92545 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x7f6433b65293 in lou_findTables /home/samy/brl/translation/liblouis-git/liblouis/metadata.c:767
    #2 0x55c2bddf4291 in main /home/samy/brl/translation/liblouis-git/tests/findTable.c:33
    #3 0x7f64339667fc in __libc_start_main ../csu/libc-start.c:332
    #4 0x55c2bddf40d9 in _start (/home/samy/ens/projet/1/translation/liblouis-git/tests/.libs/findTable+0x10d9)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f6433b92545 in __interceptor_malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
    #1 0x7f6433b637f9 in list_conj /home/samy/brl/translation/liblouis-git/liblouis/metadata.c:84
    #2 0x7f6433b652c7 in lou_findTables /home/samy/brl/translation/liblouis-git/liblouis/metadata.c:767
    #3 0x55c2bddf4291 in main /home/samy/brl/translation/liblouis-git/tests/findTable.c:33
    #4 0x7f64339667fc in __libc_start_main ../csu/libc-start.c:332
    #5 0x55c2bddf40d9 in _start (/home/samy/ens/projet/1/translation/liblouis-git/tests/.libs/findTable+0x10d9)

SUMMARY: LeakSanitizer: 80 byte(s) leaked in 4 allocation(s).
FAIL findTable (exit status: 23)