### PR TITLE
Check the length of path before copying into dataPath

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ issues]].
 
 ** New features
 ** Bug fixes
+- Fix a buffer overflow error in ~lou_setDataPath~. Thanks Marsman1996
+  for reporting and Christian Egli for fixing it.
 ** Braille table improvements
 ** Other changes
 ** Deprecation notice

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -58,7 +58,7 @@ char *EXPORT_CALL
 lou_setDataPath(const char *path) {
 	static char dataPath[MAXSTRING];
 	dataPathPtr = NULL;
-	if (path == NULL) return NULL;
+	if (path == NULL || strlen(path) >= MAXSTRING) return NULL;
 	strcpy(dataPath, path);
 	dataPathPtr = dataPath;
 	return dataPathPtr;

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -283,7 +283,8 @@ lou_getEmphClasses(const char *tableList);
 /**
  * Set the path used for searching for tables and liblouisutdml files.
  *
- * Overrides the installation path. */
+ * Overrides the installation path. Returns NULL if `path` is NULL or
+ * if the length of `path` is equal or longer than `MAXSTRING`. */
 LIBLOUIS_API
 char *EXPORT_CALL
 lou_setDataPath(const char *path);


### PR DESCRIPTION
See https://lwn.net/Articles/507319/ for more background on the security problems of strcpy.

Fixes #1292