### PR TITLE
Include contact information in author and maintainer meta data

### DIFF
--- a/tables/ar-ar-comp8.utb
+++ b/tables/ar-ar-comp8.utb
@@ -25,8 +25,7 @@
 
 #-index-name: Arabic, computer
 #-display-name: Arabic computer braille
-#-author-name: Ikrami Ahmad
-#-author-email: ikrami.ahmad@gmail.com
+#-author: Ikrami Ahmad <ikrami.ahmad@gmail.com>
 # with assistance from Hatoon Felemban <h.felemban@hotmail.com>
 
 #+language: ar

--- a/tables/ar-ar-g2.ctb
+++ b/tables/ar-ar-g2.ctb
@@ -32,8 +32,7 @@
 # Marked as "direction:both" by Bue Vester-Andersen
 # as tests run both forward and backward
 #+direction: both
-#-author-name: Ikrami Ahmad
-#-author-email: ikrami.ahmad@gmail.com
+#-author: Ikrami Ahmad <ikrami.ahmad@gmail.com>
 
 include ar-ar-g1-core.uti
 

--- a/tables/bel-comp.utb
+++ b/tables/bel-comp.utb
@@ -27,7 +27,7 @@
 # This is the Belarusian computer braille table.
 # It is based on the Russian computer braille.
 
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # As the definition of the grave accent sign in the Russian computer Braille conflicts with the Belarusian letter Ў, this definition should be changed.
 

--- a/tables/bel.utb
+++ b/tables/bel.utb
@@ -27,7 +27,7 @@
 #
 # Based on the Russian braille.
 
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # The Belarusian alphabet has 2 letters that are not in the Russian
 # alphabet, namely І and Ў. Like in ru-litbrl.ctb, the

--- a/tables/cop-eg-comp8.utb
+++ b/tables/cop-eg-comp8.utb
@@ -21,8 +21,7 @@
 
 #-index-name: Coptic, computer 
 #-display-name: Coptic computer braille
-#-author-name: Ibraam Nasif 
-#-author-email: ibraam.wahib@gmail.com
+#-author: Ibraam Nasif <ibraam.wahib@gmail.com>
 
 #+language: cop
 #+type: computer

--- a/tables/el.ctb
+++ b/tables/el.ctb
@@ -18,9 +18,7 @@
 #-copyright: 2017, Dave Mielke
 #-license: LGPLv2.1
 #
-#-author-name: Dave Mielke
-#-author-email: dave@mielke.cc
-#-author-url: http://mielke.cc/
+#-author: Dave Mielke <dave@mielke.cc>
 # -----------
 #
 # Copyright (C) 2017 Dave Mielke: <dave@mielke.cc>, [http://mielke.cc/]

--- a/tables/gurumuki.cti
+++ b/tables/gurumuki.cti
@@ -1,10 +1,8 @@
 # This table contains braille codes and rules for Gurumukhi script.
 
-#-author-name: Dipendra Manocha
-#-author-email: dmanocha@daisy.org
-#-author-name: Jake Kyle
-#-maintainer-name: Dipendra Manocha
-#-maintainer-email: dmanocha@daisy.org
+#-author: Dipendra Manocha <dmanocha@daisy.org>
+#-author: Jake Kyle
+#-maintainer: Dipendra Manocha <dmanocha@daisy.org>
 #-updated: 2022-05-23
 
 # Copyright (C) 2014,2022 National Institute for Visually Handicapped, 116, Rajpur Road, Dehradun, Uttrakhand, India

--- a/tables/he-IL-comp8.utb
+++ b/tables/he-IL-comp8.utb
@@ -31,12 +31,9 @@
 #  <http://www.gnu.org/licenses/>.
 #
 #-license: LGPLv2.1
-#-author-name: Adi Kushnir
-#-author-email: adi@accessmind.net
-#-author-name: Pavel Kaplan
-#-author-email: pavel46@gmail.com
-#-author-name: Erez Kugler
-#-author-email: erez@tsr-gaash.com
+#-author: Adi Kushnir <adi@accessmind.net>
+#-author: Pavel Kaplan <pavel46@gmail.com>
+#-author: Erez Kugler <erez@tsr-gaash.com>
 #
 #
 # This table is the official Hebrew computer Braille table for Israel,

