### PR TITLE
Check the path length before coping into tableFile

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4539,7 +4539,7 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 	char *tableFile;
 	static struct stat info;
 
-#define MAX_TABLEFILE_SIZE MAXSTRING * sizeof(char) * 2
+#define MAX_TABLEFILE_SIZE (MAXSTRING * sizeof(char) * 2)
 	if (table == NULL || table[0] == '\0') return NULL;
 	tableFile = (char *)malloc(MAX_TABLEFILE_SIZE);
 

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4539,7 +4539,9 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 	char *tableFile;
 	static struct stat info;
 
-	if (table == NULL || table[0] == '\0') return NULL;
+	if (table == NULL || table[0] == '\0' ||
+			strlen(table) >= MAXSTRING * sizeof(char) * 2)
+		return NULL;
 	tableFile = (char *)malloc(MAXSTRING * sizeof(char) * 2);
 
 	//
@@ -4547,10 +4549,13 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 	//
 	if (base) {
 		int k;
+		if (strlen(base) >= MAXSTRING * sizeof(char) * 2) goto failure;
 		strcpy(tableFile, base);
 		k = (int)strlen(tableFile);
 		while (k >= 0 && tableFile[k] != '/' && tableFile[k] != '\\') k--;
 		tableFile[++k] = '\0';
+		if (strlen(tableFile) + strlen(table) >= MAXSTRING * sizeof(char) * 2)
+			goto failure;
 		strcat(tableFile, table);
 		if (stat(tableFile, &info) == 0 && !(info.st_mode & S_IFDIR)) {
 			_lou_logMessage(LOU_LOG_DEBUG, "found table %s", tableFile);
@@ -4582,6 +4587,10 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 			last = (*cp == '\0');
 			*cp = '\0';
 			if (dir == cp) dir = ".";
+			if (strlen(dir) + strlen(table) + 1 >= MAXSTRING * sizeof(char) * 2) {
+				free(searchPath_copy);
+				goto failure;
+			}
 			sprintf(tableFile, "%s%c%s", dir, DIR_SEP, table);
 			if (stat(tableFile, &info) == 0 && !(info.st_mode & S_IFDIR)) {
 				_lou_logMessage(LOU_LOG_DEBUG, "found table %s", tableFile);
@@ -4589,6 +4598,10 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 				return tableFile;
 			}
 			if (last) break;
+			if (strlen(dir) + strlen(table) + 16 >= MAXSTRING * sizeof(char) * 2) {
+				free(searchPath_copy);
+				goto failure;
+			}
 			sprintf(tableFile, "%s%c%s%c%s%c%s", dir, DIR_SEP, "liblouis", DIR_SEP,
 					"tables", DIR_SEP, table);
 			if (stat(tableFile, &info) == 0 && !(info.st_mode & S_IFDIR)) {
@@ -4600,6 +4613,7 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 		}
 		free(searchPath_copy);
 	}
+failure:
 	free(tableFile);
 	return NULL;
 }

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4539,23 +4539,21 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 	char *tableFile;
 	static struct stat info;
 
-	if (table == NULL || table[0] == '\0' ||
-			strlen(table) >= MAXSTRING * sizeof(char) * 2)
-		return NULL;
-	tableFile = (char *)malloc(MAXSTRING * sizeof(char) * 2);
+#define MAX_TABLEFILE_SIZE MAXSTRING * sizeof(char) * 2
+	if (table == NULL || table[0] == '\0') return NULL;
+	tableFile = (char *)malloc(MAX_TABLEFILE_SIZE);
 
 	//
 	// First try to resolve against base
 	//
 	if (base) {
 		int k;
-		if (strlen(base) >= MAXSTRING * sizeof(char) * 2) goto failure;
+		if (strlen(base) >= MAX_TABLEFILE_SIZE) goto failure;
 		strcpy(tableFile, base);
 		k = (int)strlen(tableFile);
 		while (k >= 0 && tableFile[k] != '/' && tableFile[k] != '\\') k--;
 		tableFile[++k] = '\0';
-		if (strlen(tableFile) + strlen(table) >= MAXSTRING * sizeof(char) * 2)
-			goto failure;
+		if (strlen(tableFile) + strlen(table) >= MAX_TABLEFILE_SIZE) goto failure;
 		strcat(tableFile, table);
 		if (stat(tableFile, &info) == 0 && !(info.st_mode & S_IFDIR)) {
 			_lou_logMessage(LOU_LOG_DEBUG, "found table %s", tableFile);
@@ -4567,6 +4565,7 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 	// It could be an absolute path, or a path relative to the current working
 	// directory
 	//
+	if (strlen(table) >= MAX_TABLEFILE_SIZE) goto failure;
 	strcpy(tableFile, table);
 	if (stat(tableFile, &info) == 0 && !(info.st_mode & S_IFDIR)) {
 		_lou_logMessage(LOU_LOG_DEBUG, "found table %s", tableFile);
@@ -4587,7 +4586,7 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 			last = (*cp == '\0');
 			*cp = '\0';
 			if (dir == cp) dir = ".";
-			if (strlen(dir) + strlen(table) + 1 >= MAXSTRING * sizeof(char) * 2) {
+			if (strlen(dir) + strlen(table) + 1 >= MAX_TABLEFILE_SIZE) {
 				free(searchPath_copy);
 				goto failure;
 			}
@@ -4598,7 +4597,8 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 				return tableFile;
 			}
 			if (last) break;
-			if (strlen(dir) + strlen(table) + 16 >= MAXSTRING * sizeof(char) * 2) {
+			if (strlen(dir) + strlen("liblouis") + strlen("tables") + strlen(table) + 3 >=
+					MAX_TABLEFILE_SIZE) {
 				free(searchPath_copy);
 				goto failure;
 			}


### PR DESCRIPTION
Fix #1291.

Add check for path length before every string-related functions.