### PR TITLE
Fix some German emphasis issues

### DIFF
--- a/tables/de-g0-core.uti
+++ b/tables/de-g0-core.uti
@@ -2,6 +2,7 @@
 #
 #  Copyright (C) 2018 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte
 #  Copyright (C) 2020 Bue Vester-Andersen
+#  Copyright (C) 2022 Bert Frees
 #
 #  This file is part of liblouis.
 #
@@ -165,20 +166,24 @@ emphclass bold
 begemphphrase italic 456-456
 endemphphrase italic after 6-3
 lenemphphrase italic 2
-begemphword italic 456
+begemphword italic 456b
 endemphword italic 6-3
 
 begemphphrase bold 456-456
 endemphphrase bold after 6-3
 lenemphphrase bold 2
-begemphword bold 456
+begemphword bold 456b
 endemphword bold 6-3
 
 begemphphrase underline 456-456
 endemphphrase underline after 6-3
 lenemphphrase underline 2
-begemphword underline 456
+begemphword underline 456b
 endemphword underline 6-3
+
+# dot 6 required before emphasis indicator when inside word
+noback pass2 _$l@456b @6-456
+noback pass2 @456b @456
 
 emphclass downgrade
 begemphphrase downgrade 36-3

--- a/tables/de-g0-core.uti
+++ b/tables/de-g0-core.uti
@@ -168,18 +168,24 @@ endemphphrase italic after 6-3
 lenemphphrase italic 2
 begemphword italic 456b
 endemphword italic 6-3
+emphmodechars italic *()[]{}<>
+noemphchars italic \s\t\n\r\x00a0/-\x2013\x2014*()[]{}<>„“‚‘«»‹›.,:;!¡?¿
 
 begemphphrase bold 456-456
 endemphphrase bold after 6-3
 lenemphphrase bold 2
 begemphword bold 456b
 endemphword bold 6-3
+emphmodechars bold *()[]{}<>
+noemphchars bold \s\t\n\r/x00a0/-\x2013\x2014*()[]{}<>„“‚‘«»‹›.,:;!¡?¿
 
 begemphphrase underline 456-456
 endemphphrase underline after 6-3
 lenemphphrase underline 2
 begemphword underline 456b
 endemphword underline 6-3
+emphmodechars underline *()[]{}<>
+noemphchars underline \s\t\n\r\x00a0/-\x2013\x2014*()[]{}<>„“‚‘«»‹›.,:;!¡?¿
 
 # dot 6 required before emphasis indicator when inside word
 noback pass2 _$l@456b @6-456

--- a/tables/de-g1-core.cti
+++ b/tables/de-g1-core.cti
@@ -2,6 +2,7 @@
 #
 #  Copyright (C) 2018 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte
 #  Copyright (C) 2020 Bue Vester-Andersen
+#  Copyright (C) 2022 Bert Frees
 #
 #  This file is part of liblouis.
 #
@@ -23,14 +24,36 @@
 
 include de-g1-core-patterns.dic
 
-noback nocross always   au         16                           # 1 #
-noback nocross always   eu         126                          # 2 #
-noback nocross always   ei         146                          # 3 #
-noback nocross always   ch         1456                         # 4 #
-noback nocross always   sch        156                          # 5 #
-noback nocross always   st         23456                        # ] #
-noback nocross always   äu         34                           # \ #
-noback nocross always   ie         346                          # 0 #
+# Attach virtual dot "a" and letter attribute to contraction
+# patterns. Private use area U+F800 - U+F83F is used to represent
+# these.
+
+letter  \xF821  16a            # 1 #
+letter  \xF823  126a           # 2 #
+letter  \xF829  146a           # 3 #
+letter  \xF839  1456a          # 4 #
+letter  \xF831  156a           # 5 #
+letter  \xF83E  23456a         # ] #
+letter  \xF80C  34a            # \ #
+letter  \xF82C  346a           # 0 #
+
+noback pass2 @16a @16
+noback pass2 @126a @126
+noback pass2 @146a @146
+noback pass2 @1456a @1456
+noback pass2 @156a @156
+noback pass2 @23456a @23456
+noback pass2 @34a @34
+noback pass2 @346a @346
+
+noback nocross always   au         16a                           # 1 #
+noback nocross always   eu         126a                          # 2 #
+noback nocross always   ei         146a                          # 3 #
+noback nocross always   ch         1456a                         # 4 #
+noback nocross always   sch        156a                          # 5 #
+noback nocross always   st         23456a                        # ] #
+noback nocross always   äu         34a                           # \ #
+noback nocross always   ie         346a                          # 0 #
 
 nofor partword    au         16                           # 1 #
 nofor partword    eu         126                          # 2 #

--- a/tables/de-g2-core.cti
+++ b/tables/de-g2-core.cti
@@ -1,6 +1,7 @@
 #  liblouis: German Grade 2 Braille
 #
 #  Copyright (C) 2018 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte
+#  Copyright (C) 2022 Bert Frees
 #
 #  This file is part of liblouis.
 #
@@ -84,50 +85,122 @@ word	z'	6-1356-6
 
 include de-g2-core-patterns.dic
 
+# Attach virtual dot "a" and letter attribute to contraction
+# patterns. Private use area U+F800 - U+F83F is used to represent
+# these.
+
+letter  \xF804  3a             # . #
+letter  \xF806  23a            # ; #
+letter  \xF80C  34a            # \ #
+letter  \xF812  25a            # : #
+letter  \xF814  35a            # * #
+letter  \xF816  235a           # + #
+letter  \xF818  45a            # > #
+letter  \xF81C  345a           # @ #
+letter  \xF821  16a            # 1 #
+letter  \xF822  26a            # ? #
+letter  \xF823  126a           # 2 #
+letter  \xF824  36b            # - #
+letter  \xF826  236a           # ( #
+letter  \xF828  46a            # $ #
+letter  \xF829  146a           # 3 #
+letter  \xF82A  246a           # 9 #
+letter  \xF82B  1246a          # 6 #
+letter  \xF82C  346a           # 0 #
+letter  \xF82E  2346a          # ^ #
+letter  \xF82F  12346a         # & #
+letter  \xF830  56a            # < #
+letter  \xF831  156a           # 5 #
+letter  \xF832  256a           # / #
+letter  \xF833  1256a          # 8 #
+letter  \xF834  356a           # ) #
+letter  \xF836  2356a          # = #
+letter  \xF837  12356a         # [ #
+letter  \xF838  456a           # _ #
+letter  \xF839  1456a          # 4 #
+letter  \xF83B  12456a         # 7 #
+letter  \xF83C  3456a          # # #
+letter  \xF83E  23456a         # ] #
+letter  \xF83F  123456a        # % #
+
+noback pass2 @3a @3
+noback pass2 @23a @23
+noback pass2 @34a @34
+noback pass2 @25a @25
+noback pass2 @35a @35
+noback pass2 @235a @235
+noback pass2 @45a @45
+noback pass2 @345a @345
+noback pass2 @16a @16
+noback pass2 @26a @26
+noback pass2 @126a @126
+noback pass2 @36b @36a
+noback pass2 @236a @236
+noback pass2 @46a @46
+noback pass2 @146a @146
+noback pass2 @246a @246
+noback pass2 @1246a @1246
+noback pass2 @346a @346
+noback pass2 @2346a @2346
+noback pass2 @12346a @12346
+noback pass2 @56a @56
+noback pass2 @156a @156
+noback pass2 @256a @256
+noback pass2 @1256a @1256
+noback pass2 @356a @356
+noback pass2 @2356a @2356
+noback pass2 @12356a @12356
+noback pass2 @456a @456
+noback pass2 @1456a @1456
+noback pass2 @12456a @12456
+noback pass2 @3456a @3456
+noback pass2 @23456a @23456
+noback pass2 @123456a @123456
+
 word       aber       1                            #  A  #
 nocross always    aber       2-1                          #  ,A  #
