### PR TITLE
hu-hu-g1.ctb, hu-hu-g2.ctb: implemented hungarian nonumsign rules

### DIFF
--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -1633,25 +1633,4 @@ begword vázsno 1236-4-345-1345-135	For example Vázsnok town name
 partword rizszab 1235-24-345-126-1-12	For example rizszabáló word
 partword masszázszuh 134-1-156-156-4-345-126-136-125	For example masszázszuhany, masszázszuhanyokkal words
 
-#Special letters, with need marking different after numbers
-endnum a 6-1
-endnum b 6-12
-endnum c 6-14
-endnum d 6-145
-endnum e 6-15
-endnum f 6-124
-endnum g 6-1245
-endnum h 6-125
-endnum i 6-24
-endnum j 6-245
-endnum -a 36-1
-endnum -b 36-12
-endnum -c 36-14
-endnum -d 36-145
-endnum -e 36-15
-endnum -f 36-124
-endnum -g 36-1245
-endnum -h 36-125
-endnum -i 36-24
-endnum -j 36-245
 

--- a/tables/hu-hu-g1.ctb
+++ b/tables/hu-hu-g1.ctb
@@ -54,8 +54,7 @@ attribute notaccentedletters abcdefghijABCDEFGHIJ-
 attribute accentedletters áéíöőüűúóklmnopqrstuvwxyz
 include hu-hu-g1_braille_input.cti
 midendnumericmodechars ,:.-
-#nocontractsign 6
-#nonumsign 6
+nonumsign 6
 numericnocontchars abcdefghij-
 #Correcting forward translation when after a number following a hyphen
 #character, and a literary digit letter (for example a, b, c, etc).

--- a/tables/hu-hu-g1_braille_input.cti
+++ b/tables/hu-hu-g1_braille_input.cti
@@ -158,6 +158,7 @@ postpunc ! 235
 punctuation ! 235
 endnum % 3456-245-356
 endnum -% 36-3456-245-356
+noback pass2 $D.@36-3456-245-356[@36-6]%notaccentedletters @36
 endnum / 5-2
 prepunc / 5-2
 postpunc / 5-2
@@ -194,7 +195,7 @@ noback pass2 $D@46-46%accentedletters1-30[@14-234] @146
 noback pass3 $D[@36-146-6]%notaccentedletters. @36-146
 nofor pass3 $D[@36-146]%notaccentedletters. @36-146
 
-endnum ccsz 6-14-14-156
+endnum ccsz 14-14-156
 endnum -ccsz 36-14-14-156
 prepunc ccsz 14-14-156
 postpunc ccsz 14-14-156
@@ -210,7 +211,7 @@ postpunc ccs 146-146	General need replacing ccs letters with a combined dot comb
 noback pass2 $D@6%notaccentedletters[@14-14-234] @146-146
 noback pass2 $D%accentedletters1-30[@14-14-234] @146-146
 
-endnum csz 6-14-156
+endnum csz 14-156
 endnum -csz 36-14-156
 prepunc csz 14-156
 postpunc csz 14-156
@@ -268,6 +269,8 @@ endnum ny 1246
 endnum -ny 36-1246
 prepunc ny 1246	General need replacing ny letters with a combined dot combination
 postpunc ny 1246	General need replacing ny letters with a combined dot combination
+noback pass2 $D.[@6-1246] @1246
+noback pass2 $D.[@36-1246-6]%notaccentedletters. @36-1246
 
 endnum nny 1246-1246	General need replacing nny letters with a combined dot combination
 endnum -nny 36-1246-1246	General need replacing nny letters with a combined dot combination

--- a/tables/hu-hu-g2.ctb
+++ b/tables/hu-hu-g2.ctb
@@ -50,8 +50,7 @@ include hu-exceptionwords.cti
 include hu-backtranslate-word-corrections.cti
 include braille-patterns.cti
 #Braille indicators
-#nocontractsign 6
-#nonumsign 6
+nonumsign 6
 numsign 3456
 capsletter 46a
 noback pass4 @46a ? # remove in a second pass because single capital letters are not indicated
