### PR TITLE
Deprecate lou_setDataPath and lou_getDataPath

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,7 +28,19 @@ issues]].
 - Simplify the Danish test to contain fewer files thanks to Bue
   Vester-Andersen and Bert Frees.
 ** Deprecation notice
-- None
+- The ~lou_setDataPath~ and ~lou_getDataPath~ functions have been
+  deprecated. Please migrate to one of the other ways to set the table
+  search path:
+  - The recommended and most straightforward way to set the search
+    path is to set the ~LOUIS_TABLEPATH~ environment variable.
+  - You can also set a custom table resolver function through
+    ~lou_registerTableResolver~.
+  - If you use the metadata based query API and haven't set the
+    ~LOUIS_TABLEPATH~ environment variable, you can use the
+    ~lou_indexTables~ function to tell Liblouis which files (not
+    directories) to search.
+  - Finally, there is the fallback solution of using absolute file
+    paths.
 ** Backwards incompatible changes
 ** Invisible changes
 ** New, renamed or removed tables

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -56,6 +56,7 @@ static char *dataPathPtr;
 
 char *EXPORT_CALL
 lou_setDataPath(const char *path) {
+	_lou_logMessage(LOU_LOG_WARN, "warning: lou_setDataPath is deprecated.");
 	static char dataPath[MAXSTRING];
 	dataPathPtr = NULL;
 	if (path == NULL || strlen(path) >= MAXSTRING) return NULL;
@@ -66,6 +67,7 @@ lou_setDataPath(const char *path) {
 
 char *EXPORT_CALL
 lou_getDataPath(void) {
+	_lou_logMessage(LOU_LOG_WARN, "warning: lou_getDataPath is deprecated.");
 	return dataPathPtr;
 }
 

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -284,13 +284,22 @@ lou_getEmphClasses(const char *tableList);
  * Set the path used for searching for tables and liblouisutdml files.
  *
  * Overrides the installation path. Returns NULL if `path` is NULL or
- * if the length of `path` is equal or longer than `MAXSTRING`. */
+ * if the length of `path` is equal or longer than `MAXSTRING`.
+ *
+ * @deprecated Please migrate to one of the other ways to set the
+ * table search path. See the NEWS file for details.
+ */
+
 LIBLOUIS_API
 char *EXPORT_CALL
 lou_setDataPath(const char *path);
 
 /**
- * Get the path set in the previous function. */
+ * Get the path set in the previous function.
+ *
+ * @deprecated Please migrate to one of the other ways to get the
+ * table search path. See the NEWS file for details.
+ */
 LIBLOUIS_API
 char *EXPORT_CALL
 lou_getDataPath(void);


### PR DESCRIPTION
There are several other ways to set the table search path:

- The recommended and most straightforward way to set the search path is to set the LOUIS_TABLEPATH environment variable.
- You can also set a custom table resolver function through lou_registerTableResolver.
- If you use the metadata based query API and haven't set the LOUIS_TABLEPATH environment variable, you can use the lou_indexTables function to tell Liblouis which files (not directories) to search.
- Finally, there is always the fallback solution of using absolute file paths.

Fixes https://github.com/liblouis/liblouis/issues/1298