-nocross midendword    ach        56                           #  <  #
-nocross begmidword    al         25                           #  :  #
-nocross always    al'        25-6                         #  :'  #
+nocross midendword    ach        56a                           #  <  #
+nocross begmidword    al         25a                           #  :  #
+nocross always    al'        25a-6                         #  :'  #
 prfword    all        1-12345                      #  AQ  #
 nocross always    all        1                            #  A  #
-word       als        146                          #  3  #
+word       als        146a                          #  3  #
 nocross always    also       1-135                        #  AO  #
 endword    an         1-1345                       #  AN  #
-nocross always    an         235                          #  +  #
-nocross always    an'        235-6                        #  +'  #
-nocross always    ander      2-12456                      #  ,7  #
-nocross begmidword    ar         356                          #  )  #
-nocross always    ar'        356-6                        #  )'  #
-nocross always    arbeit     356-12                       #  )B  #
+nocross always    an         235a                          #  +  #
+nocross always    an'        235a-6                        #  +'  #
+nocross always    ander      2-12456a                      #  ,7  #
+nocross begmidword    ar         356a                          #  )  #
+nocross always    ar'        356a-6                        #  )'  #
+nocross always    arbeit     356a-12                       #  )B  #
 nocross always    ation      5-1345                       #  !N  #
 nocross always    ativ       5-1236                       #  !V  #
-word       au         6-16                         #  '1  #
-nocross always    au         16                           #  1  #
-word       auch       34                           #  \  #
-word       auf        16                           #  1  #
-nocross always    auf        2-16                         #  ,1  #
-nocross begmidword    be         23                           #  ;  #
-nocross always    be'        23-6                         #  ;'  #
+word       au         6-16a                         #  '1  #
+nocross always    au         16a                           #  1  #
+word       auch       34a                           #  \  #
+word       auf        16a                           #  1  #
+nocross always    auf        2-16a                         #  ,1  #
+nocross begmidword    be         23a                           #  ;  #
+nocross always    be'        23a-6                         #  ;'  #
 word       bei        12                           #  B  #
 nocross always    bei        2-12                         #  ,B  #
 nocross always    beid       12-145                       #  BD  #
 word       beim       12-134                       #  BM  #
-nocross always    besonder   23                           #  ;  #
+nocross always    besonder   23a                           #  ;  #
 nocross always    besser     234-234                      #  SS  #
 nocross always    bis        12-234                       #  BS  #
-nocross always    bist       12-23456                     #  B]  #
+nocross always    bist       12-23456a                     #  B]  #
 nocross always    bleib      12-12                        #  BB  #
-nocross always    brauch     2-34                         #  ,\  #
+nocross always    brauch     2-34a                         #  ,\  #
 nocross always    brief      12-124                       #  BF  #
 nocross always    bring      12-1245                      #  BG  #
-nocross always    bräuch     5-34                         #  !\  #
+nocross always    bräuch     5-34a                         #  !\  #
 always     c          6-14                         #  'C  #
 always     C          6-14                         #  'C  #
-word       ch         6-1456                       #  '4  #
-nocross always    ch         1456                         #  4  #
-nocross always    charakter  1456-13                      #  4K  #
-nocross midendword    ck         46                           #  $  #
+word       ch         6-1456a                       #  '4  #
+nocross always    ch         1456a                         #  4  #
+nocross always    charakter  1456a-13                      #  4K  #
+nocross midendword    ck         46a                           #  $  #
 nocross always    dabei      145-12                       #  DB  #
 word       dadurch    145-145                      #  DD  #
 nocross always    dafür      145-124                      #  DF  #
@@ -135,55 +208,55 @@ nocross always    dagegen    145-1245                     #  DG  #
 nocross always    daher      145-125                      #  DH  #
 nocross always    damit      145-134                      #  DM  #
 nocross always    dank       145-13                       #  DK  #
-nocross always    darauf     145-16                       #  D1  #
-nocross always    darüber    145-1256                     #  D8  #
+nocross always    darauf     145-16a                       #  D1  #
+nocross always    darüber    145-1256a                     #  D8  #
 word       das        145                          #  D  #
-word       dass       2346                         #  ^  #
+word       dass       2346a                         #  ^  #
 nocross always    davon      145-1236                     #  DV  #
 nocross always    dazu       145-1356                     #  DZ  #
-word       dem        12356                        #  [  #
-nocross always    dem        2-12356                      #  ,[  #
+word       dem        12356a                        #  [  #
+nocross always    dem        2-12356a                      #  ,[  #
 nocross always    demokrat   145-2345                     #  DT  #
 word       den        15                           #  E  #
 word       denen      15-14                        #  EC  #
 nocross always    denn       145-1345                     #  DN  #
 word       der        1235                         #  R  #
-word       des        3                            #  .  #
-nocross always    dessen     145-2346                     #  D^  #
-nocross always    deutsch    145-156                      #  D5  #
-word       die        346                          #  0  #
-nocross begmidword    dies       346                          #  0  #
+word       des        3a                            #  .  #
+nocross always    dessen     145-2346a                     #  D^  #
+nocross always    deutsch    145-156a                      #  D5  #
+word       die        346a                          #  0  #
+nocross begmidword    dies       346a                          #  0  #
 word       dir        145-1235                     #  DR  #
-word       doch       145-1456                     #  D4  #
-nocross always    druck      145-46                       #  D$  #
-nocross always    drück      5-145-46                     #  !D$  #
-word       durch      1456                         #  4  #
-nocross always    durch      2-1456                       #  ,4  #
+word       doch       145-1456a                     #  D4  #
+nocross always    druck      145-46a                       #  D$  #
+nocross always    drück      5-145-46a                     #  !D$  #
+word       durch      1456a                         #  4  #
+nocross always    durch      2-1456a                       #  ,4  #
 nocross always    dürf       2-145                        #  ,D  #
 nocross always    ebenso     15-135                       #  EO  #
-nocross midword    eh         2356                         #  =  #
-word       ei         6-146                        #  '3  #
-nocross always    ei         146                          #  3  #
-nocross always    ein        1246                         #  6  #
-nocross always    einander   2-1246                       #  ,6  #
+nocross midword    eh         2356a                         #  =  #
+word       ei         6-146a                        #  '3  #
+nocross always    ei         146a                          #  3  #
+nocross always    ein        1246a                         #  6  #
+nocross always    einander   2-1246a                       #  ,6  #
 nocross always    el         13456                        #  Y  #
-nocross always    em         12356                        #  [  #
+nocross always    em         12356a                        #  [  #
 nocross always    en         14                           #  C  #
-nocross begword   ent        2346                         #  ^  #
+nocross begword   ent        2346a                         #  ^  #
 word       eo         6-15-135                     #  'EO  #
-nocross always    er         12456                        #  7  #
-nocross always    es         123456                       #  %  #
+nocross always    er         12456a                        #  7  #
+nocross always    es         123456a                       #  %  #
 nocross always    etwa       15-1                         #  EA  #
 nocross always    etwas      2345-2456                    #  TW  #
-word       eu         6-126                        #  '2  #
-nocross always    eu         126                          #  2  #
+word       eu         6-126a                        #  '2  #
+nocross always    eu         126a                          #  2  #
 begword    ex         1346                         #  X  #
 nocross always    'ex        6-15-6-1346                  #  'E'X  #
 nocross always    fall       124-12345                    #  FQ  #
 nocross always    fahr       2-1235                       #  ,R  #
 word       falls      124-12345-234                #  FQS  #
 nocross midendword    falls      124                          #  F  #
-nocross always    fertig     124-45                       #  F>  #
+nocross always    fertig     124-45a                       #  F>  #
 nocross always    folg       124-1245                     #  FG  #
 nocross always    freund     124-145                      #  FD  #
 nocross always    fäll       5-124-12345                  #  !FQ  #
@@ -192,32 +265,32 @@ nocross always    führ       124-125                      #  FH  #
 word       für        124                          #  F  #
 nocross always    für        2-124                        #  ,F  #
 nocross always    ganz       1245-1356                    #  GZ  #
