### PR TITLE
Add a security policy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,25 +9,26 @@ MAIN AUTHOR
 
 CODE CONTRIBUTORS
 
-A team of three developers has taken over maintenance work since John
+A team of two developers has taken over maintenance work since John
 Boyer did a step back in 2014:
+
+Current maintainers:
 
   Christian Egli <christian.egli@sbs.ch> from SBS <www.sbs.ch>
   - maintains the build and version control systems and does releases
     on a regular basis
   - has done code contributions
-  - is one of the project maintainers
+
+  Bert Frees <bertfrees@gmail.com> for DocArch <www.docarch.be> and SBS <www.sbs.ch>
+  - has done code contributions
+  - has done table contributions as well
+
+Former maintainers:
 
   Mesar Hameed <mesar.hameed@gmail.com>
   - has done code contributions
   - has done a lot of table maintenance
   - was the main developer of the test harness
-  - is one of the project maintainers
-
-  Bert Frees <bertfrees@gmail.com> for DocArch <www.docarch.be> and SBS <www.sbs.ch>
-  - has done code contributions
-  - has done table contributions as well
-  - is one of the project maintainers
 
 Considerable coding was done by:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security issue, please email the maintainers (see
+[AUTHORS](https://github.com/liblouis/liblouis/blob/master/AUTHORS))
+with a description of the issue, the steps you took to create the
+issue, affected versions, and, if known, mitigations for the issue.
+
+Our vulnerability management team will respond within 3 working days
+of your email. If the issue is confirmed as a vulnerability, we will
+open a Security Advisory. This project follows a 90 day disclosure
+timeline.
+
+## Supported Versions
+
+Security updates are only provided for the latest version of liblouis.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ To report a security issue, please email the maintainers (see
 with a description of the issue, the steps you took to create the
 issue, affected versions, and, if known, mitigations for the issue.
 
-Our vulnerability management team will respond within 3 working days
+Our vulnerability management team will respond within 5 working days
 of your email. If the issue is confirmed as a vulnerability, we will
 open a Security Advisory. This project follows a 90 day disclosure
 timeline.


### PR DESCRIPTION
Proposal for a very simple security policy. Based on the template from https://github.com/ossf/oss-vulnerability-guide/blob/main/templates/security_policies/github_security_policy.md