### PR TITLE
Ci cleanup

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -3,6 +3,9 @@ name: Check format
 on:
   push:
     branches: [ master ]
+    paths:
+      - '**.h'
+      - '**.c'
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/check-table-license.yml
+++ b/.github/workflows/check-table-license.yml
@@ -3,6 +3,9 @@ name: Check the license of the tables
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'tables/*'
+
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/macro.yml
+++ b/.github/workflows/macro.yml
@@ -3,6 +3,9 @@ name: Test macro feature
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - README
+      - NEWS
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: Make check/distcheck
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - README
+      - NEWS
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,50 +11,31 @@ on:
 
 jobs:
   build:
-    name: Build with UCS2
-
+    name: Build with ${{ matrix.ucs }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ucs: [ucs2, ucs4]
 
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get update -qq && sudo apt-get install -y libyaml-dev texinfo texlive
-    - name: Autogen && configure
-      run: |
-        ./autogen.sh
-        ./configure
+    - name: Autogen
+      run: ./autogen.sh
+    - name: Configure
+      run: ./configure
+      if: matrix.ucs == 'ucs2'
+    - name: Configure with ucs4
+      run: ./configure --enable-ucs4
+      if: matrix.ucs == 'ucs4'
     - name: Make check
       run: make check
     - name: Store the test suite log
       if: ${{ always() }} # store the test suite log even if the tests failed
       uses: actions/upload-artifact@v2
       with:
-        name: test-suite-ucs2.log
+        name: test-suite-${{ matrix.ucs }}.log
         path: tests/test-suite.log
     - name: Make distcheck
       run: make distcheck
-
-  build-ucs4:
-    name: Build with UCS4
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: sudo apt-get update -qq && sudo apt-get install -y libyaml-dev texinfo texlive
-    - name: autogen && configure
-      run: |
-        ./autogen.sh
-        ./configure --enable-ucs4
-    - name: Make check
-      run: make check
-    - name: Store the test suite log
-      if: ${{ always() }} # store the test suite log even if the tests failed
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-suite-ucs4.log
-        path: tests/test-suite.log
-    - name: Make distcheck
-      run: make distcheck
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,13 +54,4 @@ jobs:
         path: tests/test-suite.log
     - name: Make distcheck
       run: make distcheck
-    - name: Install Go
-      run: sudo apt-get install -y golang
-    - name: Run the metadata test
-      run: make -C extra/generate-display-names
-    - name: Store the log
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: generate-display-names.log
-        path: extra/generate-display-names/generate.log
+

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,0 +1,32 @@
+name: Run the metadata test
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'tables/*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  metadata-test:
+    name: Build and check the metadta
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y libyaml-dev texinfo texlive golang
+    - name: autogen && configure
+      run: |
+        ./autogen.sh
+        ./configure --enable-ucs4
+    - name: Run the metadata test
+      run: make -C extra/generate-display-names
+    - name: Store the log
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: generate-display-names.log
+        path: extra/generate-display-names/generate.log

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -3,6 +3,9 @@ name: Cross-compile with mingw
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - README
+      - NEWS
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -3,6 +3,10 @@ name: Run sanitizer checks
 on:
   push:
     branches: [ master ]
+    paths:
+      - '**.h'
+      - '**.c'
+
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
- Use a build matrix for the main workflow to build for both ucs2 and ucs4
- move the metadata tests to a separate workflow
- trigger some workflows only if needed
  - sanitizer and format check only if C code has changed
  - table license check only if tables have changed
  - ignore changes to README and NEWS