-nocross always    ge         12346                        #  &  #
+nocross always    ge         12346a                        #  &  #
 word       gegen      1245                         #  G  #
 nocross always    gegen      2-1245                       #  ,G  #
 nocross always    gegenwart  1245-2456                    #  GW  #
 nocross always    gegenwärt  5-1245-2456                  #  !GW  #
-nocross always    gegenüber  1245-1256                    #  G8  #
+nocross always    gegenüber  1245-1256a                    #  G8  #
 nocross always    gelegen       1245-1245                    #  GG  #
 nocross always    geschäft     1245-124                     #  GF  #
-nocross always    gesellschaft  1245-156                  #  G5  #
-word       gewesen    12346                        #  &  #
-nocross always    gewesen    2-12346                      #  ,&  #
-nocross always    geworden   12346-2456                   #  &W  #
+nocross always    gesellschaft  1245-156a                  #  G5  #
+word       gewesen    12346a                        #  &  #
+nocross always    gewesen    2-12346a                      #  ,&  #
+nocross always    geworden   12346a-2456                   #  &W  #
 nocross always    gibt       1245-12                      #  GB  #
-nocross always    gleich     1245-1456                    #  G4  #
-nocross always    glück      1245-46                      #  G$  #
-nocross always    gross      1245-2346                    #  G^  #
-nocross always    groß       1245-2346                    #  G^  #
+nocross always    gleich     1245-1456a                    #  G4  #
+nocross always    glück      1245-46a                      #  G$  #
+nocross always    gross      1245-2346a                    #  G^  #
+nocross always    groß       1245-2346a                    #  G^  #
 nocross always    grund      1245-145                     #  GD  #
-nocross always    gröss      5-1245-2346                  #  !G^  #
-nocross always    größ       5-1245-2346                  #  !G^  #
+nocross always    gröss      5-1245-2346a                  #  !G^  #
+nocross always    größ       5-1245-2346a                  #  !G^  #
 nocross always    gründ      5-1245-145                   #  !GD  #
 nocross always    gänz       5-1245-1356                  #  !GZ  #
 nocross always    hab        2-125                        #  ,H  #
 nocross always    haft       125-124                      #  HF  #
 nocross always    hand       125-145                      #  HD  #
-nocross always    hast       125-23456                    #  H]  #
+nocross always    hast       125-23456a                    #  H]  #
 nocross always    hat        125-2345                     #  HT  #
 nocross always    hatt       125                          #  H  #
 nocross always    haupt      125-1234                     #  HP  #
@@ -229,46 +302,46 @@ nocross always    hier       125-1235                     #  HR  #
 nocross always    hoff       124-124                      #  FF  #
 nocross always    häft       5-125-124                    #  !HF  #
 nocross always    händ       5-125-145                    #  !HD  #
-nocross always    hätt       345                          #  @  #
+nocross always    hätt       345a                          #  @  #
 nocross always    häupt      5-125-1234                   #  !HP  #
-nocross always    ich        3456                         #  #  #
-word       ich,       24-1456-2                    #  I4,  #
-word       ich;       24-1456-23                   #  I4;  #
-word       ich:       24-1456-25                   #  I4:  #
-word       ich?       24-1456-26                   #  I4?  #
-word       ich!       24-1456-235                  #  I4+  #
-word       ich)       24-1456-2356                 #  I4=  #
-word       ich"       24-1456-356                  #  I4)  #
-word       ich«       24-1456-356                  #  I4)  #
-word       ich»       24-1456-356                  #  I4)  #
-word       ich┊       24-1456-abcdef               #  I4x  #
-nocross midendword    ie         346                          #  0  #
-nocross midendword    ig         45                           #  >  #
-word       ihm        236                          #  (  #
+nocross always    ich        3456a                         #  #  #
+word       ich,       24-1456a-2                    #  I4,  #
+word       ich;       24-1456a-23                   #  I4;  #
+word       ich:       24-1456a-25                   #  I4:  #
+word       ich?       24-1456a-26                   #  I4?  #
+word       ich!       24-1456a-235                  #  I4+  #
+word       ich)       24-1456a-2356                 #  I4=  #
+word       ich"       24-1456a-356                  #  I4)  #
+word       ich«       24-1456a-356                  #  I4)  #
+word       ich»       24-1456a-356                  #  I4)  #
+word       ich┊       24-1456a-abcdef               #  I4x  #
+nocross midendword    ie         346a                          #  0  #
+nocross midendword    ig         45a                           #  >  #
+word       ihm        236a                          #  (  #
 nocross always    ihn        24-125                       #  IH  #
 nocross sufword   ihr        24                           #  I  #
-word       im         36a                          #  -  #
+word       im         36b                          #  -  #
 word       immer      1346                         #  X  #
 nocross always    immer      2-1346                       #  ,X  #
-nocross always    in         35                           #  *  #
-nocross always    interess   2-35                         #  ,*  #
+nocross always    in         35a                           #  *  #
+nocross always    interess   2-35a                         #  ,*  #
 nocross always    irgend     24-1245                      #  IG  #
 nocross always    ismus      5-24                         #  !I  #
-word       ist        23456                        #  ]  #
-nocross always    istisch    5-156                        #  !5  #
-nocross always    ität       5-345                        #  !@  #
+word       ist        23456a                        #  ]  #
+nocross always    istisch    5-156a                        #  !5  #
+nocross always    ität       5-345a                        #  !@  #
 nocross always    jahr       245-1235                     #  JR  #
 nocross always    jahrhundert 245-125                     #  JH  #
 nocross always    jahrtausend 245-2345                    #  JT  #
 nocross always    jahrzehnt  245-1356                     #  JZ  #
 nocross always    jed        245-145                      #  JD  #
-word       jedoch     245-1456                     #  J4  #
-nocross always    jetzig     245-45                       #  J>  #
+word       jedoch     245-1456a                     #  J4  #
+nocross always    jetzig     245-45a                       #  J>  #
 word       jetzt      245                          #  J  #
 nocross always    jetzt      2-245                        #  ,J  #
 nocross always    jähr       5-245-1235                   #  !JR  #
 word       kann       13                           #  K  #
-nocross always    kannst     13-23456                     #  K]  #
+nocross always    kannst     13-23456a                     #  K]  #
 nocross always    kapital    13-1234                      #  KP  #
 nocross midendword keit      13                           #  K  #
 nocross always    komm       13-1346                      #  KX  #
@@ -282,20 +355,20 @@ nocross always    kürz       5-13-1356                    #  !KZ  #
 nocross always    lang       123-1245                     #  LG  #
 nocross always    lass       2-123                        #  ,L  #
 nocross always    leb        123-12                       #  LB  #
-nocross always    leicht     123-1456                     #  L4  #
+nocross always    leicht     123-1456a                     #  L4  #
 nocross always    letzt      123-2345                     #  LT  #
-nocross midendword lich      456                          #  _  #
+nocross midendword lich      456a                          #  _  #
 nocross midendword ll        12345                        #  Q  #
 nocross always    läng       5-123-1245                   #  !LG  #
 nocross always    läss       5-123                        #  !L  #
 word       lässt      123                          #  L  #
 nocross midendword mal       134                          #  M  #
 word       man        134                          #  M  #
-nocross always    maschin    134-156                      #  M5  #
+nocross always    maschin    134-156a                      #  M5  #
 nocross always    material   134-123                      #  ML  #
 nocross always    materiell  134-12345                    #  MQ  #
-word       mehr       2356                         #  =  #
-nocross always    mehr       2-2356                       #  ,=  #
+word       mehr       2356a                         #  =  #
+nocross always    mehr       2-2356a                       #  ,=  #
 nocross always    mir        134-1235                     #  MR  #
 word       mit        2345                         #  T  #
 nocross always    mit        2-2345                       #  ,T  #
@@ -306,41 +379,41 @@ always     mr.        134-1235-3                   #  MR.  #
 word       mrs        6-134-1235-234               #  'MRS  #
 always     mrs.       134-1235-234-3               #  MRS.  #
 nocross always    musik      134-13                       #  MK  #