--- a/tables/he-IL.utb
+++ b/tables/he-IL.utb
@@ -38,10 +38,8 @@
 # assistance of BAUM Engineering.
 
 #-license: LGPLv2.1
-#-author-name: BAUM Engineering
-#-author-email: liblouis@baum.ro
-#-author-name: Erez Kugler
-#-author-email: erez@tsr-gaash.com
+#-author: BAUM Engineering <liblouis@baum.ro>
+#-author: Erez Kugler <erez@tsr-gaash.com>
 
 # The 4 most used languages in Israel are Hebrew, Arabic, Russian and
 # English. This table supports 3 of them: Hebrew, Arabic and

--- a/tables/ja-kantenji.utb
+++ b/tables/ja-kantenji.utb
@@ -12,9 +12,8 @@
 
 #-copyright: 2021, Kensaku Y.
 #-license: LGPLv2.1
-#-author-name: Kensaku Y.
-#-maintainer-name: Kensaku Y.
-#-maintainer-email: kanjibrailles@gmail.com
+#-author: Kensaku Y. <kanjibrailles@gmail.com>
+#-maintainer: Kensaku Y. <kanjibrailles@gmail.com>
 
 # Copyright (C) 2021, Kensaku Y.
 # Created by Kensaku Y. <kanjibrailles@gmail.com>

--- a/tables/kk.utb
+++ b/tables/kk.utb
@@ -27,7 +27,7 @@
 #
 # Based on the Russian braille.
 
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # The Kazakh alphabet has 9 letters that are not in the Russian
 # alphabet, namely Ә, Ғ, Қ, Ң, Ө, Ұ, Ү, Һ and І. Like in ru-litbrl.ctb, the

--- a/tables/km-g1.utb
+++ b/tables/km-g1.utb
@@ -34,8 +34,7 @@
 # with help from Khemara Ly from Myanmar
 #
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17
 #

--- a/tables/kmr.tbl
+++ b/tables/kmr.tbl
@@ -11,9 +11,8 @@
 #+grade:0
 
 # This table was created by Imam Kahraman <imam.kahraman@gmail.com>
-#-author-name: Imam Kahraman
-#-maintainer-name: Imam Kahraman
-#-maintainer-email: imam.kahraman@gmail.com
+#-author: Imam Kahraman <imam.kahraman@gmail.com>
+#-maintainer: Imam Kahraman <imam.kahraman@gmail.com>
 
 #-copyright: 2021, Imam Kahraman
 #-license: LGPLv2.1

--- a/tables/my-g1.utb
+++ b/tables/my-g1.utb
@@ -33,8 +33,7 @@
 # Created and maintained by: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 # with help from Benedict and Pyae Phyopaing from Myanmar
 #
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17

--- a/tables/my-g2.ctb
+++ b/tables/my-g2.ctb
@@ -34,8 +34,7 @@
 # with help from Benedict and Pyae Phyopaing from Myanmar
 #
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17
 #

--- a/tables/no-no-8dot-fallback-6dot-g0.utb
+++ b/tables/no-no-8dot-fallback-6dot-g0.utb
@@ -23,13 +23,8 @@
 #
 # Created August 2015 by Jostein Austvik Jacobsen <jostein@nlb.com> and Ammar Usama <ammar.usama@nlb.no>
 #
-#-author-name: Jostein Austvik Jacobsen
-#-author-email: jostein@nlb.no
-#-author-url: https://github.com/josteinaj
-#
-#-author-name: Ammar Usama
-#-author-email: ammar.usama@nlb.no
-#-author-url: https://github.com/usama49
+#-author: Jostein Austvik Jacobsen <jostein@nlb.no>
+#-author: Ammar Usama <ammar.usama@nlb.no>
 #
 # Official norwegian braille specifications are collected here:
 # http://liblouis.org/braille-specs/norwegian

--- a/tables/no-no-8dot.utb
+++ b/tables/no-no-8dot.utb
@@ -17,13 +17,8 @@
 #
 # Created August 2015 by Jostein Austvik Jacobsen <jostein@nlb.com> and Ammar Usama <ammar.usama@nlb.no>
 #
