### PR TITLE
Reduce CI load

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -7,8 +7,13 @@ on:
     paths:
       - '**.h'
       - '**.c'
+      - 'liblouis/liblouis/liblouis.h.in'
   pull_request:
     branches: [ master ]
+    paths:
+      - '**.h'
+      - '**.c'
+      - 'liblouis/liblouis/liblouis.h.in'
 
 jobs:
   check-format:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -7,7 +7,13 @@
 # script from the Liblouis OSS-Fuzz project folder. It runs on GitHub's
 # servers.
 name: CIFuzz
-on: [pull_request]
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '**.h'
+      - '**.c'
+      - 'liblouis/liblouis/liblouis.h.in'
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   js-build:

--- a/.github/workflows/macro.yml
+++ b/.github/workflows/macro.yml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - README
       - NEWS
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -4,11 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches: [ master ]
-    paths-ignore:
-      - README
-      - NEWS
+    paths:
+      - '**.h'
+      - '**.c'
+      - 'liblouis/liblouis/liblouis.h.in'
   pull_request:
     branches: [ master ]
+    paths:
+      - '**.h'
+      - '**.c'
+      - 'liblouis/liblouis/liblouis.h.in'
 
 env:
   LIBYAML_VERSION: 0.1.4


### PR DESCRIPTION
- [x] Run checkformat and cross-compilation only if any C code changed
- [x] CiFuzz could be run only on C code changes
- [x] Proposal: only run JavaScript compilation if the master branch changes
- [ ] Maybe some actions could be combined in a single workflow?
- [x] Test macro feature could also be done less frequent.
- [ ] Run costly workflows only if the main workflow succeeds
  - such as `emscripten` and `mingw` 
- [ ] Make sure `Fuzz lou_translateString` is not run in forks