-nocross always    muss       134-2346                     #  M^  #
-nocross begmidword möcht     1456                         #  4  #
-nocross always    mög        2-246                        #  ,9  #
-nocross always    möglich    134-456                      #  M_  #
+nocross always    muss       134-2346a                     #  M^  #
+nocross begmidword möcht     1456a                         #  4  #
+nocross always    mög        2-246a                        #  ,9  #
+nocross always    möglich    134-456a                      #  M_  #
 nocross always    müss       2-134                        #  ,M  #
 nocross always    nachdem    1345-145                     #  ND  #
 nocross always    nahm       1345-134                     #  NM  #
 nocross always    natur      1345-2345                    #  NT  #
-nocross always    natürlich  1345-456                     #  N_  #
+nocross always    natürlich  1345-456a                     #  N_  #
 nocross always    neben      1345-12                      #  NB  #
 nocross always    nehm       1345-125                     #  NH  #
 word       nicht      1345                         #  N  #
 nocross always    nicht      2-1345                       #  ,N  #
 nocross always    nichts     1345-234                     #  NS  #
 nocross midendword nis       1346                         #  X  #
-nocross always    noch       1345-1456                    #  N4  #
+nocross always    noch       1345-1456a                    #  N4  #
 nocross always    nommen     1345-1346                    #  NX  #
 nocross always    notwendig  1345-2456                    #  NW  #
 nocross always    nur        1345-1235                    #  NR  #
 nocross always    nutz       1345-1356                    #  NZ  #
-nocross always    nächst     1345-23456                   #  N]  #
+nocross always    nächst     1345-23456a                   #  N]  #
 nocross always    nähm       5-1345-134                   #  !NM  #
 nocross always    nütz       5-1345-1356                  #  !NZ  #
 word       oder       135                          #  O  #
 nocross always    ohne       135-15                       #  OE  #
-nocross begmidword or        26                           #  ?  #
-nocross always    or'        26-6                         #  ?'  #
+nocross begmidword or        26a                           #  ?  #
+nocross always    or'        26a-6                         #  ?'  #
 nocross always    paragraf   1234-1245                    #  PG  #
 nocross always    person     1234-1345                    #  PN  #
 nocross always    persön     5-1234-1345                  #  !PN  #
 nocross always    platz      1234-1356                    #  PZ  #
 nocross always    plätz      5-1234-1356                  #  !PZ  #
-nocross always    plötzlich  1234-456                     #  P_  #
+nocross always    plötzlich  1234-456a                     #  P_  #
 nocross always    politik    1234-13                      #  PK  #
-nocross always    politisch  1234-156                     #  P5  #
+nocross always    politisch  1234-156a                     #  P5  #
 begword    pro        12345                        #  Q  #
 nocross always    prou       1234-1235-135-136            #  PROU  #
 nocross always    punkt      1234-2345                    #  PT  #
@@ -351,27 +424,27 @@ nocross always    recht      1235-2345                    #  RT  #
 nocross always    regier     1235-1245                    #  RG  #
 nocross always    rehabilit  1235-12                      #  RB  #
 nocross always    republik   1235-13                      #  RK  #
-nocross always    richt      2-3456                       #  ,#  #
-nocross always    rück       1235-46                      #  R$  #
+nocross always    richt      2-3456a                       #  ,#  #
+nocross always    rück       1235-46a                      #  R$  #
 nocross always    sag        234-1245                     #  SG  #
-nocross midendword sam       2346                         #  ^  #
+nocross midendword sam       2346a                         #  ^  #
 nocross always    satz       234-1356                     #  SZ  #
-word       sch        6-156                        #  '5  #
-nocross always    sch        156                          #  5  #
-sufword    schaft     156-1-124-2345               #  5AFT  #
-nocross midendword schaft    156                          #  5  #
-nocross always    schlag     156-1245                     #  5G  #
-nocross always    schliess   156-2346                     #  5^  #
-nocross always    schließ    156-2346                     #  5^  #
-nocross always    schläg     5-156-1245                   #  !5G  #
-word       schon      156                          #  5  #
-nocross always    schreib    156-12                       #  5B  #
-nocross always    schrieb    2-156                        #  ,5  #
-nocross always    schrift    156-2345                     #  5T  #
-nocross always    schwierig  156-45                       #  5>  #
+word       sch        6-156a                        #  '5  #
+nocross always    sch        156a                          #  5  #
+sufword    schaft     156a-1-124-2345               #  5AFT  #
+nocross midendword schaft    156a                          #  5  #
+nocross always    schlag     156a-1245                     #  5G  #
+nocross always    schliess   156a-2346a                     #  5^  #
+nocross always    schließ    156a-2346a                     #  5^  #
+nocross always    schläg     5-156a-1245                   #  !5G  #
+word       schon      156a                          #  5  #
+nocross always    schreib    156a-12                       #  5B  #
+nocross always    schrieb    2-156a                        #  ,5  #
+nocross always    schrift    156a-2345                     #  5T  #
+nocross always    schwierig  156a-45a                       #  5>  #
 nocross always    sehr       234-1235                     #  SR  #
-nocross sufword   sein       246                          #  9  #
-nocross always    selbst     234-23456                    #  S]  #
+nocross sufword   sein       246a                          #  9  #
+nocross always    selbst     234-23456a                    #  S]  #
 nocross always    setz       2-15                         #  ,E  #
 word       sich       14                           #  C  #
 word       sie        234                          #  S  #
@@ -379,39 +452,39 @@ nocross always    sind       234-145                      #  SD  #
 nocross always    sitz       2-24                         #  ,I  #
 word       so         1234                         #  P  #
 nocross always    so         2-1234                       #  ,P  #
-nocross always    solch      234-1456                     #  S4  #
+nocross always    solch      234-1456a                     #  S4  #
 nocross always    soll       2-234                        #  ,S  #
 nocross always    sondern    234-1345                     #  SN  #
 nocross always    sozial     234-123                      #  SL  #
-nocross always    spiel      2-346                        #  ,0  #
-nocross always    sprech     2-2346                       #  ,^  #
+nocross always    spiel      2-346a                        #  ,0  #
+nocross always    sprech     2-2346a                       #  ,^  #
 word       ss         6-234-234                    #  'SS  #
-nocross midendword ss        2346                         #  ^  #
+nocross midendword ss        2346a                         #  ^  #
 word       st         234-2345                     #  ST  #
-nocross always    st         23456                        #  ]  #
-nocross always    staat      23456-2345                   #  ]T  #
-nocross always    stand      2-23456                      #  ,]  #
+nocross always    st         23456a                        #  ]  #
+nocross always    staat      23456a-2345                   #  ]T  #
+nocross always    stand      2-23456a                      #  ,]  #
 nocross always    stell      2-13456                      #  ,Y  #
-nocross always    stets      23456-234                    #  ]S  #
-nocross always    ständ      5-23456                      #  !]  #
+nocross always    stets      23456a-234                    #  ]S  #
+nocross always    ständ      5-23456a                      #  !]  #
 nocross always    säg        5-234-1245                   #  !SG  #
 nocross always    sätz       5-234-1356                   #  !SZ  #
-nocross midendword te        236                          #  (  #
+nocross midendword te        236a                          #  (  #
 nocross always    technik    2345-13                      #  TK  #
-nocross always    technisch  2345-156                     #  T5  #
+nocross always    technisch  2345-156a                     #  T5  #
 nocross always    trag       2345-1245                    #  TG  #
 nocross always    treff      2345-124                     #  TF  #
 nocross always    trotz      2345-1356                    #  TZ  #
 nocross always    träg       5-2345-1245                  #  !TG  #
 word       tz         6-2345-1356                  #  'TZ  #
 word       un         136-1345                     #  UN  #
-nocross always    un         256                          #  /  #
+nocross always    un         256a                          #  /  #
 word       und        136                          #  U  #
 nocross always    und        2-136                        #  ,U  #
 nocross midendword ung       136                          #  U  #
