### PR TITLE
Add a table for German grade 2 with capitalization

### DIFF
--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -39,6 +39,7 @@
 * ../../tables/de-g1.ctb                         German, partially contracted                       German partially contracted braille
   ../../tables/de-g1-detailed.ctb                German, partially contracted, with capitals        German partially contracted braille with indication of capitals
 * ../../tables/de-g2.ctb                         German, contracted                                 German contracted braille
+  ../../tables/de-g2-detailed.ctb                German, contracted, with capitals                  German contracted braille with indication of capitals
 * ../../tables/dra.tbl                           Dravidian, computer                                Dravidian computer braille
 * ../../tables/el.ctb                            Greek                                              Greek braille
   ../../tables/grc-international-en.utb          Greek, international, English                      Greek internationalized braille as used by English speakers

--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -85,6 +85,7 @@ table_files = \
 	de-g2-core.cti \
 	de-g2-core-patterns.dic \
 	de-g2.ctb \
+	de-g2-detailed.ctb \
 	devanagari.cti \
 	digits6DotsPlusDot6.uti \
 	digits6Dots.uti \

--- a/tables/de-g2-detailed.ctb
+++ b/tables/de-g2-detailed.ctb
@@ -1,0 +1,54 @@
+# liblouis: German Grade 2 Braille (with capitals)
+#
+# Das System der deutschen Blindenschrift (2015/2018)
+# http://www.bskdl.org/textschrift.html
+#
+# Differences between this table (de-g2-detailed.utb) and de-g2.utb:
+# This table is meant to be used with screen readers and note-takers
+# for both forward and backward translation.
+# Forward translation in this table is designed to give as much
+# information as possible in order for the result to be
+# back-translatable.
+# Forward translation differs from that of de-g2.utb in the following ways.
+# 1. All capital letters are marked.
+# 2. Accented letters are translated using de-accents-detailed.cti
+#    to make the translation as detailed as possible.
+# 3. "`" and "´" are translated as "'" so they won't cover other
+#    characters.
+#
+# -----------
+#-name: Deutsche Kurzschrift
+#-index-name: German, contracted, with capitals
+#-display-name: German contracted braille with indication of capitals
+#
+#+language: de
+#+type: literary
+#+contraction: full
+#+grade: 2
+#+direction: both
+#+variant: detailed
+#-has-nocross: yes
+# -----------
+#
+#  Copyright (C) 2022 SBS Schweizerische Bibliothek für Blinde, Seh- und Lesebehinderte
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+#-------------------------------------------------------------------------------
+
+include de-g1-detailed.ctb
+include de-g2-core.cti

--- a/tables/de-g2-detailed.ctb
+++ b/tables/de-g2-detailed.ctb
@@ -3,12 +3,18 @@
 # Das System der deutschen Blindenschrift (2015/2018)
 # http://www.bskdl.org/textschrift.html
 #
-# Differences between this table (de-g2-detailed.utb) and de-g2.utb:
-# This table is meant to be used with screen readers and note-takers
-# for both forward and backward translation.
-# Forward translation in this table is designed to give as much
-# information as possible in order for the result to be
-# back-translatable.
+# Unlike `de-g2.utb` this table provides more detailed braille
+# representation so back-translation is more exact. This can be
+# beneficial when used with screen readers and note-takers for both
+# forward and backward translation.
+#
+# However due to the lack of consideration for back-translation of the
+# German standard for grade 2 it is nearly impossible to do proper
+# back-translation of German grade 2 braille. This table is slightly
+# better than `de-g2.utb` but it cannot in good conscience be
+# recommended for back-translation. Use it at your own risk or help
+# improving it.
+
 # Forward translation differs from that of de-g2.utb in the following ways.
 # 1. All capital letters are marked.
 # 2. Accented letters are translated using de-accents-detailed.cti

--- a/tables/de-g2-detailed.ctb
+++ b/tables/de-g2-detailed.ctb
@@ -25,7 +25,7 @@
 #+type: literary
 #+contraction: full
 #+grade: 2
-#+direction: both
+#+direction: forward
 #+variant: detailed
 #-has-nocross: yes
 # -----------

--- a/tables/de-g2.ctb
+++ b/tables/de-g2.ctb
@@ -1,8 +1,9 @@
-# This table is meant to be used for forward translation only.
-# The generated Braille is primarily meant for embossing and is not
-# suitable for back-translation.
-# Please, use the detailed tables in contexts where
-# back-translation is an issue.
+# liblouis: German Grade 2 Braille
+#
+# This table is primarily meant to be used for forward translation.
+# The generated Braille is really meant for embossing and is not ideal
+# for back-translation. Please, use the detailed tables in contexts
+# where back-translation is an issue.
 # -----------
 
 #-name: Deutsche Kurzschrift

