### PR TITLE
Adding fuzzer for lou_translateString and lou_backTranslateString

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,75 @@
+name: Fuzz lou_translateString
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+
+jobs:
+  build:
+    name: Build with ${{ matrix.ucs }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ucs: [ucs2]
+        # ucs4
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get update -qq && sudo apt-get install -y libyaml-dev texinfo texlive clang llvm
+    - name: Autogen
+      run: ./autogen.sh
+    - name: Configure
+      run: CC=clang CXX=clang++
+           CFLAGS="-fsanitize=address,undefined -fstack-protector-strong -g -Og -fno-omit-frame-pointer"
+           CXXFLAGS="-fsanitize=address,undefined -fstack-protector-strong -g -Og -fno-omit-frame-pointer"
+           LDFLAGS="-fsanitize=address,undefined -lubsan"
+           ./configure --with-fuzzer
+      if: matrix.ucs == 'ucs2'
+    - name: Configure with ucs4
+      run: CC=clang CXX=clang++
+           CFLAGS="-fsanitize=address,undefined -fstack-protector-strong -g -Og -fno-omit-frame-pointer"
+           CXXFLAGS="-fsanitize=address,undefined -fstack-protector-strong -g -Og -fno-omit-frame-pointer"
+           LDFLAGS="-fsanitize=address,undefined -lubsan"
+           ./configure --with-fuzzer --enable-ucs4
+      if: matrix.ucs == 'ucs4'
+    - name: Compile project
+      run: make -j
+    - uses: actions/cache@v3
+      with:
+        path: /home/runner/work/liblouis/liblouis
+        key: build-${{ matrix.ucs }}-${{ github.sha }}
+
+  run:
+    name: Run with ${{ matrix.ucs }} for ${{ matrix.table }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ucs: [ucs2]
+        # ucs4
+        table: [ afr-za-g1.ctb, afr-za-g2.ctb, ar-ar-comp8.utb, ar-ar-g1.utb, ar-ar-g2.ctb, as-in-g1.utb, aw-in-g1.utb, ba.utb, be-in-g1.utb, bel.utb, bel-comp.utb, bg.ctb, bg.utb, bh.ctb, bo.ctb, boxes.ctb, br-in-g1.utb, ca-g1.ctb, chr-us-g1.ctb, ckb-g1.ctb, cop-eg-comp8.utb, cs-comp8.utb, cs-g1.ctb, cy-cy-g1.utb, cy-cy-g2.ctb, da-dk-g08.ctb, da-dk-g16.ctb, da-dk-g16-lit.ctb, da-dk-g18.ctb, da-dk-g26.ctb, da-dk-g26l.ctb, da-dk-g26-lit.ctb, da-dk-g26l-lit.ctb, da-dk-g28.ctb, da-dk-g28l.ctb, de-chess.ctb, de-comp6.utb, de-de-comp8.ctb, de-g0.utb, de-g0-detailed.utb, de-g1.ctb, de-g1-detailed.ctb, de-g2.ctb, de-g2-detailed.ctb, dra.ctb, el.ctb, en_CA.ctb, en-chess.ctb, en-gb-comp8.ctb, en-gb-g1.utb, en-GB-g2.ctb, en-in-g1.ctb, en-nabcc.utb, en-ueb-g1.ctb, en-ueb-g2.ctb, en-ueb-math.ctb, en-us-comp6.ctb, en-us-comp8.ctb, en-us-comp8-ext.utb, en-us-g1.ctb, en-us-g2.ctb, en-us-interline.ctb, en-us-mathtext.ctb, eo-g1.ctb, eo-g1-x-system.ctb, Es-Es-G0.utb, es-g1.ctb, es-g2.ctb, et.ctb, et-g0.utb, ethio-g1.ctb, fa-ir-comp8.ctb, fa-ir-g1.utb, fi-fi-8dot.ctb, fi.utb, fr-bfu-comp6.utb, fr-bfu-comp8.utb, fr-bfu-g2.ctb, ga-g1.utb, ga-g2.ctb, gd.ctb, gon.ctb, grc-international-en.utb, gu-in-g1.utb, haw-us-g1.ctb, he-IL.utb, he-IL-comp8.utb, hi-in-g1.utb, hr-comp8.utb, hr-g1.ctb, hu-hu-comp8.ctb, hu-hu-g1.ctb, hu-hu-g2.ctb, hy.ctb, IPA.utb, is.ctb, it-it-comp6.utb, it-it-comp8.utb, iu-ca-g1.ctb, ja-kantenji.utb, ka-in-g1.utb, kh-in-g1.utb, kk.utb, km-g1.utb, ko-2006-g1.ctb, ko-2006-g2.ctb, ko-g1.ctb, ko-g2.ctb, kok.ctb, kru.ctb, ks-in-g1.utb, lg-ug-g1.utb, lt-6dot.utb, lt.ctb, Lv-Lv-g1.utb, mao-nz-g1.ctb, ml-in-g1.utb, mn-in-g1.utb, mn-MN-g1.utb, mn-MN-g2.ctb, mr-in-g1.utb, ms-my-g2.ctb, mt.ctb, mun.ctb, mwr.ctb, my-g1.utb, my-g2.ctb, ne.ctb, nl-comp8.utb, nl-NL-g0.utb, no-no-8dot-fallback-6dot-g0.utb, no-no-8dot.utb, no-no-comp8.ctb, no-no-g0.utb, no-no-g1.ctb, no-no-g2.ctb, no-no-g3.ctb, no-no-generic.ctb, np-in-g1.utb, nso-za-g1.utb, nso-za-g2.ctb, or-in-g1.utb, pi.ctb, pl-pl-comp8.ctb, Pl-Pl-g1.utb, pt-pt-comp8.ctb, pt-pt-g1.utb, pt-pt-g2.ctb, pu-in-g1.utb, ro.ctb, ru-compbrl.ctb, ru.ctb, ru-litbrl.ctb, ru-litbrl-detailed.utb, ru-ru-g1.ctb, rw-rw-g1.utb, sa-in-g1.utb, sah.utb, se-se.ctb, si-in-g1.utb, sin.utb, sk-g1.ctb, sk-sk-g1.utb, sk-sk.utb, sl-si-comp8.ctb, sl-si-g1.utb, sot-za-g1.ctb, sot-za-g2.ctb, sr-g1.ctb, sv-1989.ctb, sv-1996.ctb, sv-g0.utb, sv-g1.ctb, sv-g2.ctb, ta.ctb, ta-ta-g1.ctb, te-in-g1.utb, tr.ctb, tr-g1.ctb, tr-g2.ctb, tsn-za-g1.ctb, tsn-za-g2.ctb, tt.utb, uk.utb, uk-comp.utb, unicode-braille.utb, ur-pk-g1.utb, ur-pk-g2.ctb, uz-g1.utb, ve-za-g1.utb, ve-za-g2.ctb, vi.ctb, vi-saigon-g1.ctb, vi-vn-g0.utb, vi-vn-g1.ctb, vi-vn-g2.ctb, xh-za-g1.utb, xh-za-g2.ctb, zh-chn.ctb, zhcn-cbs.ctb, zhcn-g1.ctb, zhcn-g2.ctb, zh-hk.ctb, zh-tw.ctb, zu-za-g1.utb, zu-za-g2.ctb, ]
+
+    steps:
+    - uses: actions/cache@v3
+      with:
+        path: /home/runner/work/liblouis/liblouis
+        key: build-${{ matrix.ucs }}-${{ github.sha }}
+    - name: Fuzz function lou_translateString()
+      run: mkdir tests/fuzzing/CORPUS ; FUZZ_TABLE=tables/${{ matrix.table }} tests/fuzzing/fuzz_translate -seed=1234 -runs=100000 -max_len=10000 tests/fuzzing/CORPUS
+    - name: Store the crash POC
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: crash-${{ matrix.ucs }}-${{ matrix.table }}.1
+        path: crash-* timeout-*
+    - name: Fuzz function lou_translateString() with language-specific input
+      run: cp tables/${{ matrix.table }} tests/fuzzing/CORPUS/ ; FUZZ_TABLE=tables/${{ matrix.table }} tests/fuzzing/fuzz_translate -seed=1234 -runs=100000 -max_len=10000 tests/fuzzing/CORPUS
+    - name: Store the crash POC
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: crash-${{ matrix.ucs }}-${{ matrix.table }}.2
+        path: crash-* timeout-*

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,18 @@ TAGS
 /tests/braille-specs/*.log
 /tests/braille-specs/*.trs
 
+# /tests/fuzzing/
+/tests/fuzzing/.deps
+/tests/fuzzing/.dirstamp
+/tests/fuzzing/.libs
+/tests/fuzzing/*.profdata
+/tests/fuzzing/*.profraw
+/tests/fuzzing/CORPUS/*
+/tests/fuzzing/crash-*
+/tests/fuzzing/fuzz-*.log
+/tests/fuzzing/leak-*
+/tests/fuzzing/oom-*
+
 # /tests/yaml/
 /tests/yaml/Makefile
 /tests/yaml/Makefile.in

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,16 @@ AC_ARG_WITH([yaml],
   [with_yaml=$withval],
   [])
 
+# Check if the user wants to enable coverage
+AC_ARG_WITH([coverage],
+    [AS_HELP_STRING([--with-coverage], [enable clang coverage in the fuzzer tests (also add coverage to lib sources) @<:@default=no@:>@])],
+    [])
+
+# Check if the user wants to compile fuzzer
+AC_ARG_WITH([fuzzer],
+    [AS_HELP_STRING([--with-fuzzer], [enable fuzzer for function lou_translateString @<:@default=no@:>@])],
+    [])
+
 # Checks for libraries.
 if test "x$with_yaml" == xno; then
   AC_DEFINE([WITHOUT_YAML],[1],[Disable YAML tests])
@@ -49,6 +59,14 @@ if test x$ac_cv_lib_yaml_yaml_parser_initialize != xyes; then
   *) AC_MSG_WARN([libyaml was not found. YAML tests will be skipped]);;
   esac
 fi
+
+# Check for coverage 
+AM_CONDITIONAL(USE_COVERAGE, [test x"$with_coverage" = xyes])
+
+# Check for fuzzer 
+AC_MSG_CHECKING([whether to enable fuzzer])
+AS_IF([test "x$with_fuzzer" = "xyes" && test "$CC" = "clang" && test "$CXX" = "clang++"], AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+AM_CONDITIONAL(USE_FUZZER, [test "x$with_fuzzer" = "xyes" && test "$CC" = "clang" && test "$CXX" = "clang++"])
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/liblouis/Makefile.am
+++ b/liblouis/Makefile.am
@@ -14,6 +14,10 @@ AM_CPPFLAGS = 						\
 	-I$(top_srcdir)/gnulib				\
 	-I$(top_builddir)/gnulib
 
+if USE_COVERAGE
+AM_CPPFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+
 liblouis_la_LIBADD = $(top_builddir)/gnulib/libgnu.la
 
 liblouis_la_LDFLAGS =	\

--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -406,6 +406,13 @@ table_files = \
 	zu-za-g1.utb \
 	zu-za-g2.ctb
 
+comma=,
+fuzzing_yml = $(top_srcdir)/.github/workflows/fuzzing.yml
+$(fuzzing_yml): $(srcdir)/Makefile.am
+	[ ! -w $(fuzzing_yml) ] || sed -i -e "s/table: .*/table: [ $(patsubst %,%$(comma),$(filter %.utb %.ctb,$(table_files))) ]/" $(fuzzing_yml)
+
+all-local: $(fuzzing_yml)
+
 tablesdir = $(datadir)/liblouis/tables
 tables_DATA = $(table_files)
 EXTRA_DIST = $(table_files)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,6 +7,10 @@ AM_CPPFLAGS =					\
 	-I$(top_builddir)/gnulib		\
 	-I$(top_builddir)/tools
 
+if USE_COVERAGE
+AM_CPPFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+
 LDADD =							\
 	$(top_builddir)/liblouis/liblouis.la		\
 	$(top_builddir)/gnulib/libgnu.la		\
@@ -303,3 +307,14 @@ AM_TESTS_ENVIRONMENT =								\
 	WINEPATH=$(top_builddir)/tools						\
 	WINE=$(WINE)								\
 	EXEEXT=$(EXEEXT)
+
+if USE_FUZZER
+fuzzing_fuzz_translate_SOURCES = fuzzing/fuzz_translate.c
+fuzzing_fuzz_translate_LDADD = $(top_builddir)/liblouis/liblouis.la
+fuzzing_fuzz_translate_CFLAGS = \
+	-fsanitize=address,fuzzer,undefined \
+	-fno-omit-frame-pointer \
+	$(AM_CPPFLAGS) 
+	-g -O2
+noinst_PROGRAMS = fuzzing/fuzz_translate
+endif

--- a/tests/fuzzing/README.md
+++ b/tests/fuzzing/README.md
@@ -1,3 +1,69 @@
-All fuzzers here are run continously through OSS-fuzz.
+# Table fuzzer
+
+`build.sh` and `table_fuzzer.cc` are run continously through OSS-fuzz.
 
 Link to OSS-fuzz integration: Pending
+
+# Translation fuzzers
+
+Currently, there is 2 fuzzers related to translation, **fuzz_translate** that will target **lou_translateString** and **fuzz_backtranslate** that will, in a similar way, fuzz **lou_backTranslateString**. The following sections will explain how to configure the fuzzers, how to use them and how to get a coverage report of the fuzzing result. 
+
+## Configure the project for fuzzing
+
+We have added some switchs to configure.ac for fuzzing and coverage. The `--with-fuzzer` switch will check if your are actually using clang and clang++ as compilers (by looking at CC and CXX) and allows generation of compilation instructions for fuzzer targets. The `--with-coverage` will add `-fprofile-instr-generate -fcoverage-mapping` to AM_CPPFLAGS in tests/makefile.am and liblouis/makefile.am.
+
+To configure and build the project with coverage and fuzzer.
+```
+./autogen.sh
+CC=clang CXX=clang++ ./configure --with-coverage --with-fuzzer
+make -j8
+```
+
+## Run the fuzzers
+
+You are now able to run the fuzzer and will have to give 2 parameters to it. First, you need to choose a table (or many) to fuzz and set the `FUZZ_TABLE` environment variable to them. Then, you need to provide a corpus with files containing sample inputs that will be used by libfuzzer to craft the data passed to the fuzzing function (the idea is to keep corpus as minimal as possible). If you don't provide any corpus directory, libfuzzer just generates random inputs.
+
+Here is how you can start fuzzing for `lou_translateString` function.
+```
+# first we move to tests/fuzzing directory
+cd tests/fuzzing
+
+# we consider here you have added corpus files into tests/fuzzing/CORPUS directory
+FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate CORPUS/
+
+# to run the fuzzer using parallelization
+# you can even set more jobs than workers (the ones that just stopped will be instantly replaced by a new fuzzer process)
+FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate CORPUS/ -workers=8 -jobs=8
+
+# start the fuzzer and let it generate random input (without corpus files), here we doesn't parallelize the process
+FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate 
+
+```
+
+After running the fuzzer multiple times with the same corpus directory, it might be possible that many corpus files added by the fuzzer explores the same paths. Hopefully, libfuzzer allows you to minimize a corpus. There is a simple bash script in tests/fuzzing that allows you to do that.
+```
+./minimize-corpus.sh CORPUS/
+
+# if you have added a POC file in the corpus directory and you want to keep it intact, change his extension to .txt and use --preserve-txt switch that keep .txt files intact in the directory
+./minimize-corpus.sh --preserve-txt CORPUS/
+```
+
+## Look at fuzzer coverage
+
+If you want to see what are the source code parts that are explored by the fuzzer, you can use clang coverage. So, you have to configure with coverage switch, run the fuzzer and show coverage data from the run with llvm tools. 
+To be able to use the coverage data, you need first to compile the raw profile data file of the run. By default, this file is created after execution under the name of default.profraw but you can specify it with `LLVM_PROFILE_FILE`.
+Here is how to do that.
+```
+LLVM_PROFILE_FILE=fuzz_translate.profraw FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate CORPUS/ -workers=8 -jobs=8
+
+# wait for a bit and press CTRL+C
+
+# compile raw profile
+llvm-profdata merge -sparse fuzz_translate.profraw -o fuzz_translate.profdata
+
+# show coverage (redlines are the one wich are reached)
+# Actually tests/fuzzing/fuzz_translate is just a wrapper to tests/fuzzing/.libs/fuzz_translate, 
+# so for covering we directly pass the binary
+llvm-cov show .libs/fuzz_translate -instr-profile=fuzz_translate.profdata
+
+```

--- a/tests/fuzzing/build-corpus.py
+++ b/tests/fuzzing/build-corpus.py
@@ -1,0 +1,178 @@
+#!/bin/python3
+
+#
+#   liblouis Braille Translation and Back-Translation Library
+#
+#   Copyright (C) 2022 Anna Stan, Nicolas Morel, Kalilou Mamadou Dramé
+#
+#   This file is part of liblouis.
+#
+#   liblouis is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 2.1 of the License, or
+#   (at your option) any later version.
+#
+#   liblouis is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import sys
+import argparse
+import os
+from os import O_WRONLY, O_TRUNC, O_CREAT, SEEK_END, SEEK_CUR, SEEK_SET
+ 
+ 
+ 
+'''from pwn import *
+context.quiet'''
+ 
+DEFAULT_BINARY_NAME = 'fuzz_voice'
+DEFAULT_CORPUS_NAME = 'corpus.txt'
+ 
+def fd_get_size(fd):
+    cur_off = os.lseek(fd, 0, SEEK_CUR)
+    size = os.lseek(fd, 0, SEEK_END)
+    os.lseek(fd, cur_off, SEEK_SET)
+    return size
+
+
+'''
+    Check if a bytestring (should be a 2 letter bytestring) is an unicode character
+
+    (
+    As it doesn't check if the string passed (s) or a substring is a valid ascii 
+    or utf value that we just added to corpus, it can add more characters than it
+    was originally contained in files.
+    However, it can be usefull to add more chars to corpus file so we dont fix this for now.
+    )
+    
+    Returns the int value of the char and True if it is an unicode char, otherwise None and False
+'''
+def isUnicode(s):
+    c=None
+    try:
+        c=ord(s.decode('utf-8'))
+        if (c > 0 and c < 0xffff) or (c > 0xe000 and c < 0x10ffff):
+            return c, True
+    except:
+        pass
+    return None, False
+
+
+def isAscii(c):
+    if c > 0 and c <= 127:
+        return True
+    return False
+
+
+'''
+    Corpus class
+    
+    Allows to create corpus file from xx_list
+'''
+class Corpus:
+    
+    def __init__(self, files, output=DEFAULT_CORPUS_NAME, stdout=False):
+        self.files = files
+        self.output = output
+        if stdout is True:
+            self.output = None
+        self.dict = ""
+        self.dict_uni = ""
+        self.ascii_lut = [False for i in range(0, 128)]
+        self.unicode_lut = [False for i in range(0, 1112065)]
+        
+    '''
+        build a dictonnary with all chars appearing in xx_list
+    '''
+    def retrieveDict(self):
+        for filename in self.files:
+            with open(filename, mode='rb') as fp:
+                for line in fp.readlines():
+                    for i in range(0, len(line)):
+                        
+                        if i != 0:
+                            s = line[i-1: i+1] 
+                            c, ret = isUnicode(s)
+                            if ret == True and self.unicode_lut[c] is False:
+                                self.unicode_lut[c] = True
+                                self.dict_uni += chr(c)
+                        if i >= 2:
+                            s = line[i-2: i+1] 
+                            c, ret = isUnicode(s)
+                            if ret == True and self.unicode_lut[c] is False:
+                                self.unicode_lut[c] = True
+                                self.dict_uni += chr(c)
+                        if i >= 3:
+                            s = line[i-3: i+1] 
+                            c, ret = isUnicode(s)
+                            if ret == True and self.unicode_lut[c] is False:
+                                self.unicode_lut[c] = True
+                                self.dict_uni += chr(c)
+                        
+                        c = line[i]
+                        if isAscii(c) and self.ascii_lut[c] is False:
+                            self.ascii_lut[c] = True
+                            self.dict += chr(c)
+                    
+                       
+    
+    '''
+        Write dictionnary to output file
+    '''
+    def writeDictToFile(self):
+        if self.output is None:
+            print(self.dict)
+            print(self.dict_uni)
+        else:
+            fd = os.open(self.output, O_WRONLY|O_CREAT|O_TRUNC, 0o644)
+            os.write(fd, self.dict.encode())
+            os.write(fd, self.dict_uni.encode('utf-8'))
+            os.close(fd)
+ 
+def main(argc, argv):
+    if argc < 3:
+        print('Summary: Build corpus from files', file=sys.stderr)
+        print(f'Usage: {argv[0]} -f <file(s)> (-o <output-filename>|--stdout)', file=sys.stderr)
+        exit(1)
+ 
+    ap = argparse.ArgumentParser()
+ 
+    # Add the arguments to the parser
+    ap.add_argument("-f", "--files", required=True,
+    help="the filenames list to extract char from and build corpus")
+    ap.add_argument("-o", "--output", required=False,
+    help="the output filename for the corpus file")
+    ap.add_argument("-s", "--stdout", required=False, action='store_true',
+    help="only display corpus to stdout")
+    args = vars(ap.parse_args())
+ 
+    files = []
+    for file in args['files'].split(','):
+        if file == '':
+            print('Error in --files format', file=sys.stderr)
+            print('Format is : --files=file0,file1,file2', file=sys.stderr)
+            exit(1)
+        files.append(file)
+ 
+    if args['stdout'] is False and args['output'] is None:
+        print('Error arguments: you need to specify an output option (file: --output|-o, stdout: --stdout|-s)', file=sys.stderr)
+        exit(1)
+    
+    c=None
+    if args['stdout'] is True:
+        c = Corpus(files, stdout=True)
+    else:
+        c = Corpus(files, args['output'])
+    c.retrieveDict()
+    c.writeDictToFile()
+ 
+ 
+if __name__ == "__main__":
+    main(len(sys.argv), sys.argv)
+ 

--- a/tests/fuzzing/fuzz_translate.c
+++ b/tests/fuzzing/fuzz_translate.c
@@ -1,0 +1,94 @@
+//
+// liblouis Braille Translation and Back-Translation Library
+//
+// Copyright (C) 2022 Anna Stan, Nicolas Morel, Kalilou Mamadou Dramé
+//
+// This file is part of liblouis.
+//
+// liblouis is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 2.1 of the License, or
+// (at your option) any later version.
+//
+// liblouis is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <internal.h>
+#include <liblouis.h>
+#include <assert.h>
+
+#define LANGUAGE	"en"
+
+static int initialized = 0;
+
+#define BOLDRED(x)	"\x1b[31m\x1b[1m" x "\x1b[0m"
+
+static const char *table_default;
+
+static void __attribute__((destructor))
+free_ressources(void) {
+	lou_free();
+}
+
+void
+avoid_log(logLevels level, const char *msg) {
+	(void) level;
+	(void) msg;
+}
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	int inputLen = 0;
+	int outputLen = 0;
+	char *mutable_data = NULL;
+	
+	if (!initialized)
+	{
+		lou_registerLogCallback(avoid_log);
+		table_default = getenv("FUZZ_TABLE");
+		initialized = 1;
+	}
+
+	mutable_data = strndup((char*)data, size);
+	if (!mutable_data) 
+	{
+		perror("malloc");
+		exit(1);
+	}
+
+	widechar *inputText = malloc((size*16+1)*sizeof(widechar));
+	int len = (int)_lou_extParseChars(mutable_data, inputText);
+	free(mutable_data);
+	if (len <= 0) {
+		free(inputText);
+		return -1;
+	}
+
+	assert(len <= (size*16));
+	inputLen = len;
+	outputLen = len*16;
+	widechar *outputText = malloc((outputLen+1)*sizeof(widechar));
+	if (table_default == NULL)
+	{
+		fprintf(stderr, "\n" BOLDRED("[Please set up FUZZ_TABLE env var before starting fuzzer]")"\nThis environment variable is supposed to contain the table you want to test with lou_translateString()\n\n");
+		exit(0);
+	}
+	lou_translateString(table_default, inputText, &inputLen, outputText, &outputLen, NULL, NULL, ucBrl);
+	free(inputText);
+	free(outputText);
+
+	return 0;
+}

--- a/tests/fuzzing/minimize-corpus.sh
+++ b/tests/fuzzing/minimize-corpus.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+#
+#   liblouis Braille Translation and Back-Translation Library
+#
+#   Copyright (C) 2022 Anna Stan, Nicolas Morel, Kalilou Mamadou Dramé
+#
+#   This file is part of liblouis.
+#
+#   liblouis is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 2.1 of the License, or
+#   (at your option) any later version.
+#
+#   liblouis is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
+#
+
+if [[ $# -lt 1 ]]
+then
+  echo "Usage: $0 <corpus-dir>"
+  echo "Usage: $0 --preserve-txt <corpus-dir> (minimize corpus but keep .txt files intact)"
+  exit 1
+fi
+
+preserve_txt=0
+if [[ "$1" == "--preserve-txt" ]]
+then
+  preserve_txt=1
+  CORPUS_DIR=$2
+else
+  CORPUS_DIR=$1
+fi 
+
+ROOT_PWD=../../
+export FUZZ_TABLE=$ROOT_PWD/tables/en-us-g2.ctb
+FUZZER=$ROOT_PWD/tests/fuzzing/fuzz_translate
+
+TMP_DIR=$(mktemp -d)
+echo "Merging..."
+`$FUZZER -merge=1 $TMP_DIR $CORPUS_DIR`
+echo "Removing old files..."
+if [[ $preserve_txt -eq 1 ]]
+then
+  echo " => Preserve .txt files"
+  rm -rvf $(find $CORPUS_DIR | grep -vE "*.txt|$CORPUS_DIR") 2>/dev/null
+else
+  rm -rf $CORPUS_DIR/* 2>/dev/null
+fi
+cp $TMP_DIR/* $CORPUS_DIR 2>/dev/null
+rm -rf $TMP_DIR
+echo "Merging done !"


### PR DESCRIPTION
Hi all,

We are 3 students in IT security ( @annastan, @kmamadoudram, @yocvito) and are currently working on fuzzing liblouis/espeak-ng for a school project with @sthibaul. For liblouis, we have decided to focus on translation/back-translation functions and for now, only the translation fuzzer is available but we will add the back-translation one soon. We come here to show you the work we have done and to try to improve it.

**So, what have we done yet ?**
Basically, we have used _libfuzzer_ to implements fuzzing on `lou_translateString` and `lou_backTranslateString`. The fuzzer just look for an ENV variable containing the table you want to test, avoid liblouis logging and start fuzzing.
If you are already familiar with libfuzzer, then there is no other specific switch than libfuzzer ones to pass to the fuzzer. The only thing you need to care about is configuration but you can find more information on how to use the fuzzer we added in tests/fuzzing/README.md

To check that our fuzzer was actually working, we have used clang coverage and have added the related compiler flags to the liblouis directory sources in makefile.am. We were thus able to see that our fuzzer was, indeed, really reaching a lot of the source code. (more info on coverage in the README.md, currently coverage isn't working well on liblouis fuzzer)

**What’s now ?**
We will continue to integrate and improve the fuzzers in the next months. It's not entirely ready yet but we will continue to modify it and come back to you to highlights our changes. 

Finally, to find bugs, we need relevant corpus files for each table and the good translation mode. We have built a first skeleton of what could be a fuzzer for these functions and have added some scripts to help using it. We are still working on it and will be grateful about any suggestions you could make.

Thank you.