-word       unter      256                          #  /  #
-nocross always    unter      2-256                        #  ,/  #
-nocross begword   ver        36a                          #  -  #
+word       unter      256a                          #  /  #
+nocross always    unter      2-256a                        #  ,/  #
+nocross begword   ver        36b                          #  -  #
 nocross always    verhältnis 1236-125                     #  VH  #
 nocross always    viel       1236-123                     #  VL  #
 nocross always    vielleicht 1236-2345                    #  VT  #
@@ -421,42 +494,42 @@ nocross always    voll       2-12345                      #  ,Q  #
 nocross always    vom        1236-134                     #  VM  #
 word       von        1236                         #  V  #
 nocross always    von        2-1236                       #  ,V  #
-word       vor        26                           #  ?  #
-nocross always    vor        2-26                         #  ,?  #
+word       vor        26a                           #  ?  #
+nocross always    vor        2-26a                         #  ,?  #
 nocross always    völk       5-1236-13                    #  !VK  #
 nocross always    völl       5-12345                      #  !Q  #
 nocross always    wahr       2456-125                     #  WH  #
-nocross sufword   war        356                          #  )  #
+nocross sufword   war        356a                          #  )  #
 word       was        2456                         #  W  #
 nocross always    weg        2456-1245                    #  WG  #
 nocross always    weit       2456-2345                    #  WT  #
-nocross always    weis       2-146                        #  ,3  #
+nocross always    weis       2-146a                        #  ,3  #
 nocross always    welch      13456                        #  Y  #
-nocross always    wenig      2456-45                      #  W>  #
+nocross always    wenig      2456-45a                      #  W>  #
 nocross always    wenn       2456-1345                    #  WN  #
 nocross always    werd       2-2456                       #  ,W  #
-nocross always    wesentlich 2456-456                     #  W_  #
-nocross always    wiss       2456-2346                    #  W^  #
-word       wie        126                          #  2  #
-nocross always    wie        2-126                        #  ,2  #
-nocross always    wieder     346-145                      #  0D  #
+nocross always    wesentlich 2456-456a                     #  W_  #
+nocross always    wiss       2456-2346a                    #  W^  #
+word       wie        126a                          #  2  #
+nocross always    wie        2-126a                        #  ,2  #
+nocross always    wieder     346a-145                      #  0D  #
 nocross always    will       2456-12345                   #  WQ  #
 nocross always    wir        2456-1235                    #  WR  #
 nocross always    wird       2456-145                     #  WD  #
 nocross always    wirk       2456-13                      #  WK  #
-nocross always    wirst      2456-23456                   #  W]  #
-nocross always    wirtschaft 2456-156                     #  W5  #
+nocross always    wirst      2456-23456a                   #  W]  #
+nocross always    wirtschaft 2456-156a                     #  W5  #
 nocross always    wohl       2456-123                     #  WL  #
 nocross always    woll       2-135                        #  ,O  #
 nocross always    worden     135-14                       #  OC  #
 word       wurd       2456-136-1235-145            #  WURD  #
 nocross always    wurd       136                          #  U  #
 nocross always    währ       5-2456-125                   #  !WH  #
-nocross always    während    345-145                      #  @D  #
-nocross always    wär        5-356                        #  !)  #
+nocross always    während    345a-145                      #  @D  #
+nocross always    wär        5-356a                        #  !)  #
 endword    wärts      2456                         #  W  #
-word       würd       2456-1256-1235-145           #  W8RD  #
-nocross always    würd       1256                         #  8  #
+word       würd       2456-1256a-1235-145           #  W8RD  #
+nocross always    würd       1256a                         #  8  #
 always     x          6-1346                       #  'X  #
 always     X          6-1346                       #  'X  #
 always     y          6-13456                      #  'Y  #
@@ -468,20 +541,20 @@ nocross always    zu         2-1356                       #  ,Z  #
 nocross always    zum        1356-134                     #  ZM  #
 nocross always    zunächst   1356-1345                    #  ZN  #
 nocross always    zur        1356-1235                    #  ZR  #
-nocross always    zurück     1356-46                      #  Z$  #
+nocross always    zurück     1356-46a                      #  Z$  #
 nocross always    zusammen   1356-234                     #  ZS  #
 nocross always    zwischen   1356-2456                    #  ZW  #
 nocross always    zähl       5-1356-123                   #  !ZL  #
-always     ß          6-2346                       #  '^  #
-nocross always    ähnlich    345-456                      #  @_  #
-nocross always    änder      5-12456                      #  !7  #
-nocross always    äu         34                           #  \  #
-nocross always    öffentlich 246-456                      #  9_  #
-word       über       1256                         #  8  #
-nocross always    über       2-1256                       #  ,8  #
-word       überhaupt  1256-125                     #  8H  #
-nocross always    übrig      1256-45                      #  8>  #
-endword    'st        6-23456                      #  ']  #
+always     ß          6-2346a                       #  '^  #
+nocross always    ähnlich    345a-456a                      #  @_  #
+nocross always    änder      5-12456a                      #  !7  #
+nocross always    äu         34a                           #  \  #
+nocross always    öffentlich 246a-456a                      #  9_  #
+word       über       1256a                         #  8  #
+nocross always    über       2-1256a                       #  ,8  #
+word       überhaupt  1256a-125                     #  8H  #
+nocross always    übrig      1256a-45a                      #  8>  #
+endword    'st        6-23456a                      #  ']  #
 
 # Ausnahmen:
 word       'e         6-6-15                         #  ''E  #
@@ -490,45 +563,45 @@ word       'm         6-6-134                        #  ''M  #
 word       'n         6-6-1345                       #  ''N  #
 word       's         6-6-234                        #  ''S  #
 word       't         6-6-2345                       #  ''T  #
-word       'tsch      6-6-2345-156                   #  ''T5  #
+word       'tsch      6-6-2345-156a                   #  ''T5  #
 word       'u         6-6-136                        #  ''U  #
 word       ao         6-1-135                        #  'AO  #
 word       aos        6-1-135-234                    #  'AOS  #
-word       che        6-1456-15                      #  '4E  #
-word       chen       6-1456-14                      #  '4C  #
-word       chens      6-1456-14-234                  #  '4CS  #
-word       chet       6-1456-15-2345                 #  '4ET  #
-word       chets      6-1456-15-2345-234             #  '4ETS  #
-word       dau        6-145-16                       #  'D1  #
+word       che        6-1456a-15                      #  '4E  #
+word       chen       6-1456a-14                      #  '4C  #
+word       chens      6-1456a-14-234                  #  '4CS  #
+word       chet       6-1456a-15-2345                 #  '4ET  #
+word       chets      6-1456a-15-2345-234             #  '4ETS  #
+word       dau        6-145-16a                       #  'D1  #
 word       dirs       145-1235-234                   #  DRS  #
 word       dr         6-145-1235                     #  'DR  #
 always     dr.        145-1235-3                     #  DR.  #
-word       dschem     6-145-156-12356                #  'D5[  #
-word       dü         6-145-1256                    #   'D8  #
-word       gsch       6-1245-156                     #  'G5  #
+word       dschem     6-145-156a-12356a                #  'D5[  #
+word       dü         6-145-1256a                    #   'D8  #
+word       gsch       6-1245-156a                     #  'G5  #
 word       he'd       125-15-6-145                   #  HE'D  #
 word       he's       125-15-6-234                   #  HE'S  #
 word       ih         6-24-125                       #  'IH  #
 word       ihm's      24-125-134-6-234               #  IHM'S  #
-word       mal'ach    134-25-6-1-1456                #  M:'A4  #
-word       mal'n      134-25-6-1345                  #  M:'N  #
+word       mal'ach    134-25a-6-1-1456a                #  M:'A4  #
+word       mal'n      134-25a-6-1345                  #  M:'N  #
 word       mlle       6-134-12345-15                 #  'MQE  #
 word       nta        6-1345-2345-1                  #  'NTA  #
 word       nu'man     1345-136-6-134-1-1345          #  NU'MAN  #
