### PR TITLE
SwapTest: Fix read overflow

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -390,6 +390,7 @@ swapTest(int swapIC, int *pos, const TranslationTableHeader *table, const InStri
 	swapRule = (TranslationTableRule *)&table->ruleArea[swapRuleOffset];
 	while (p - *pos < passInstructions[swapIC + 3]) {
 		int test;
+		if (p >= input->length) return 0;
 		if (swapRule->opcode == CTO_SwapDd) {
 			for (test = 1; test < swapRule->charslen; test += 2) {
 				if (input->chars[p] == swapRule->charsdots[test]) break;
@@ -408,6 +409,10 @@ swapTest(int swapIC, int *pos, const TranslationTableHeader *table, const InStri
 	}
 	while (p - *pos < passInstructions[swapIC + 4]) {
 		int test;
+		if (p >= input->length) {
+			*pos = p;
+			return 1;
+		}
 		if (swapRule->opcode == CTO_SwapDd) {
 			for (test = 1; test < swapRule->charslen; test += 2) {
 				if (input->chars[p] == swapRule->charsdots[test]) break;


### PR DESCRIPTION
SwapTest has to check wheter it overflows the input. Otherwise we get in
tests/braille-specs/da-dk-g16-lit.log:

==43588==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000026712 at pc 0x7f7d9ff57381 bp 0x7fff050fd170 sp 0x7fff050fd168
READ of size 2 at 0x602000026712 thread T0
    #0 0x7f7d9ff57380 in swapTest /home/samy/brl/translation/liblouis-git/liblouis/lou_translateString.c:399
    #1 0x7f7d9ff5d22e in passDoTest /home/samy/brl/translation/liblouis-git/liblouis/lou_translateString.c:861
    #2 0x7f7d9ff552f2 in findForPassRule /home/samy/brl/translation/liblouis-git/liblouis/lou_translateString.c:211
    #3 0x7f7d9ff55ac9 in makeCorrections /home/samy/brl/translation/liblouis-git/liblouis/lou_translateString.c:276
    #4 0x7f7d9ff6128d in _lou_translate /home/samy/brl/translation/liblouis-git/liblouis/lou_translateString.c:1272
    #5 0x55b837c9bdac in check_base /home/samy/brl/translation/liblouis-git/tools/brl_checks.c:180
    #6 0x55b837c97717 in read_test /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:807
    #7 0x55b837c97f69 in read_tests /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:869
    #8 0x55b837c9948a in main /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:1063
    #9 0x7f7d9fd447fc in __libc_start_main ../csu/libc-start.c:332
    #10 0x55b837c914c9 in _start (/home/samy/ens/projet/1/translation/liblouis-git/tools/.libs/lou_checkyaml+0x64c9)

0x602000026712 is located 0 bytes to the right of 2-byte region [0x602000026710,0x602000026712)
allocated by thread T0 here:
    #0 0x7f7da00777cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x55b837c9b8b6 in check_base /home/samy/brl/translation/liblouis-git/tools/brl_checks.c:138
    #2 0x55b837c97717 in read_test /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:807
    #3 0x55b837c97f69 in read_tests /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:869
    #4 0x55b837c9948a in main /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:1063
    #5 0x7f7d9fd447fc in __libc_start_main ../csu/libc-start.c:332