@@ -88,12 +87,12 @@ noback pass2 $D[@6-1236] @1236
 #wrong backtranslated output is „20-19”, „25-59”
 nofor pass2 $D[@36-36]%notaccentedletters @36-36-6
 nofor pass2 $D[@36]%notaccentedletters @36-6
-nofor correct "—'annyi" "--ai"
-nofor correct "—'ennyi" "--ei"
-nofor correct $D1-30["--'annyi"] "--ai"
-nofor correct $D1-30["--'ennyi"] "--ei"
-nofor correct $D1-30["-'annyi"] "-ai"
-nofor correct $D1-30["-'ennyi"] "-ei"
+nofor correct "—annyi" "--ai"
+nofor correct "—ennyi" "--ei"
+nofor correct $D1-30["--annyi"] "--ai"
+nofor correct $D1-30["--ennyi"] "--ei"
+nofor correct $D1-30["-annyi"] "-ai"
+nofor correct $D1-30["-ennyi"] "-ei"
 #Special letter replacements
 always cs 146	General need replacing cs letters with a combined dot combination
 always ccs 146-146	General need replacing ccs letters with a combined dot combination

--- a/tables/hu-hu-g2_exceptions.cti
+++ b/tables/hu-hu-g2_exceptions.cti
@@ -279,7 +279,6 @@ always voltmérő =
 always elektronvolt =
 always elektronvolttal 15-123-15-13-2345-1235-135-1345-1236-135-123-2345-1236
 always elektronvolt-tal 15-123-15-13-2345-1235-135-1345-1236-135-123-2345-36-1236
-always -a 36-1
 joinword a 2
 joinword A 2
 joinword az 3
@@ -765,9 +764,9 @@ endnum -ból 36-12-123
 endnum -ből 36-12-123
 endnum ához 4-125-126
 endnum -ához 36-4-125-126
-endnum hoz 6-125-126
-endnum hez 6-125-126
-endnum höz 6-125-126
+endnum hoz 125-126
+endnum hez 125-126
+endnum höz 125-126
 #noback pass2 @6-6-125 @6-125
 endnum -hoz 36-125-126
 endnum éhez 16-125-126
@@ -796,18 +795,18 @@ endnum -tól 36-2345-123
 endnum -től 36-2345-123
 noback correct $D.["-TŐL"] "-től"
 noback correct $D.["-Től"] "-től"
-endnum asával 6-1-234-4-1236
+endnum asával 1-234-4-1236
 endnum -asával 36-1-234-4-1236
 endnum ával 4-1236
 endnum -ával 36-4-1236
-endnum esével 6-15-234-16-1236
+endnum esével 15-234-16-1236
 endnum -esével 36-15-234-16-1236
 endnum ével 16-1236
 endnum -ével 36-16-1236
 endnum val 1236
 endnum -val 36-1236
 endnum -vel 36-1236
-endnum a\sés 6-1-0-16
+endnum a\sés 1-0-16
 endnum cal 1236
 endnum cel 1236
 endnum -cal 36-1236
@@ -884,17 +883,17 @@ endnum §tól 3456-1236-2345-123
 endnum §-tól 3456-1236-36-2345-123
 endnum %ként 3456-245-356-13-2345
 endnum %-ként 3456-245-356-36-13-2345
-endnum jében 6-245-16-12
+endnum jében 245-16-12
 endnum -jében 36-245-16-12
-endnum jéből 6-245-16-12-123
+endnum jéből 245-16-12-123
 endnum -jéből 36-245-16-12-123
-endnum jéhez 6-245-16-125-126
+endnum jéhez 245-16-125-126
 endnum -jéhez 36-245-16-125-126
-endnum jéről 6-245-16-1235-123
+endnum jéről 245-16-1235-123
 endnum -jéről 36-245-16-1235-123
-endnum jétől 6-245-16-2345-123
+endnum jétől 245-16-2345-123
 endnum -jétől 36-245-16-2345-123
-endnum jével 6-245-16-1236
+endnum jével 245-16-1236
 endnum -jével 36-245-16-1236
 noback pass3 @36-6-245-16-1236-15-123 @36-245-16-1236
 noback pass3 @36-46a-6-245-16-1236-15-123 @36-245-16-1236