--- a/tables/de-g2.ctb
+++ b/tables/de-g2.ctb
@@ -1,10 +1,15 @@
 # liblouis: German Grade 2 Braille
 #
 # This table is primarily meant to be used for forward translation.
-# The generated Braille is really meant for embossing and is not ideal
-# for back-translation. Please, use the detailed tables in contexts
-# where back-translation is an issue.
-# -----------
+#
+# It can be used for back-translation but due to the lack of
+# consideration for back-translation of the German standard for
+# Kurzschrift (grade 2) it is nearly impossible to do accurate
+# back-translation of German grade 2 braille.
+
+# The detailed table helps somewhat in that provides more detailed
+# braille representation but the fundamental problems of the standard
+# remain.
 
 #-name: Deutsche Kurzschrift
 #-index-name: German, contracted

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -104,6 +104,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/de-g1-dictionary.yaml		  \
 	braille-specs/de-g2.yaml			  \
 	braille-specs/de-g2-sbs.yaml			  \
+	braille-specs/de-g2-detailed-specs.yaml		  \
 	braille-specs/de-g2-dictionary.yaml		  \
 	braille-specs/el-backward.yaml			  \
 	braille-specs/el-forward.yaml			  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -36,6 +36,7 @@ EXTRA_DIST =					\
 	de-g1.yaml				\
 	de-g1-dictionary.yaml			\
 	de-g2.yaml				\
+	de-g2-detailed-specs.yaml		\
 	de-g2-dictionary.yaml			\
 	de-g2-sbs.yaml				\
 	el-backward.yaml			\

--- a/tests/braille-specs/de-g2-detailed-specs.yaml
+++ b/tests/braille-specs/de-g2-detailed-specs.yaml
@@ -1,0 +1,21 @@
+display: unicode-without-blank.dis
+table:
+  language: de
+  grade: 2
+  type: literary
+  dots: 6
+  variant: detailed
+  __assert-match: de-g2-detailed.ctb
+
+flags: {testmode: forward}
+tests:
+  -
+    - Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich
+    - ⠨⠵⠺⠪⠇⠋ ⠨⠃⠕⠠⠭⠅⠜⠍⠏⠋⠻ ⠚⠁⠛⠉ ⠨⠧⠊⠅⠞⠕⠗ ⠠⠟⠥⠻ ⠳ ⠑ ⠛⠮⠉ ⠨⠎⠠⠽⠇⠞⠻ ⠨⠙⠩⠹
+
+flags: {testmode: backward}
+tests:
+  -
+    - ⠨⠵⠺⠪⠇⠋ ⠨⠃⠕⠠⠭⠅⠜⠍⠏⠋⠻ ⠚⠁⠛⠉ ⠨⠧⠊⠅⠞⠕⠗ ⠠⠟⠥⠻ ⠳ ⠑ ⠛⠮⠉ ⠨⠎⠠⠽⠇⠞⠻ ⠨⠙⠩⠹
+    - Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich
+    - xfail: backtranslating german grade 2 needs more attention

--- a/tests/braille-specs/de-g2-detailed-specs.yaml
+++ b/tests/braille-specs/de-g2-detailed-specs.yaml
@@ -18,4 +18,7 @@ tests:
   -
     - ⠨⠵⠺⠪⠇⠋ ⠨⠃⠕⠠⠭⠅⠜⠍⠏⠋⠻ ⠚⠁⠛⠉ ⠨⠧⠊⠅⠞⠕⠗ ⠠⠟⠥⠻ ⠳ ⠑ ⠛⠮⠉ ⠨⠎⠠⠽⠇⠞⠻ ⠨⠙⠩⠹
     - Zwölf Boxkämpfer jagen Viktor quer über den großen Sylter Deich
-    - xfail: backtranslating german grade 2 needs more attention
+    - xfail: >
+        backtranslating german grade 2 is almost impossible due to ambiguous rules.
+        For example '⠋' at the end of a word can mean just the letter 'f' or (at the readers
+        discretion) it can also mean 'falls'.


### PR DESCRIPTION
A German grade 2 table with capitalization and detailed accents. To be able to recommend it for back-translation is an other step (look at the result of the back-translation in the YAML test). It probably needs similar rules just for back-translation as @BueVest  added for `de-g1-detailed.utb`.

Resolves #1212 