-#-author-name: Jostein Austvik Jacobsen
-#-author-email: jostein@nlb.no
-#-author-url: https://github.com/josteinaj
-#
-#-author-name: Ammar Usama
-#-author-email: ammar.usama@nlb.no
-#-author-url: https://github.com/usama49
+#-author: Jostein Austvik Jacobsen <jostein@nlb.no>
+#-author: Ammar Usama <ammar.usama@nlb.no>
 #
 # Official norwegian braille specifications are collected here:
 # http://liblouis.org/braille-specs/norwegian

--- a/tables/no-no-chardefs6.uti
+++ b/tables/no-no-chardefs6.uti
@@ -15,21 +15,10 @@
 # Updated June 2009 by Lars Bjørndal <lars@lamasti.net>
 # Updated April 2015 by Jostein Austvik Jacobsen <jostein@nlb.com> and Ammar Usama <ammar.usama@nlb.no>
 #
-#-author-name: Leon Ungier
-#-author-email: Leon.Ungier@ViewPlus.com
-#-author-url: www.viewplus.com
-#
-#-author-name: Lars Bjørndal
-#-author-email: lars@lamasti.net
-#-author-url: https://github.com/larsbjorndal
-#
-#-author-name: Jostein Austvik Jacobsen
-#-author-email: jostein@nlb.no
-#-author-url: https://github.com/josteinaj
-#
-#-author-name: Ammar Usama
-#-author-email: ammar.usama@nlb.no
-#-author-url: https://github.com/usama49
+#-author: Leon Ungier <Leon.Ungier@ViewPlus.com>
+#-author: Lars Bjørndal <lars@lamasti.net>
+#-author: Jostein Austvik Jacobsen <jostein@nlb.no>
+#-author: Ammar Usama <ammar.usama@nlb.no>
 #
 #  This file is part of liblouis.
 #

--- a/tables/no-no-comp8.ctb
+++ b/tables/no-no-comp8.ctb
@@ -27,13 +27,8 @@
 #
 # Updated August 2015 by Jostein Austvik Jacobsen <jostein@nlb.com> and Ammar Usama <ammar.usama@nlb.no>
 #
-#-author-name: Jostein Austvik Jacobsen
-#-author-email: jostein@nlb.no
-#-author-url: https://github.com/josteinaj
-#
-#-author-name: Ammar Usama
-#-author-email: ammar.usama@nlb.no
-#-author-url: https://github.com/usama49
+#-author: Jostein Austvik Jacobsen <jostein@nlb.no>
+#-author: Ammar Usama <ammar.usama@nlb.no>
 #
 # Based on the braille contraction modules in BRLTTY
 #

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -27,21 +27,10 @@
 # Updated June 2009 by Lars Bjørndal <lars@lamasti.net>
 # Updated April 2015 by Jostein Austvik Jacobsen <jostein@nlb.com> and Ammar Usama <ammar.usama@nlb.no>
 #
-#-author-name: Leon Ungier
-#-author-email: Leon.Ungier@ViewPlus.com
-#-author-url: www.viewplus.com
-#
-#-author-name: Lars Bjørndal
-#-author-email: lars@lamasti.net
-#-author-url: https://github.com/larsbjorndal
-#
-#-author-name: Jostein Austvik Jacobsen
-#-author-email: jostein@nlb.no
-#-author-url: https://github.com/josteinaj
-#
-#-author-name: Ammar Usama
-#-author-email: ammar.usama@nlb.no
-#-author-url: https://github.com/usama49
+#-author: Leon Ungier <Leon.Ungier@ViewPlus.com>
+#-author: Lars Bjørndal <lars@lamasti.net>
+#-author: Jostein Austvik Jacobsen <jostein@nlb.no>
+#-author: Ammar Usama <ammar.usama@nlb.no>
 #
 # Official norwegian braille specifications are collected here:
 # http://liblouis.org/braille-specs/norwegian

--- a/tables/no-no-g1.ctb
+++ b/tables/no-no-g1.ctb
@@ -25,13 +25,8 @@
 # Modified Sep 30, 2005 by LU
 # Heavily overworked by lars@lamasti.net, 2009.
 #
-#-author-name: Leon Ungier
-#-author-email: Leon.Ungier@ViewPlus.com
-#-author-url: www.viewplus.com
-#
-#-author-name: Lars Bjørndal
-#-author-email: lars@lamasti.net
-#-author-url: https://github.com/larsbjorndal
+#-author: Leon Ungier <Leon.Ungier@ViewPlus.com>
+#-author: Lars Bjørndal <lars@lamasti.net>
 #
 # Official norwegian braille specifications are collected here:
 # http://liblouis.org/braille-specs/norwegian

