### PR TITLE
analyzeTable: correctly parenthesize src arg of memcpy calls

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -531,15 +531,15 @@ analyzeTable(const char *table, int activeOnly) {
 							if (strcasecmp(k, "locale") == 0) {
 								FeatureWithLineNumber *f1 =
 										memcpy(malloc(sizeof(FeatureWithLineNumber)),
-												&(FeatureWithLineNumber){
+												(&(FeatureWithLineNumber){
 														feature_new("language", v),
-														info.lineNumber },
+														info.lineNumber }),
 												sizeof(FeatureWithLineNumber));
 								FeatureWithLineNumber *f2 =
 										memcpy(malloc(sizeof(FeatureWithLineNumber)),
-												&(FeatureWithLineNumber){
+												(&(FeatureWithLineNumber){
 														feature_new("region", v),
-														info.lineNumber },
+														info.lineNumber }),
 												sizeof(FeatureWithLineNumber));
 								_lou_logMessage(LOU_LOG_DEBUG,
 										"Table has feature '%s:%s'", f1->feature.key,
@@ -557,8 +557,8 @@ analyzeTable(const char *table, int activeOnly) {
 							} else {
 								FeatureWithLineNumber *f = memcpy(
 										malloc(sizeof(FeatureWithLineNumber)),
-										&(FeatureWithLineNumber){
-												feature_new(k, v), info.lineNumber },
+										(&(FeatureWithLineNumber){
+												feature_new(k, v), info.lineNumber }),
 										sizeof(FeatureWithLineNumber));
 								_lou_logMessage(LOU_LOG_DEBUG,
 										"Table has feature '%s:%s'", f->feature.key,
@@ -583,8 +583,8 @@ analyzeTable(const char *table, int activeOnly) {
 		fclose(info.in);
 		if (!region && language) {
 			region = memcpy(malloc(sizeof(FeatureWithLineNumber)),
-					&(FeatureWithLineNumber){
-							feature_new("region", language->feature.val), -1 },
+					(&(FeatureWithLineNumber){
+							feature_new("region", language->feature.val), -1 }),
 					sizeof(FeatureWithLineNumber));
 			_lou_logMessage(LOU_LOG_DEBUG, "Table has feature '%s:%s'",
 					region->feature.key, region->feature.val);


### PR DESCRIPTION
Clang 11 on macos will fail to build 3.21.0's `metadata.c` otherwise, complaining:

```
metadata.c:537:13: error: too many arguments provided to function-like macro invocation
                                                                                                sizeof(FeatureWithLineNumber));
                                                                                                ^
/nix/store/c5jrszdq2hy3hj9rpyx3hk9gba60wd1d-Libsystem-1238.60.2/include/secure/_string.h:64:9: note: macro 'memcpy' defined here
#define memcpy(dest, src, len)                                  \
        ^
metadata.c:533:11: note: parentheses are required around macro argument containing braced initializer list
                                                                                memcpy(malloc(sizeof(FeatureWithLineNumber)),
```

Full build log available at https://hydra.nixos.org/log/jpjrkavb354d98lidivsxv5c8y5li2jc-liblouis-3.21.0.drv