@@ -906,25 +905,25 @@ noback pass3 @36-46-6-12-1-1345 @36-46-12
 noback correct $D.%notaccentedletters.["ként"] "kt"
 noback correct $D.%notaccentedletters.["ban"] "b"
 noback correct $D.%notaccentedletters.["-ban"] "-b"
-endnum asában 6-1-234-4-12
-endnum asából 6-1-234-4-12-123
+endnum asában 1-234-4-12
+endnum asából 1-234-4-12-123
 endnum -asában 36-1-234-4-12
 endnum -asából 36-1-234-4-12-123
-endnum asához 6-1-234-4-125-126
+endnum asához 1-234-4-125-126
 endnum -asához 36-1-234-4-125-126
-endnum asáról 6-1-234-4-1235-123
+endnum asáról 1-234-4-1235-123
 endnum -asáról 1-234-4-1235-123
-endnum asától 6-1-234-4-2345-123
+endnum asától 1-234-4-2345-123
 endnum -asától 36-1-234-4-2345-123
-endnum esben 6-15-234-12
+endnum esben 15-234-12
 endnum -esben 36-15-234-12
-endnum esből 6-15-234-12-123
+endnum esből 15-234-12-123
 endnum -esből 36-15-234-12-123
-endnum essel 6-15-234-1236
+endnum essel 15-234-1236
 endnum -essel 36-15-234-1236
-endnum eshez 6-15-234-125-126
+endnum eshez 15-234-125-126
 endnum -eshez 36-15-234-125-126
-endnum esről 6-15-234-1235-123
+endnum esről 15-234-1235-123
 endnum -esről 36-15-234-1235-123
 endnum sz 156
 endnum szeresében 156-15-1235-15-234-16-12
@@ -949,41 +948,41 @@ endnum szorosától 156-135-1235-135-234-4-2345-123
 endnum -szorosától 36-156-135-1235-135-234-4-2345-123
 endnum szorosával 156-135-1235-135-234-4-1236
 endnum -szorosával 36-156-135-1235-135-234-4-1236
-endnum estől 6-15-234-2345-123
+endnum estől 15-234-2345-123
 endnum -estől 36-15-234-2345-123
-endnum esekében 6-15-234-16-12
+endnum esekében 15-234-16-12
 endnum -esekében 36-15-234-16-12
-endnum esekéből 6-15-234-15-13-16-12-123
+endnum esekéből 15-234-15-13-16-12-123
 endnum -esekéből 36-15-234-15-13-16-12-123
-endnum esekéhez 6-15-234-15-13-16-125-126
+endnum esekéhez 15-234-15-13-16-125-126
 endnum -esekéhez 36-15-234-15-13-16-125-126
-endnum esekéről 6-15-234-15-13-16-1235-123
+endnum esekéről 15-234-15-13-16-1235-123
 endnum -esekéről 36-15-234-15-13-16-1235-123
-endnum esekétől 6-15-234-15-13-16-2345-123
+endnum esekétől 15-234-15-13-16-2345-123
 endnum -esekétől 36-15-234-15-13-16-2345-123
-endnum esekkel 6-15-234-15-13-1236
+endnum esekkel 15-234-15-13-1236
 endnum -esekkel 36-15-234-15-13-1236
-endnum esekben 6-15-234-15-13-12
+endnum esekben 15-234-15-13-12
 endnum -esekben 36-15-234-15-13-12
-endnum esekből 6-15-234-15-13-12-123
+endnum esekből 15-234-15-13-12-123
 endnum -esekből 36-15-234-15-13-12-123
-endnum esekhez 6-15-234-15-13-125-126
+endnum esekhez 15-234-15-13-125-126
 endnum -esekhez 36-15-234-15-13-125-126
-endnum esekről 6-15-234-15-13-1235-123
+endnum esekről 15-234-15-13-1235-123
 endnum -esekről 36-15-234-15-13-1235-123
-endnum esektől 6-15-234-15-13-2345-123
+endnum esektől 15-234-15-13-2345-123
 endnum -esektől 36-15-234-15-13-2345-123
-endnum esekével 6-15-234-15-13-16-1236
+endnum esekével 15-234-15-13-16-1236
 endnum -esekével 36-15-234-15-13-16-1236
