### PR TITLE
Problems in the Ukrainian braille table and priority of `base` rules

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,8 @@ issues]].
   the standard. Thanks to Kensaku Yoza.
 - Migrate the hungarian tables to the ~nonumsign~ opcode. Thanks to
   Attila Hammer.
+- Fixed a bug in the Ukrainian table that led to wrong translation of
+  some uppercase letters. Thanks to Andrey Yakuboy and Bert Frees.
 ** Other changes
 ** Deprecation notice
 - None

--- a/tables/bel.utb
+++ b/tables/bel.utb
@@ -33,14 +33,20 @@
 # alphabet, namely І and Ў. Like in ru-litbrl.ctb, the
 # following definitions have dot 9 set to make them distinguishable
 # from the Latin letters.
+#
+# The first definition conflicts with a definition in ru-litbrl.ctb
+# and needs to be placed before AND after the "ru-litbrl.ctb" include
+# in order for both the lower- and uppercase part to take precedence
+# (see https://github.com/liblouis/liblouis/issues/384).
+
 lowercase \x0456 134569  SMALL CYRILLIC LETTER I    і
-always \x0406 134569
+lowercase \x045e 3469  CYRILLIC LETTER SHORT U    ў
 
 include ru-litbrl.ctb
 
 lowercase \x0456 134569  SMALL CYRILLIC LETTER I    і
 
-lowercase \x045e 3469  CYRILLIC LETTER SHORT U    ў
+# base rule for Ў (the base rule for І is already in ru-litbrl.ctb)
 base uppercase \x040e \x045e  CYRILLIC LETTER SHORT U    Ўў
 
 # Extend classes defined in ru-litbrl.ctb

--- a/tables/kk.utb
+++ b/tables/kk.utb
@@ -33,6 +33,12 @@
 # alphabet, namely Ә, Ғ, Қ, Ң, Ө, Ұ, Ү, Һ and І. Like in ru-litbrl.ctb, the
 # following definitions have dot 9 set to make them distinguishable
 # from the Latin letters.
+#
+# The last definition conflicts with a definition in ru-litbrl.ctb
+# and needs to be placed before AND after the "ru-litbrl.ctb" include
+# in order for both the lower- and uppercase part to take precedence
+# (see https://github.com/liblouis/liblouis/issues/384).
+
 lowercase \x04d9 3459
 lowercase \x0493 124569
 lowercase \x049b 14569
@@ -43,6 +49,7 @@ lowercase \x04af 349
 lowercase \x04bb 12369
 lowercase \x0456 134569
 
+# base rule for Ә, Ғ, Қ, Ң, Ө, Ұ, Ү and Һ (the base rule for І is already in ru-litbrl.ctb)
 base uppercase \x04d8 \x04d9
 base uppercase \x0492 \x0493
 base uppercase \x049a \x049b
@@ -58,9 +65,11 @@ punctuation ) 2356
 
 include ru-litbrl.ctb
 
+lowercase \x0456 134569
+
 # Extend classes defined in ru-litbrl.ctb
-attribute uppercyrillic \x04d8\x0492\x049a\x04a2\x04e8\x04b0\x04ae\x04ba\x0406
-attribute lowercyrillic \x04d9\x0493\x049b\x04a3\x04e9\x04b1\x04af\x04bb\x0456
+attribute uppercyrillic \x04d8\x0492\x049a\x04a2\x04e8\x04b0\x04ae\x04ba
+attribute lowercyrillic \x04d9\x0493\x049b\x04a3\x04e9\x04b1\x04af\x04bb
 
 # In spite of conflicts of letters and parentheses, in math text parentheses should be marked like in the Russian braille
 # The correct opcode is used to avoid conflicts with rules in ru-litbrl.ctb

--- a/tables/uk.utb
+++ b/tables/uk.utb
@@ -45,16 +45,27 @@
 # alphabet, namely Є, І, Ї and Ґ. Like in ru-litbrl.ctb, the
 # following definitions have dot 9 set to make them distinguishable
 # from the Latin letters.
