### PR TITLE
removed the computer braille indicator part, it's not official Braille Kanji's rule

### DIFF
--- a/tables/ja-kantenji.utb
+++ b/tables/ja-kantenji.utb
@@ -658,34 +658,6 @@ base uppercase \x01f7 \x01bf Ƿƿ wynn
 base uppercase \x014a \x014b Ŋŋ
 base uppercase \x018f \x0259 Əə
 
-begcomp 8-378
-endcomp 8-678
-compbrl ://
-compbrl ()
-compbrl www.
-compbrl ::
-compbrl .jp
-compbrl .com
-compbrl .edu
-compbrl .gov
-compbrl .ini
-compbrl .mil
-compbrl .net
-compbrl .org
-compbrl .doc
-compbrl .xml
-compbrl .xsl
-compbrl .htm
-compbrl .html
-compbrl .tex
-compbrl .txt
-compbrl .gif
-compbrl .jpg
-compbrl .png
-compbrl .wav
-compbrl .tar
-compbrl .zip
-
 #end Hankaku(half width) punctuations and symbols
 
 #begin Zenkaku(full width) punctuations and symbols

--- a/tests/braille-specs/ja-kantenji.yaml
+++ b/tests/braille-specs/ja-kantenji.yaml
@@ -14,6 +14,12 @@ tests:
   - # Needs alphabet indicator dots(6-8) before the first alphabet of continuous alphabet letters
     - njpw
     - ⢠⡲⠴⡖⢴
+  - # Web URLs and E-mail addresses are translated with the same rule as other alphabets
+    - http://www.yahoo.com/
+    - ⢠⠦⡴⡴⡖ ⠤⢰⡐⡐⢠⢴⢴⢴⢤⢠⣲⠂⠦⡢⡢⢤⢠⠒⡢⡒ ⡐
+  - #
+    - name@gmail.com
+    - ⢠⡲⠂⡒⠢ ⢔⢠⠶⡒⠂⠔⡆⢤⢠⠒⡢⡒
   - # 
     - JR東海
     - ⢠⢀⢀⠴⡦ ⠱⣎⡇⣊


### PR DESCRIPTION
When converting text which includes e-mails or URLs, lou_translate stops processing. So I removed teh compbrl lines it doesn't apply special substitions for e-mails and URLs and avoid lou_translate stops processing.