-word       pnin       6-1234-1345-35                 #  'PN*  #
-word       psch       6-1234-156                     #  'P5  #
-word       pschscht   6-1234-156-156-2345            #  'P55T  #
-word       pscht      6-1234-156-2345                #  'P5T  #
+word       pnin       6-1234-1345-35a                 #  'PN*  #
+word       psch       6-1234-156a                     #  'P5  #
+word       pschscht   6-1234-156a-156-2345            #  'P55T  #
+word       pscht      6-1234-156a-2345                #  'P5T  #
 word       qa'im      6-12345-1-6-24-134             #  'QA'IM  #
 word       rrm        6-1235-1235-134                #  'RRM  #
 word       s'         6-234-6                        #  'S'  #
-word       sch'chinah 156-6-1456-35-1-125            #  5'4*AH  #
-word       scht       6-156-2345                     #  '5T  #
+word       sch'chinah 156a-6-1456a-35a-1-125            #  5'4*AH  #
+word       scht       6-156a-2345                     #  '5T  #
 word       sgt        6-234-1245-2345                #  'SGT  #
-word       tsch       6-2345-156                     #  'T5  #
-word       tschk      6-2345-156-13                  #  'T5K  #
-word       un'ora     256-6-135-1235-1               #  /'ORA  #
+word       tsch       6-2345-156a                     #  'T5  #
+word       tschk      6-2345-156a-13                  #  'T5K  #
+word       un'ora     256a-6-135-1235-1               #  /'ORA  #
 word       when       2456-125-14-1345                  #  'WHC  #
-word       where      6-2456-125-12456-15            #  'WH7E  #
+word       where      6-2456-125-12456a-15            #  'WH7E  #
 word       whu        6-2456-125-136                 #  'WHU  #
-word       über'aupt  2-1256-6-16-1234-2345          #  ,8'1PT  #
+word       über'aupt  2-1256a-6-16a-1234-2345          #  ,8'1PT  #

--- a/tests/braille-specs/de-g0.yaml
+++ b/tests/braille-specs/de-g0.yaml
@@ -559,18 +559,18 @@ tests:
   - -                     "(Test)"
     - "_=test="
     - typeform: { italic: "++++++" }
+      xfail: got "=_test=" (word indicator after "(")
   # When the brackets are not emphasized, the word indicator comes
   # after the opening bracket (but there is no closing indicator).
   - -                     "(Test)"
     - "=_test="
     - typeform: { italic: " ++++ " }
-      xfail: got "=test=" (the word has no emphasis marks)
   # When only the opening bracket is emphasized, the word indicator is
   # used (and no closing indicator).
   - -                     "(Test)"
     - "_=test="
     - typeform: { italic: "+++++ " }
-      xfail: got "=test=" (the word has no emphasis marks)
+      xfail: got "=_test=" (word indicator after "(")
   # When only the closing bracket is emphasized, the word indicator is
   # used after the quotation mark.
   - -                     "(Test)"
@@ -584,27 +584,27 @@ tests:
   - -                     "(Test Test)"
     - "__=test test='."
     - typeform: { italic: "+++++++++++" }
+      xfail: got "=__test test='." (start indicator after "(")
   # When the brackets are not emphasized, the opening indicator comes
   # after the opening bracket and the closing indicator comes before
   # the closing bracket.
   - -                     "(Test Test)"
     - "=__test test'.="
     - typeform: { italic: " +++++++++ " }
-      xfail: got "=_test test='" (only the first word is marked)
+      xfail: got "=__test test='." (end indicator after ")")
   # When only the opening bracket is emphasized, the opening indicator
   # comes before the opening bracket and the closing indicator comes
   # before the closing bracket.
   - -                     "(Test Test)"
     - "__=test test'.="
     - typeform: { italic: "++++++++++ " }
-      xfail: got "=_test test='" (only the first word is marked)
+      xfail: got "=__test test='." (start indicator after "(" and end indicator after ")")
   # When only the closing bracket is emphasized, the opening indicator
   # comes after the opening bracket and the closing indicator comes
   # after the closing bracket.
   - -                     "(Test Test)"
     - "=__test test='."
     - typeform: { italic: " ++++++++++" }
-      xfail: got "=_test _test=" (the words are marked individually)
 
   # Three Words
 
@@ -613,13 +613,14 @@ tests:
   - -                     "(Test Test Test)"
     - "__=test test test='."
     - typeform: { italic: "++++++++++++++++" }
+      xfail: got "=__test test test='." (start indicator after "(")
   # When the brackets are not emphasized, the opening indicator comes
   # after the opening bracket and the closing indicator comes before
   # the closing bracket.
   - -                     "(Test Test Test)"
     - "=__test test test'.="
     - typeform: { italic: " ++++++++++++++ " }
-      xfail: got "=_test _test test=" (the words are marked individually and the last word is not marked at all)
+      xfail: got "=__test test test='." (start indicator after "(" and end indicator after ")")
 
   # Emphasised letters within words
   # -------------------------------
@@ -657,7 +658,6 @@ tests:
   - -                     "Test."
     - "te'_st."
     - typeform: { italic: "  ++ " }
-      xfail: got "test." (no emphasis marks)
 
 # Quotation marks
 

--- a/tests/braille-specs/de-g0.yaml
+++ b/tests/braille-specs/de-g0.yaml
@@ -631,11 +631,9 @@ tests:
   - -                     "Test"
     - "te'_s'.t"
     - typeform: { italic: "  + " }
-      xfail: got "test" (no emphasis marks)
   - -                     "Test"
     - "t'_es'.t"
     - typeform: { italic: " ++ " }
-      xfail: got "test" (no emphasis marks)
   # When the first letters of a word are emphasized, a word indicator
   # comes before the letters and a closing indicator after the
   # letters. Only the closing indicator needs a letsign.
@@ -650,11 +648,9 @@ tests:
   - -                     "Test"
     - "tes'_t"
     - typeform: { italic: "   +" }
-      xfail: got "tes_t" (missing letsign)
   - -                     "Test"
     - "te'_st"
     - typeform: { italic: "  ++" }
-      xfail: got "te_st" (missing letsign)
   # When the last letters of a word are emphasized but the full stop
   # that follows is not, a word indicator comes before the letters,
   # and there is no closing indicator.

--- a/tests/braille-specs/de-g1.yaml
+++ b/tests/braille-specs/de-g1.yaml
@@ -499,7 +499,6 @@ tests:
   - -                     "Test."
     - "_te}."
     - typeform: { italic: "++++ " }
-      xfail: got "test." (the word has no emphasis mark and it is not contracted)
 
   # Two words
 
@@ -508,11 +507,11 @@ tests:
   - -                     "Test Test."
     - "__te} te}.'."
     - typeform: { italic: "++++++++++" }
+      xfail: got "__te} te}'.." (end indicator before ".")
   # When the full stop is not emphasized, the result is:
   - -                     "Test Test."
     - "__te} te}'.."
     - typeform: { italic: "+++++++++ " }
-      xfail: got "_te} test." (the second word is not marked and not contracted)
 
   # Three words
 
@@ -521,11 +520,11 @@ tests:
   - -                     "Test Test Test."
     - "__te} te} te}.'."
     - typeform: { italic: "+++++++++++++++" }
+      xfail: got "__te} te} te}'.." (end indicator before ".")
   # When the full stop is not emphasized, the result is:
   - -                     "Test Test Test."
     - "__te} te} te}'.."
     - typeform: { italic: "++++++++++++++ " }
-      xfail: got "__te} te}'. test." (the last word is not marked and not contracted)
 
   # Quotation marks / brackets included in emphasis or not
   # ------------------------------------------------------
@@ -537,30 +536,30 @@ tests:
   - -                     "«Test»"
     - "_(te})"
     - typeform: { italic: "++++++" }