+#
+# The first three definitions conflict with definitions in
+# ru-litbrl.ctb and need to be placed before AND after the
+# "ru-litbrl.ctb" include in order for both the lower- and uppercase
+# part to take precedence (see
+# https://github.com/liblouis/liblouis/issues/384).
+
 lowercase \x0454 3459    CYRILLIC LETTER IE   є
 lowercase \x0456 134569  CYRILLIC LETTER I    і
 lowercase \x0457 14569   CYRILLIC LETTER II   ї
 lowercase \x0491 124569  CYRILLIC LETTER GE   ґ
 
+# base rule for Ґ (the base rules for Є, І and Ї are already in ru-litbrl.ctb)
+base uppercase \x0490 \x0491  CYRILLIC LETTER GE   Ґґ
+
 # Ukrainian braille is largely the same as Russian braille
 include ru-litbrl.ctb
 
-# base rule for Ґ, the other rules are already in ru-litbrl.ctb
-base uppercase \x0490 \x0491  CYRILLIC LETTER GE   Ґґ
+lowercase \x0454 3459    CYRILLIC LETTER IE   є
+lowercase \x0456 134569  CYRILLIC LETTER I    і
+lowercase \x0457 14569   CYRILLIC LETTER II   ї
 
 # Extend classes defined in ru-litbrl.ctb
 attribute uppercyrillic \x0490

--- a/tables/uk.utb
+++ b/tables/uk.utb
@@ -50,14 +50,12 @@ lowercase \x0456 134569  CYRILLIC LETTER I    і
 lowercase \x0457 14569   CYRILLIC LETTER II   ї
 lowercase \x0491 124569  CYRILLIC LETTER GE   ґ
 
-base uppercase \x0404 \x0454  CYRILLIC LETTER IE   Єє
-base uppercase \x0406 \x0456  CYRILLIC LETTER I    Іі
-base uppercase \x0407 \x0457  CYRILLIC LETTER II   Її
-base uppercase \x0490 \x0491  CYRILLIC LETTER GE   Ґґ
-
 # Ukrainian braille is largely the same as Russian braille
 include ru-litbrl.ctb
 
+# base rule for Ґ, the other rules are already in ru-litbrl.ctb
+base uppercase \x0490 \x0491  CYRILLIC LETTER GE   Ґґ
+
 # Extend classes defined in ru-litbrl.ctb
-attribute uppercyrillic \x0404\x0406\x0407\x0490
-attribute lowercyrillic \x0454\x0456\x0457\x0491
+attribute uppercyrillic \x0490
+attribute lowercyrillic \x0491

--- a/tests/braille-specs/uk.yaml
+++ b/tests/braille-specs/uk.yaml
@@ -3,7 +3,7 @@
 # Initial version of this test was adapted from ru.yaml
 #
 # Copyright © 2018 by Sergiy Moskalets <www.trosti.com.ua>
-# Copyright © 2020 by Andrey Yakuboy <andrewia2002@yandex.ru>
+# Copyright © 2020, 2022 by Andrey Yakuboy <andrewia2002@yandex.ru>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,6 +28,8 @@ tests:
     - ⠼⠁⠠⠂⠼⠉⠠⠂⠼⠑⠠⠂⠼⠛⠠⠂⠼⠁⠁⠠⠂⠼⠁⠉⠠⠂⠼⠁⠛⠠⠂⠼⠁⠊⠠⠂⠼⠃⠉
   - - ½
     - ⠼⠁⠆
+  - - Єє Іі Її Ґґ
+    - ⠜⠜ ⠽⠽ ⠹⠹ ⠻⠻
 
 # with indication of capitals
   - - Вона мріє про зів’яле листя на ґанку, але її мрії не збуваються.
@@ -35,6 +37,9 @@ tests:
     - xfail: option to indicate capitals does not exist yet
   - - Этот подъём был круче, тяжелее прежнего.
     - ⠘⠪⠞⠕⠞ ⠏⠕⠙⠷⠡⠍ ⠃⠮⠇ ⠅⠗⠥⠟⠑⠂⠞⠫⠚⠑⠇⠑⠑ ⠏⠗⠑⠚⠝⠑⠛⠕⠲
