### PR TITLE
Fix metadata check

### DIFF
--- a/extra/generate-display-names/Makefile
+++ b/extra/generate-display-names/Makefile
@@ -15,9 +15,8 @@ generate.o : generate.c displayLanguage.h
 	$(CC) -I. -I../../liblouis -g -O2 -c -o $@ $<
 
 displayLanguage.a displayLanguage.h : displayLanguage.go
-	go get golang.org/x/text/language/display
 	go build -buildmode=c-archive $<
 
 .PHONY : clean
 clean :
-	rm -rf displayLanguage.a displayLanguage.h $(GOPATH)
+	rm -rf displayLanguage.a displayLanguage.h $(GOPATH) generate.o generate generate.log

--- a/extra/generate-display-names/go.mod
+++ b/extra/generate-display-names/go.mod
@@ -1,0 +1,5 @@
+module liblouis.org/generate-display-names
+
+go 1.19
+
+require golang.org/x/text v0.4.0


### PR DESCRIPTION
The generate-display-names script did not work anymore with the latest version of go.