+      xfail: got "(_te})" (word indicator after "«")
   - -                     "(Test)"
     - "_=te}="
     - typeform: { italic: "++++++" }
+      xfail: got "=_te}=" (word indicator after "(")
   # When the quotation marks are not emphasized, the word indicator
   # comes after the quotation mark (but there is no closing
   # indicator).
   - -                     "«Test»"
     - "(_te})"
     - typeform: { italic: " ++++ " }
-      xfail: got "(test)" (the word has no emphasis marks and is not contracted)
   - -                     "(Test)"
     - "=_te}="
     - typeform: { italic: " ++++ " }
-      xfail: got "=test=" (the word has no emphasis marks and is not contracted)
   # When only the opening quotation mark is emphasized, the word
   # indicator is used (and no closing indicator).
   - -                     "«Test»"
     - "_(te})"
     - typeform: { italic: "+++++ " }
-      xfail: got "(test)" (the word has no emphasis marks and is not contracted)
+      xfail: got "(_te})" (word indicator after "«")
   - -                     "(Test)"
     - "_=te}="
     - typeform: { italic: "+++++ " }
-      xfail: got "=test=" (the word has no emphasis marks and is not contracted)
+      xfail: got "=_te}=" (word indicator after "(")
   # When only the closing quotation mark is emphasized, the word
   # indicator is used after the quotation mark.
   - -                     "«Test»"
@@ -577,42 +576,42 @@ tests:
   - -                     "«Test Test»"
     - "__(te} te})'."
     - typeform: { italic: "+++++++++++" }
+      xfail: got "(__te} te}'.)" (start indicator after "«" and end indicator before "»")
   - -                     "(Test Test)"
     - "__=te} te}='."
     - typeform: { italic: "+++++++++++" }
+      xfail: got "=__te} te}='." (start indicator after "(")
   # When the quotation marks are not emphasized, the opening indicator
   # comes after the quotation mark and the closing indicator comes
   # before the quotation mark.
   - -                     "«Test Test»"
     - "(__te} te}'.)"
     - typeform: { italic: " +++++++++ " }
-      xfail: got "(_te} test)" (only the first word is marked and the second word is not contracted)
   - -                     "(Test Test)"
     - "=__te} te}'.="
     - typeform: { italic: " +++++++++ " }
-      xfail: got "=_te} test=" (only the first word is marked and the second word is not contracted)
+      xfail: got "=__te} te}='." (end indicator after ")")
   # When only the opening quotation mark is emphasized, the opening
   # indicator comes before the quotation mark and the closing
   # indicator comes before the quotation mark.
   - -                     "«Test Test»"
     - "__(te} te}'.)"
     - typeform: { italic: "++++++++++ " }
-      xfail: got "_(te} test)" (only the first word is marked and the second word is not contracted)
+      xfail: got "(__te} te}'.)" (start indicator after "«")
   - -                     "(Test Test)"
     - "__=te} te}'.="
     - typeform: { italic: "++++++++++ " }
-      xfail: got "_=te} test=" (only the first word is marked and the second word is not contracted)
+      xfail: got "=__te} te}='." (start indicator after "(" and end indicator after ")")
   # When only the closing quotation mark is emphasized, the opening
   # indicator comes after the quotation mark and the closing indicator
   # comes after the quotation mark.
   - -                     "«Test Test»"
     - "(__te} te})'."
     - typeform: { italic: " ++++++++++" }
-      xfail: got "(_te} _te})" (the words are marked individually)
+      xfail: got "(__te} te}'.)" (end indicator after "»")
   - -                     "(Test Test)"
     - "=__te} te}='."
     - typeform: { italic: " ++++++++++" }
-      xfail: got "=_te} _te}=" (the words are marked individually)
 
   # Three words
 
@@ -621,20 +620,21 @@ tests:
   - -                     "«Test Test Test»"
     - "__(te} te} te})'."
     - typeform: { italic: "++++++++++++++++" }
+      xfail: got "(__te} te} te}'.)" (start indicator after "«" and end indicator before "»")
   - -                     "(Test Test Test)"
     - "__=te} te} te}='."
     - typeform: { italic: "++++++++++++++++" }
+      xfail: got "=__te} te} te}='." (start indicator after "(")
   # When the quotation marks are not emphasized, the opening indicator
   # comes after the quotation mark and the closing indicator comes
   # before the quotation mark.
   - -                     "«Test Test Test»"
     - "(__te} te} te}'.)"
     - typeform: { italic: " ++++++++++++++ " }
-      xfail: got "(_te} _te} test)" (the words are marked individually and the last word is not marked at all and not contracted)
   - -                     "(Test Test Test)"
     - "=__te} te} te}'.="
     - typeform: { italic: " ++++++++++++++ " }
-      xfail: got "=_te} _te} test=" (the words are marked individually and the last word is not marked at all and not contracted)
+      xfail: got "=__te} te} te}='." (end indicator after ")")
 
 # Quotation marks
 

--- a/tests/braille-specs/de-g2-sbs.yaml
+++ b/tests/braille-specs/de-g2-sbs.yaml
@@ -37,11 +37,9 @@ tests:
   - -                     "experimentalprotektorverhalten"
     - "xp7imct:'_pro(kt?'.v7h:tc"
     - typeform: { italic: "            +++++++++         " }
-      xfail: true
   - -                     "experimentalprotektorverhalten"
     - "xp7imct:pro(kt?'_v7h:tc"
     - typeform: { italic: "                     +++++++++" }
-      xfail: true
 
   # Falsches Resultat bei Wortersatzstrich -xxx, wenn direkt nach Tag
   - - "-losenheim"
@@ -134,13 +132,11 @@ tests:
   - -                     "Liebegang"
     - "l0;'_g+g"
     - typeform: { italic: "     ++++"}
-      xfail: "' missing in front of emphasis indicator"
 
   # Single word mixed emphasis em inside
   - -                     "LiebeMenschenversuch"
     - "l0;'_mc5c'.v7su4"
     - typeform: { italic: "     ++++++++       "}
-      xfail: Capitalized emphasis is neither indicated nor contracted
   # Falsches Resultat bei gemischtem Bruch, wenn Zeilenumbruch vorkommt
   - - "4\n1/2"
     - "#d#a;"
@@ -387,22 +383,18 @@ tests:
   - -                     "blakursiv"
     - "bla'_kursiv"
     - typeform: { italic: "   ++++++"}
-      xfail: "' missing in front of emphasis indicator"
   - -                     "blakursivblo"
     - "bla'_kursiv'.blo"
     - typeform: { italic: "   ++++++   "}
-      xfail: "' missing in front of emphasis indicator"
   - -                     "kursiv...blo"
     - "_kursiv'....blo"
     - typeform: { italic: "++++++      "}
   - -                     "bla...kursiv"
     - "bla...'_kursiv"
     - typeform: { italic: "      ++++++"}
-      xfail: "' missing in front of emphasis indicator"
   - -                     "bla...kursiv...blo"
     - "bla...'_kursiv'....blo"
     - typeform: { italic: "      ++++++      "}
-      xfail: "' missing in front of emphasis indicator"
 
   # Punctuation tests
   # Punctuation after numbers

--- a/tests/braille-specs/de-g2-sbs.yaml
+++ b/tests/braille-specs/de-g2-sbs.yaml
@@ -68,7 +68,7 @@ tests:
   - -                     "Mist, dachte er, wie komme ich hier raus?"
     - "_mi}, d<( 7, __2 kxe # hr r1s?'."
     - typeform: { italic: "++++             ++++++++++++++++++++++++" }
-      xfail: Capitalized emphasis is neither indicated nor contracted
+      xfail: got "_mi}, d<( 7, __2 kxe # hr r1s'.?" (end indicator before "?")
   - -                     "ABCs"
     - ">abc's"
     - typeform: { abbrev: "+++ " }
@@ -122,7 +122,6 @@ tests:
   - -                     "»Test«"
     - "(_te})"
     - typeform: { italic: " ++++ "}
