### PR TITLE
check_base: fix computing input length

### DIFF
--- a/tools/brl_checks.h
+++ b/tools/brl_checks.h
@@ -166,3 +166,6 @@ convert_typeform(const char *typeform_string);
 
 void
 update_typeform(const char *typeform_string, formtype *typeform, typeforms kind);
+
+int
+parsed_strlen(char *s);

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -700,33 +700,6 @@ read_options(yaml_parser_t *parser, int testmode, int wordLen, int translationLe
 	yaml_event_delete(&event);
 }
 
-/* see http://stackoverflow.com/questions/5117393/utf-8-strings-length-in-linux-c */
-static int
-my_strlen_utf8_c(char *s) {
-	int i = 0, j = 0;
-	while (s[i]) {
-		if ((s[i] & 0xc0) != 0x80) j++;
-		i++;
-	}
-	return j;
-}
-
-/*
- * String parsing is also done later in check_base. At this point we
- * only need it to compute the actual string length in order to be
- * able to provide error messages when parsing typeform and position arrays.
- */
-static int
-parsed_strlen(char *s) {
-	widechar *buf;
-	int len, maxlen;
-	maxlen = my_strlen_utf8_c(s);
-	buf = malloc(sizeof(widechar) * maxlen);
-	len = _lou_extParseChars(s, buf);
-	free(buf);
-	return len;
-}
-
 static void
 read_test(yaml_parser_t *parser, char **tables, const char *display_table, int testmode) {
 	yaml_event_t event;


### PR DESCRIPTION
read_test gives parsed_strlen(word) to read_options, so that it gives it
to read_typeforms, and thus typeform has that length. check_base should
thus also use that length when memcpying it.

Otherwise we get in braille-specs/de-g1.yaml:

==95136==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000f451c at pc 0x7f5603f1b9b0 bp 0x7ffe24c6bc60 sp 0x7ffe24c6b410
READ of size 16 at 0x6020000f451c thread T0
    #0 0x7f5603f1b9af in __interceptor_memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827
    #1 0x5626d22d983b in check_base /home/samy/brl/translation/liblouis-git/tools/brl_checks.c:116
    #2 0x5626d22d5717 in read_test /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:807
    #3 0x5626d22d5f69 in read_tests /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:869
    #4 0x5626d22d748a in main /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:1063
    #5 0x7f5603c5d7fc in __libc_start_main ../csu/libc-start.c:332
    #6 0x5626d22cf4c9 in _start (/home/samy/ens/projet/1/translation/liblouis-git/tools/.libs/lou_checkyaml+0x64c9)

0x6020000f451c is located 0 bytes to the right of 12-byte region [0x6020000f4510,0x6020000f451c)
allocated by thread T0 here:
    #0 0x7f5603f90987 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x5626d22d37b5 in read_typeforms /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:567
    #2 0x5626d22d40c6 in read_options /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:642
    #3 0x5626d22d51e7 in read_test /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:774
    #4 0x5626d22d5f69 in read_tests /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:869
    #5 0x5626d22d748a in main /home/samy/brl/translation/liblouis-git/tools/lou_checkyaml.c:1063
    #6 0x7f5603c5d7fc in __libc_start_main ../csu/libc-start.c:332