--- a/tables/no-no-g2.ctb
+++ b/tables/no-no-g2.ctb
@@ -25,13 +25,8 @@
 # Modified Sep 30, 2005 by LU
 # Heavily overworked by lars@lamasti.net, 2009.
 #
-#-author-name: Leon Ungier
-#-author-email: Leon.Ungier@ViewPlus.com
-#-author-url: www.viewplus.com
-#
-#-author-name: Lars Bjørndal
-#-author-email: lars@lamasti.net
-#-author-url: https://github.com/larsbjorndal
+#-author: Leon Ungier <Leon.Ungier@ViewPlus.com>
+#-author: Lars Bjørndal <lars@lamasti.net>
 #
 # Official norwegian braille specifications are collected here:
 # http://liblouis.org/braille-specs/norwegian

--- a/tables/no-no-g3.ctb
+++ b/tables/no-no-g3.ctb
@@ -26,13 +26,8 @@
 # Modified October 25, 2005
 # Last modified July 2012, by lars@lamasti.net
 #
-#-author-name: Leon Ungier
-#-author-email: Leon.Ungier@ViewPlus.com
-#-author-url: www.viewplus.com
-#
-#-author-name: Lars Bjørndal
-#-author-email: lars@lamasti.net
-#-author-url: https://github.com/larsbjorndal
+#-author: Leon Ungier <Leon.Ungier@ViewPlus.com>
+#-author: Lars Bjørndal <lars@lamasti.net>
 #
 # Official norwegian braille specifications are collected here:
 # http://liblouis.org/braille-specs/norwegian

--- a/tables/ru.ctb
+++ b/tables/ru.ctb
@@ -62,7 +62,7 @@
 
 # Comments from Russians are very welcome.
 
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # General
 space \s 0		SPACE

--- a/tables/sah.utb
+++ b/tables/sah.utb
@@ -25,7 +25,7 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 #
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # The Yakut braille code was created by Ivan Gorny (the real name is
 # Ivan Nikolaevich Egorov) and accepted in 1992. It was described in

--- a/tables/sot-za-g1.ctb
+++ b/tables/sot-za-g1.ctb
@@ -58,9 +58,8 @@
 #+direction: both
 
 # This table is Maintained by Christo de Klerk <cjdk@mweb.co.za>
-#-author-name: Christo de Klerk
-#-maintainer-name: Christo de Klerk
-#-maintainer-email: cjdk@mweb.co.za
+#-author: Christo de Klerk <cjdk@mweb.co.za>
+#-maintainer: Christo de Klerk <cjdk@mweb.co.za>
 
 # Apart from the addition of the letter š the grade 1 system is
 # identical to UEB.

--- a/tables/sot-za-g2.ctb
+++ b/tables/sot-za-g2.ctb
@@ -60,9 +60,8 @@
 #+direction: both
 
 # This table is maintained by Christo de Klerk <cjdk@mweb.co.za>
-#-author-name: Christo de Klerk
-#-maintainer-name: Christo de Klerk
-#-maintainer-email: cjdk@mweb.co.za
+#-author: Christo de Klerk <cjdk@mweb.co.za>
+#-maintainer: Christo de Klerk <cjdk@mweb.co.za>
 
 # Begin entries
 

--- a/tables/tt.utb
+++ b/tables/tt.utb
@@ -25,7 +25,7 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 #
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # The Tatar braille code was created by Sharif Kalimullovich Enikeev
 # and accepted in 1939. It was described in "Braille codes of the

--- a/tables/uk-comp.utb
+++ b/tables/uk-comp.utb
@@ -28,7 +28,7 @@
 # This is the Ukrainian computer braille table.
 # It is based on the Russian computer braille.
 
-#-maintainer-name: Andrey Yakuboy
+#-maintainer: Andrey Yakuboy
 
 # As some Russian punctuation definitions conflict with Ukrainian letters, these definitions should be changed.
 

--- a/tables/uk.utb
+++ b/tables/uk.utb
@@ -36,8 +36,7 @@
 
 # Maintained by Sergiy Moskalets.
 
-#-maintainer-name: Sergiy Moskalets
-#-maintainer-url: www.trosti.com.ua
+#-maintainer: Sergiy Moskalets <www.trosti.com.ua>
 
 # -----------------
 

