### PR TITLE
typeform test: avoid oversized input buffer size

### DIFF
--- a/tests/typeform.c
+++ b/tests/typeform.c
@@ -676,7 +676,7 @@ main (int argc, char **argv)
         formtype* typeform = malloc(outlen * sizeof(formtype));
         for (j=0; j<=inlen; j++)
             typeform[j] = 0;
-        _lou_extParseChars(strings[i], inbuf);
+        inlen = _lou_extParseChars(strings[i], inbuf);
         if (!lou_translate(table, inbuf, &inlen, outbuf, &outlen, typeform, NULL, NULL, NULL, NULL, 0))
             return 1;
         free(inbuf);


### PR DESCRIPTION
inlen is initially set as the mere C string length, lou_translate
expects the number of wide characters, which is actually exactly what
_lou_extParseChars returns.