+    - xfail: option to indicate capitals does not exist yet
+  - - Єє Іі Її Ґґ
+    - ⠘⠜⠜ ⠘⠽⠽ ⠘⠹⠹ ⠘⠻⠻
     - xfail: option to indicate capitals does not exist yet
 
 # computer braille

--- a/tests/yaml/precedence.yaml
+++ b/tests/yaml/precedence.yaml
@@ -79,10 +79,10 @@ tests:
   - - Aa Bb Cc Dd Ee Ff Gg Hh
     - ⠁⠁ ⠃⠃ ⠉⠉ ⠙⠙ ⠑⠑ ⠋⠋ ⠛⠛ ⠓⠓
 
-# if capsletter is defined
-# - and "X" is defined as "uppercase X ...", the first "uppercase X" wins
-# - and "X" is defined as "base uppercase X x", the last definition of "x" wins
+# if "X" is defined as "uppercase X ...", the first "uppercase X" wins
+# if "X" is defined as "base uppercase X x", the last definition of "x" wins
 # (original issue: https://github.com/liblouis/liblouis/issues/384)
+# (note that it does not matter anymore whether capsletter is defined or not)
 table: |
   include tables/unicode-without-blank.dis
   include tables/spaces.uti
@@ -111,6 +111,34 @@ table: |
 tests:
   - - Aa Bb Cc Dd Ee Ff Gg Hh
     - ⠠⠁⠁ ⠠⠃⠃ ⠠⠉⠉ ⠠⠉⠙ ⠠⠑⠑ ⠠⠑⠋ ⠠⠛⠛ ⠠⠛⠓
+# same but without capsletter
+table: |
+  include tables/unicode-without-blank.dis
+  include tables/spaces.uti
+  lowercase a 1
+  base uppercase A a
+  uppercase B 12
+  lowercase b 12
+  lowercase c 14
+  base uppercase C c
+  lowercase d 145
+  base uppercase D d
+  lowercase e 15
+  base uppercase E e
+  lowercase f 124
+  base uppercase F f
+  lowercase g 1245
+  base uppercase G g
+  lowercase h 125
+  base uppercase H h
+  uppercase B 1
+  lowercase b 1
+  lowercase d 14
+  lowercase f 15
+  lowercase h 1245
+tests:
+  - - Aa Bb Cc Dd Ee Ff Gg Hh
+    - ⠁⠁ ⠃⠃ ⠉⠉ ⠉⠙ ⠑⠑ ⠑⠋ ⠛⠛ ⠛⠓
 
 # for printing escape sequences for undefined characters, only
 # character definitions that map to a single dot are used and the


### PR DESCRIPTION
Hi!

This PR adds tests for Ukrainian capital letters, because the bug in displaying them has been found.

The problem is that some specific Ukrainian letters are in the Russian braille table, but they have other definitions there (this is for reading Old Church Slavonic texts).

uk.utb:

```
lowercase \x0454 3459    CYRILLIC LETTER IE   є
lowercase \x0456 134569  CYRILLIC LETTER I    і
lowercase \x0457 14569   CYRILLIC LETTER II   ї

...

base uppercase \x0404 \x0454  CYRILLIC LETTER IE   Єє
base uppercase \x0406 \x0456  CYRILLIC LETTER I    Іі
base uppercase \x0407 \x0457  CYRILLIC LETTER II   Її
```

ru-litbrl.ctb:

```
noback lowercase \x0454 159-34-34
noback lowercase \x0456 249-34
noback lowercase \x0457 249-34-34

...

base uppercase \x0404 \x0454
base uppercase \x0406 \x0456
base uppercase \x0407 \x0457
```

In the uk.utb, definitions of Ukrainian letters are before including ru-litbrl.ctb, so they should have a priority. It works for lowercase letters, but for uppercase, Ukrainian table translates them as they are defined in the ru-litbrl.ctb (as shown in the failure test). It looks like priority for `base` rules doesn't work as expected. Potentially, it can cause bugs in other tables, too, but I haven't checked it yet.

I think I could just don't use `base` rules in uk.utb, but if it's a Liblouis bug, i believe it's important to fix it.