-endnum esében 6-15-234-16-12
+endnum esében 15-234-16-12
 endnum -esében 36-15-234-16-12
-endnum eséből 6-15-234-16-12-123
+endnum eséből 15-234-16-12-123
 endnum -eséből 36-15-234-16-12-123
-endnum eséhez 6-15-234-16-125-126
+endnum eséhez 15-234-16-125-126
 endnum -eséhez 36-15-234-16-125-126
-endnum eséről 6-15-234-16-1235-123
+endnum eséről 15-234-16-1235-123
 endnum -eséről 36-15-234-16-1235-123
-endnum esétől 6-15-234-16-2345-123
+endnum esétől 15-234-16-2345-123
 endnum -esétől 36-15-234-16-2345-123
 endnum szeres 156-15-1235-15-234
 endnum -szeres 36-156-15-1235-15-234
@@ -999,9 +998,9 @@ endnum szeressel 156-15-1235-15-234-1236
 endnum -szeressel 36-156-15-1235-15-234-1236
 endnum szerestől 156-15-1235-15-234-2345-123
 endnum -szerestől 36-156-15-1235-15-234-2345-123
-endnum asként 6-1-234-13-2345
+endnum asként 1-234-13-2345
 endnum -asként 36-1-234-13-2345
-endnum esként 6-15-234-13-2345
+endnum esként 15-234-13-2345
 endnum -esként 36-15-234-13-2345
 endnum részesben 1235-16-156-15-234-12
 endnum -részesben 36-1235-16-156-15-234-12
@@ -1015,17 +1014,17 @@ endnum részestől 1235-16-156-15-234-2345-123
 endnum -részestől 36-1235-16-156-15-234-2345-123
 endnum részessel 1235-16-156-15-234-1236
 endnum -részessel 36-1235-16-156-15-234-1236
-endnum hetesben 6-125-15-2345-15-234-12
+endnum hetesben 125-15-2345-15-234-12
 endnum -hetesben 36-125-15-2345-15-234-12
-endnum hetesből 6-125-15-2345-15-234-12-123
+endnum hetesből 125-15-2345-15-234-12-123
 endnum -hetesből 36-125-15-2345-15-234-12-123
-endnum heteshez 6-125-15-2345-15-234-125-126
+endnum heteshez 125-15-2345-15-234-125-126
 endnum -heteshez 36-125-15-2345-15-234-125-126
-endnum hetesről 6-125-15-2345-15-234-1235-123
+endnum hetesről 125-15-2345-15-234-1235-123
 endnum -hetesről 36-125-15-2345-15-234-1235-123
-endnum hetestől 6-125-15-2345-15-234-2345-123
+endnum hetestől 125-15-2345-15-234-2345-123
 endnum -hetestől 36-125-15-2345-15-234-2345-123
-endnum hetessel 6-125-15-2345-15-234-1236
+endnum hetessel 125-15-2345-15-234-1236
 endnum -hetessel 36-125-15-2345-15-234-1236
 endnum évessel 16-1236-15-234-1236
 endnum -évessel 36-16-1236-15-234-1236
@@ -1163,17 +1162,3 @@ always boldogkő =
 always boldog-liget =
 always boldogon =
 always boldog-szigetek 12-135-123-145-135-1245-36-156-24-1245-15-2345-15-13
-
-#Special letters, with need marking different after numbers
-
-endnum A 46a-6-1
-endnum B 46a-6-12
-endnum C 46a-6-14
-endnum D 46a-6-145
-endnum E 46a-6-15
-endnum F 46a-6-124
-endnum G 46a-6-1245
-endnum H 46a-6-125
-endnum I 46a-6-24
-endnum J 46a-6-245
-


### PR DESCRIPTION
Hi Chris and Bert,

I ported nonumsign opcode the hungarian tables. Fortunately not need do more works this change related, neeed doed only small changes with hu-hu-g1.ctb and hu-hu-g2.ctb tables and affected subtable files.

The change is full review ready, I will don't commit any change this feature branch. So, this table change related I doed a final push. :-):-)

If fit your time, please do a review and a final merge for the master branch.

The translation quality passed my local large 1857864 words containing test yaml corpus database, so the change hungarian translation tables related not result regression.

Kind regards,

Attila