-      xfail: Capitalized emphasis is neither indicated nor contracted
   # Single word mixed emphasis em before
   - -                     "Menschenversuch"
     - "_mc5c'.v7su4"
@@ -166,13 +165,13 @@ tests:
     - "_i4, _i4; _i4: _i4? _i4+ =_i4= (_i4)."
     - typeform: { italic: "+++       +++  +++        +++   +++  ",
                   bold:   "     +++            +++              "}
-      xfail: apparently ich should be contracted to i4, don't know why
+      xfail: '"ich: ich?" seen as one emphasised phrase (and last "ich" translated to "#")'
   # Emphasis: Wortgrenzenerkennung bei "-" und "/"
   - -                     "Wort, Wort, Wort. Zwei Wörter, eins/zwei, eins-­zwei."
     - "_w?t, _w?t, _w?t. __zw3 w9rt7'., __6s!,zw3'., __6s-mzw3'.."
     - typeform: { italic: "++++        ++++  +++++++++++             ++++++++++ ",
                   bold:   "      ++++                     +++++++++             "}
-      xfail: apparently before puntuation no '. is needed at least for single word emphasis
+      xfail: '"Wort. Zwei Wörter" is seen as one emphasized phrase'
   # line break before ndash
   - - "word\n– word"
     - "w?d'- w?d"
@@ -279,21 +278,18 @@ tests:
   - -                     "ich, "
     - "_i4, "
     - typeform: { italic: "+++  "}
-      xfail: inside em and followed by space the ich specific rules e.g. 'word ich, 24-1456-2' from de-g2-core.cti don't seem to work
   # "ich" inside em
   - -                     "ich) "
     - "_i4= "
     - typeform: { italic: "+++  "}
-      xfail: inside em and followed by space the ich specific rules e.g. 'word ich, 24-1456-2' from de-g2-core.cti don't seem to work
   # "ich" inside em
   - -                     "(ich) "
     - "_=i4= "
     - typeform: { italic: "++++  "}
-      xfail: inside em and followed by space the ich specific rules e.g. 'word ich, 24-1456-2' from de-g2-core.cti don't seem to work
+      xfail: got "=_i4=" (word indicator after "(")
   - -                     "mich) "
     - "_m#= "
     - typeform: { italic: "++++  "}
-      xfail: there is an extra '. after # which shouldn't be there
 
   # "ich" inside em
   - -                     "ich"
@@ -335,23 +331,18 @@ tests:
   - - "ICH."
     - "_#."
     - typeform: { italic: "+++ "}
-      xfail: there is an extra '. after # which shouldn't be there
   - -                     "ICH,"
     - "_i4,"
     - typeform: { italic: "+++ "}
-      xfail: inside em and allcaps the ich specific rules from de-g2-core.cti don't seem to work
   - -                     "ICH;"
     - "_i4;"
     - typeform: { italic: "+++ "}
-      xfail: inside em and allcaps the ich specific rules from de-g2-core.cti don't seem to work
   - -                     "ICH!"
     - "_i4+"
     - typeform: { italic: "+++ "}
-      xfail: inside em and allcaps the ich specific rules from de-g2-core.cti don't seem to work
   - - "ICH?"
     - "_i4?"
     - typeform: { italic: "+++ "}
-      xfail: inside em and allcaps the ich specific rules from de-g2-core.cti don't seem to work
   # Capitalized "ich"
   - ["Ich", "#"]
   - ["Ich.", "#."]
@@ -401,7 +392,7 @@ tests:
   - -                     " 2? 2! 2; (2) »2« "
     - " _#b'? _#b'+ _#b'; =_#b'= (_#b') "
     - typeform: { italic: " +  +  +   +   +  "}
-      xfail: there are extra '. after the numbers which shouldn't be there
+      xfail: whole string seen as one emphasised phrase ("__" before first "2" and ".'" after last "2")
 
   - ["»Am 10?«", "(am #aj'?)"]
 

--- a/tests/braille-specs/de-g2-sbs.yaml
+++ b/tests/braille-specs/de-g2-sbs.yaml
@@ -859,8 +859,15 @@ tests:
     - " '-steigen"
     - xfail: fix not yet upstream
   # test for <em> starting or ending with dash
+
+  # This test case is splitting hair. It is not handled in the
+  # Systematik. You need a ' in front of - at the beginning of the
+  # word, otherwise it reads as "ver". You also need a ' in front of _
+  # in the middle of a word otherwise it reads as "lich". So to be on
+  # the safe side there should be a ' in front of the - and the _, but
+  # the second ' would be redundant.
   - -                     "auffallen und -steigen "
-    - "auf'_fallen und '-_steigen "
+    - "auf'_fallen und '-_steigen " # or to be on the safe side: "auf'_fallen und '-'_steigen"
     - typeform: { italic: "   ++++++     ++++++++ "}
       xfail: "' missing in front of emphasis indicator"
   - -                     "hin- und hergehen "

--- a/tests/braille-specs/de-g2.yaml
+++ b/tests/braille-specs/de-g2.yaml
@@ -491,14 +491,14 @@ tests:
   - -                     "(Test)"
     - "_=te}="
     - typeform: { italic: "++++++" }
+      xfail: got "=_te}=" (word indicator after "(")
   - -                     "(Test)"
     - "=_te}="
     - typeform: { italic: " ++++ " }
-      xfail: got "=test=" (the word has no emphasis marks and is not contracted)
   - -                     "(Test)"
     - "_=te}="
     - typeform: { italic: "+++++ " }
-      xfail: got "=test=" (the word has no emphasis marks and is not contracted)
+      xfail: got "=_te}=" (word indicator after "(")
   - -                     "(Test)"
     - "=_te}="
     - typeform: { italic: " +++++" }
@@ -508,28 +508,29 @@ tests:
   - -                     "(Test Test)"
     - "__=te} te}='."
     - typeform: { italic: "+++++++++++" }
+      xfail: got "=__te} te}='." (start indicator after "(")
   - -                     "(Test Test)"
     - "=__te} te}'.="
     - typeform: { italic: " +++++++++ " }
-      xfail: got "=_te} test=" (only the first word is marked and the second word is not contracted)
+      xfail: got "=__te} te}='." (end indicator after ")")
   - -                     "(Test Test)"
     - "__=te} te}'.="
     - typeform: { italic: "++++++++++ " }
-      xfail: got "_=te} test=" (only the first word is marked and the second word is not contracted)
+      xfail: got "=__te} te}='." (start indicator after "(" and end indicator after ")")
   - -                     "(Test Test)"
     - "=__te} te}='."
     - typeform: { italic: " ++++++++++" }
-      xfail: got "=_te} _te}=" (the words are marked individually)
 
   # Three Words
 
   - -                     "(Test Test Test)"
     - "__=te} te} te}='."
     - typeform: { italic: "++++++++++++++++" }
+      xfail: got "=__te} te} te}='." (start indicator after "(")
   - -                     "(Test Test Test)"
     - "=__te} te} te}'.="
     - typeform: { italic: " ++++++++++++++ " }
-      xfail: got "=_te} _te} test=" (the words are marked individually and the last word is not marked at all and not contracted)
+      xfail: got "=__te} te} te}='." (end indicator after ")")
 
 # Quotation marks
 


### PR DESCRIPTION
@egli I've started to work on the emphasis issues.

The first issues I'm looking at it the missing dot 6 before the begword marker when it happens inside a word. A lot of failing tests seem to be because of this. My solution involves checking the character before dots 456 (in pass2) and adding dot 6 if it is a letter or a contraction. In order to be able to know whether a dot pattern is a contraction I needed to add a virtual dot. For now I decided to not drop this virtual dot in a later pass and include it in the output. I think this could be useful. The calling application might want to do something special with this extra information. For example, dots 26a will represent the "or" contraction while dots 26 will represent the question mark. The calling application might have a braille preview or editor that shows 26a as "or" (with some special font) and 26 as "?".

Before I continue down this path I'd like to know your thoughts.