### PR TITLE
Amend + symbol in en-gb-comp8.ctb

### DIFF
--- a/tables/en-gb-comp8.ctb
+++ b/tables/en-gb-comp8.ctb
@@ -62,7 +62,7 @@ math < 236
 math = 2356
 math > 356
 sign % 46
-math + 236
+math + 235
 math ~ 14567
 sign ` 3457
 sign £ 467

--- a/tables/en-gb-comp8.ctb
+++ b/tables/en-gb-comp8.ctb
@@ -18,10 +18,9 @@
 # author yet. It is merely an attempt by the liblouis maintainers
 # to get some sensible initial values in place.
 #
-# TODO: Please add a reference to official documentation about
-# the implemented braille code. Preferably submit the documents
-# to https://github.com/liblouis/braille-specs.
-# -----------
+# This table implements the specifications for Braille Computer
+# Notation from the UK Association for Accessible Formats, see
+# https://www.ukaaf.org/wp-content/uploads/2020/03/Braille-Computer-Notation-PDF.pdf
 #
 #  Copyright (C) 2013 David Reynolds <dkreynolds@ntlworld.com>
 #


### PR DESCRIPTION
Both + and < symbols have 236 in the same table, which is wrong. The correct for '+' is 235 which is confirmed by this document from UK Association for Accessible Formats in page 24: https://www.ukaaf.org/wp-content/uploads/2020/03/Braille-Computer-Notation-PDF.pdf

As notified by @glenbuck1 on https://github.com/liblouis/liblouis/issues/1087