--- a/tables/uz-g1.utb
+++ b/tables/uz-g1.utb
@@ -28,8 +28,7 @@
 #+direction:forward
 
 #-license: LGPLv2.1
-#-author-name: BAUM Engineering
-#-author-email: liblouis@baum.ro
+#-author: BAUM Engineering <liblouis@baum.ro>
 
 include ru-unicode.dis
 

--- a/tables/ve-za-g1.utb
+++ b/tables/ve-za-g1.utb
@@ -47,9 +47,8 @@
 #+direction: both
 
 # This table is Maintained by Christo de Klerk <cjdk@mweb.co.za>
-#-author-name: Christo de Klerk
-#-maintainer-name: Christo de Klerk
-#-maintainer-email: cjdk@mweb.co.za
+#-author: Christo de Klerk <cjdk@mweb.co.za>
+#-maintainer: Christo de Klerk <cjdk@mweb.co.za>
 
 # Apart from the addition of the diacritic  letters the grade 1 system is
 # identical to UEB.

--- a/tables/ve-za-g2.ctb
+++ b/tables/ve-za-g2.ctb
@@ -48,9 +48,8 @@
 #+direction: both
 
 # This table is Maintained by Christo de Klerk <cjdk@mweb.co.za>
-#-author-name: Christo de Klerk
-#-maintainer-name: Christo de Klerk
-#-maintainer-email: cjdk@mweb.co.za
+#-author: Christo de Klerk <cjdk@mweb.co.za>
+#-maintainer: Christo de Klerk <cjdk@mweb.co.za>
 
 # Begin entries
 

--- a/tables/vi-saigon-g1.ctb
+++ b/tables/vi-saigon-g1.ctb
@@ -33,8 +33,7 @@
 # Created and maintained by: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17
 #

--- a/tables/vi-vn-g0.utb
+++ b/tables/vi-vn-g0.utb
@@ -33,8 +33,7 @@
 # Created and maintained by: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17
 #

--- a/tables/vi-vn-g1.ctb
+++ b/tables/vi-vn-g1.ctb
@@ -33,8 +33,7 @@
 # Created and maintained by: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17
 #

--- a/tables/vi-vn-g2.ctb
+++ b/tables/vi-vn-g2.ctb
@@ -33,8 +33,7 @@
 # Created and maintained by: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-author: Dang Hoai Phúc <danghoaiphuc@gmail.com>
-#-maintainer-name: Dang Hoai Phuc
-#-maintainer-email: danghoaiphuc@gmail.com
+#-maintainer: Dang Hoai Phuc <danghoaiphuc@gmail.com>
 #
 #-updated: 2020-11-17
 #

--- a/tables/xh-za-g1.utb
+++ b/tables/xh-za-g1.utb
@@ -55,8 +55,7 @@
 
 # The table is maintained by Christo de Klerk <cjdk@mweb.co.za>.
 
-#-author-name: Christo de Klerk
-#-maintainer-name: Christo de Klerk
-#-maintainer-email: cjdk@mweb.co.za
+#-author: Christo de Klerk <cjdk@mweb.co.za>
+#-maintainer: Christo de Klerk <cjdk@mweb.co.za>
 
 include en-ueb-g1.ctb

--- a/tables/xh-za-g2.ctb
+++ b/tables/xh-za-g2.ctb
@@ -57,11 +57,9 @@
 
 # The table is maintained by Christo de Klerk <cjdk@mweb.co.za>.
 
-#-author-name: Laurent Cadet de Fontenay
-#-author-email: laurentd@gmail.com
-#-author-name: Christo de Klerk
-#-maintainer-name: Christo de Klerk
-#-maintainer-email: cjdk@mweb.co.za
+#-author: Laurent Cadet de Fontenay <laurentd@gmail.com>
+#-author: Christo de Klerk <cjdk@mweb.co.za>
+#-maintainer: Christo de Klerk <cjdk@mweb.co.za>
 
 include xh-za-g1.utb
 


### PR DESCRIPTION
instead of having it split up in author-name and author-email / maintainer-name and maintainer-email. The contact information is enclosed in < > so can be easily extracted if desired. In case there was both a author-email and a author-url field, author-email was used as contact information and the author-url info was discarded.