### PR TITLE
Add newforward and backward exceptions and new testcases in hungarian Braille tables

### DIFF
--- a/tables/hu-backtranslate-word-corrections.cti
+++ b/tables/hu-backtranslate-word-corrections.cti
@@ -856,6 +856,7 @@ nofor correct "Hússzed"	* For example hússzedő word not need apply the genera
 nofor correct "ússzed" "úszszed"	For example túszszedő word backtranslation correction
 nofor correct "utásszak" "utászszak"	For example utászszakasz, utászszakaszaiban words backtranslation correction
 nofor correct "tásszáz" "tászszáz"	For example utásszázad, utászszázadból words backtranslation correction
+nofor correct "TÁSSZÁZ" "TÁSZSZÁZ"	For example UTÁSZSZÁZADBA word
 nofor correct "vadásszáz" "vadászszáz"	For example vadászszázad, vadászszázadban words backtranslation correction
 nofor correct "Vadásszáz" "Vadászszáz"	For example Vadászszázad word
 nofor correct "VADÁSSZÁZ" "VADÁSZSZÁZ"	For example VADÁSZSZÁZAD word
@@ -1656,6 +1657,9 @@ nofor correct "Szösszűr" "Szöszszűr"	For example Szöszszűrőt word
 nofor correct "SZÖSSZŰR" "SZÖSZSZŰR"	For example SZÖSZSZŰRŐT word
 nofor correct "ókusszí" "ókuszszí"	For example kókuszszívet word
 nofor correct "ÓKUSSZÍ" "ÓKUSZSZÍ"	For example KÓKUSZSZÍVET word
+nofor correct "szesszag" "szeszszag"	For example szeszszagú word
+nofor correct "Szesszag" "Szeszszag"	For example Szeszszagú word
+nofor correct "SZESSZAG" "SZESZSZAG"	For example SZESZSZAGÚ word
 
 #zszs backtranslated word corrections
 nofor correct "törzszsel" "törzzsel"

--- a/tables/hu-backtranslate-word-corrections.cti
+++ b/tables/hu-backtranslate-word-corrections.cti
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2022 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2011-2023 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #
@@ -28,55 +28,103 @@
 #Because in hungarian Braille usual the dot combinations equals with single consonants letters and double consonants letters (for example 146 with cs, 146-146 with ccs, and 146-146 with cscs), need doing last correction when happening a back translation
 #cscs, ccs word part related backtranslate corrections
 nofor correct "aganccsap" "agancscsap"	For example agancscsapról word
+nofor correct "Aganccsap" "Agancscsap"	For example Agancscsapról word
+nofor correct "AGANCCSAP" "AGANCSCSAP"	for example AGANCSCSAPRÓL word
 nofor correct "aganccsatt" "agancscsatt"	For example agancscsattogásának word
+nofor correct "Aganccsatt" "Agancscsatt"	For example Agancscsattogásának word
+nofor correct "AGANCCSATT" "AGANCSCSATT"	For example AGANCSCSATTOGÁSÁNAK word
 nofor correct "apoccsont" "apocscsont"	For example álkapocscsont, szárkapocscsont, szárkapocscsonttal word part corrections
-nofor correct "Csúccsap" "Csúcscsap"	For example Csúcscsapat word
+nofor correct "APOCCSONT" "APOCSCSONT"	For example SZÁRKAPOCSCSONT word
 nofor correct "csúccsap" "csúcscsap"	For example csúcscsapat word
+nofor correct "Csúccsap" "Csúcscsap"	For example Csúcscsapat word
+nofor correct "CSÚCCSAP" "CSÚCSCSAP"	For example CSÚCSCSAPATAINAK word
 nofor correct "kapocscsal" "kapoccsal"
+nofor correct "Kapocscsal" "Kapoccsal"
+nofor correct "KAPOCSCSAL" "KAPOCCSAL"
 nofor correct "rkölccső" "rkölcscső"	For example erkölcscsősz, erkölcscsősszel words backtranslation correction
+nofor correct "RKÖLCCSŐ" "RKÖLCSCSŐ"	For example ERKÖLCSCSŐSZ word correction
 nofor correct "furdanccsi" "furdancscsi"	With furdancscsiga backtranslation correction
+nofor correct "Furdanccsi" "Furdancscsi"	For example Furdancscsiga word
+nofor correct "FURDANCCSI" "FURDANCSCSI"	For example FURDANCSCSIGA word
 nofor correct "habarccsö" "habarcscsö"	For example habarcscsövekkel, habarcscsövet words backtranslation word correction
+nofor correct "Habarccsö" "Habarcscsö"	For example Habarcscsövekkel word
+nofor correct "HABARCCSÖ" "HABARCSCSÖ"	For example HABARCSCSÖVEKKEL word
 nofor correct "habarccső" "habarcscső"	Similar correction, for example habarcscsővel, habarcscső word
 nofor correct "orbáccsap" "orbácscsap"	For example korbácscsapás word backtranslation correction
+nofor correct "ORBÁCCSAP" "ORBÁCSCSAP"	For example KORBÁCSCSAPÁSKÉNT word
 nofor correct "ulccse" "ulcscse"	With kulcscsere word part backtranslation correction
+nofor correct "ULCCSE" "ULCSCSE"	For example with KULCCSERE word
 nofor correct "ulccso" "ulcscso"	For example kulcscsomó, kulcscsomag, kulcscsont backtranslation words corrections
+nofor correct "ULCCSO" "ULCSCSO"	For example KULCSCSONT word
 nofor correct "ulccsö" "ulcscsö"	For example áfakulcscsökkentés, kulcscsörgés words backtranslation correction
+nofor correct "ULCCSÖ" "ULCSCSÖ"	For example ÁFAKULCSCSÖKKENTÉS word
 nofor correct "ullanccsi" "ullancscsi"	With kullancscsipesz word part correction
+nofor correct "ULLANCCSI" "ULLANCSCSI"	For example KULLANCSCSIPESZ word
 nofor correct "ullanccsí" "ullancscsí"	With kullancscsípés word correction
+nofor correct "ULLANCCSÍ" "ULLANCSCSÍ"	For example KULLANCSCSÍPÉS word
 nofor correct "anccsap" "ancscsap"	For example mancsapással word backtranslation
+nofor correct "ANCCSAP" "ANCSCSAP"	For example MANCSCSAPÁSSAL word
 nofor correct "kinccsemp" "kincscsemp"	With műkincscsempész word part backtranslation
+nofor correct "KINCCSEMP" "KINCSCSEMP"	For example MŰKINCSCSEMPÉSZ word
 nofor correct "felejccsok" "felejcscsok"	For example nefelejcscsokorral word part
+nofor correct "FELEJCCSOK" "FELEJCSCSOK"	For example NEFELEJCSCSOKOR word
 nofor correct "akáccsap" "akácscsap"	For example szakácscsapat word
+nofor correct "AKÁCCSAP" "AKÁCSCSAP"	For example SZAKÁCSCSAPAT word
 nofor correct "endviccsi" "endvicscsi"	For example szendvicscsinálás word
+nofor correct "ENDVICCSI" "ENDVICSCSI"	For example SZENDVICSCSINÁLÁS word
 nofor correct "anáccsap" "anácscsap"
+nofor correct "ANÁCCSAP" "ANÁCSCSAP"
 nofor correct "anáccsop" "anácscsop"	For example tanácscsoport word correction
+nofor correct "ANÁCCSOP" "ANÁCSCSOP"	For example TANÁCSCSOPORT word
 nofor correct "artácscsal" "artáccsal"	For example fémkartáccsal, kartáccsal words backtranslation
+nofor correct "ARTÁCSCSAL" "ARTÁCCSAL"	For example FÉMKARTÁCCSAL word
 nofor correct "arancscsal" "aranccsal"
 nofor correct "ARANCSCSAL" "ARANCCSAL"
 nofor correct "ronccsalá" "roncscsalá"	For example abroncscsalád, gumiabroncscsalád words
+nofor correct "RONCCSALÁ" "RONCSCSALÁ"	For example ABRONCSCSALÁD word
 nofor correct "ronccser" "roncscser"	For example abroncscsere, gumiabroncscsere words
+nofor correct "RONCCSER" "RONCSCSER"	For example ABRONCSCSERE WORD
 nofor correct "unccsod" "uncscsod"	For example puncscsoda word
+nofor correct "UNCCSOD" "UNCSCSOD"	For example PUNCSCSODA word
 nofor correct "akanccsó" "akancscsó"	For example bakancscsók word
+nofor correct "AKANCCSÓK" "AKANCSCSÓK"	For example BAKANCSCSÓK word
 nofor correct "abronccsapd" "abroncscsapd"	For example gumiabroncscsapda word
 nofor correct "Abronccsapd" "Abroncscsapd"	For example Abroncscsapda word
+nofor correct "ABRONCCSAPD" "ABRONCSCSAPD"	For example GUMIABRONCSCSAPDA word 
 nofor correct "ullanccsecs" "ullancscsecs"	For example kullancscsecsemő word
+nofor correct "ULLANCCSECS" "ULLANCSCSECS"	For example KULLANCSCSECSEMŐ word
 nofor correct "endviccsoma" "endvicscsoma"	For example szendvicscsomagoló word
+nofor correct "ENDVICCSOMA" "ENDVICSCSOMA"	For example SZENDVICSCSOMAGOLÓ word
 nofor correct "gánccsapa" "gáncscsapa"	For example cselgáncscsapat word
+nofor correct "GÁNCCSAPA" "GÁNCSCSAPA"	For example CSELGÁNCSCSAPAT word
 nofor correct "kviddiccsapa" "kviddicscsapa"	For example kviddicscsapat word
+nofor correct "KVIDDICCSAPA" "KVIDDICSCSAPA"	For example KVIDDICSCSAPAT word
 nofor correct "úccsat" "úcscsat"	For example csúcscsatája word
+nofor correct "ÚCCSAT" "ÚCSCSAT"	For example CSÚCSCSATÁJA word
 nofor correct "úccsont" "úcscsont"	For example csúcscsonttömeg word
+nofor correct "ÚCCSONT" "ÚCSCSONT"	For example CSÚCSCSONTTÖMEG word
 nofor correct "aláccso" "alácscso"	For example kalácscsoda word
+nofor correct "ALÁCCSO" "ALÁCSCSO"	For example KALÁCSCSODA word
 nofor correct "örccsi" "örcscsi"	For example görcscsillapító word
+nofor correct "ÖRCCSI" "ÖRCSCSI"	For example GÖRCSCSILLAPÍTÁS word
 nofor correct "accsőr" "acscsőr"	For example Kacscsőrű word
+nofor correct "ACCSŐR" "ACSCSŐR"	For example KACSCSŐRŰ word
 nofor correct "ümölccsom" "ümölcscsom"	For example gyümölcscsomagolás word
+nofor correct "ÜMÖLCCSOM" "ÜMÖLCSCSOM"	For example GYÜMÖLCSCSOMAGOLÓ word
 nofor correct "elgánccsar" "elgáncscsar"	For example cselgáncscsarnok word
+nofor correct "ELGÁNCCSAR" "ELGÁNCSCSAR"	For example CSELGÁNCSCSARNOK word
 nofor correct "akáccsom" "akácscsom"	For example takácscsomót word
+nofor correct "AKÁCCSOM" "AKÁCSCSOM"	For example TAKÁCSCSOMÓT word
 nofor correct "inccsalá" "incscsalá"	For example műkincscsalás word
+nofor correct "INCCSALÁ" "INCSCSALÁ"	For example MŰKINCSCSALÁS word
 nofor correct "ulaccser" "ulacscser"	For example kulacscsere word
+nofor correct "ULACCSER" "ULACSCSER"	For example KULACSCSERE word
 nofor correct "apuccsőr" "apucscsőr"	For example papucscsőrű word
+nofor correct "APUCCSŐR" "APUCSCSŐR"	For example PAPUCSCSŐRŰ word
 nofor correct "ilinccsop" "ilincscsop"	For example bilincscsoport word
 nofor correct "ILINCCSOP" "ILINCSCSOP"	For example BILINCSCSOPORT word
 nofor correct "apuccsod" "apucscsod"	For example papucscsoda word
+nofor correct "APUCCSOD" "APUCSCSOD"	For example PAPUCSCSODA word
 nofor correct "csúccsö" "csúcscsö"	For example csúcscsökkentő word
 nofor correct "CSÚCCSÖ" "CSÚCSCSÖ"	For example CSÚCSCSÖKKENTŐ word
 nofor correct "ümölccsen" "ümölcscsen"	For example gyümölcscsendélet word
@@ -92,66 +140,124 @@ nofor correct "Csúccsok" "Csúcscsok"	For example Csúcscsoki word
 nofor correct "CSÚCCSOK" "CSÚCSCSOK"	For example CSÚCSCSOKI word
 nofor correct "ümölccserj" "ümölcscserj"	For example gyümölcscserjéket word
 nofor correct "ÜMÖLCCSERJ" "ÜMÖLCSCSERJ"	For example GYÜMÖLCSCSERJÉKET word
+nofor correct "ilinccsatla" "ilincscsatla"	For example bilincscsatlakozó word
+nofor correct "ILINCCSATLA" "ILINCSCSATLA"	For example BILINCSCSATLAKOZÓ word
+nofor correct "ivaccsí" "ivacscsí"	For example szivacscsíkokból word
+nofor correct "IVACCSÍ" "IVACSCSÍ"	For example SZIVACSCSÍKOKBÓL word
+nofor correct "alapáccsatt" "alapácscsatt"	For example kalapácscsattogás word
+nofor correct "ALAPÁCCSATT" "ALAPÁCSCSATT"	For example KALAPÁCSCSATTOGÁS word
+nofor correct "endviccsod" "endvicscsod"	For example szendvicscsoda word
+nofor correct "ENDVICCSOD" "ENDVICSCSOD"	For example SZENDVICSCSODA word
+nofor correct "csúccsúcs" "csúcscsúcs"	For example csúcscsúcszenekar word
+nofor correct "Csúccsúcs" "Csúcscsúcs"	For example Csúcscsúcszenekar word
+nofor correct "CSÚCCSÚCS" "CSÚCSCSÚCS"	For example CSÚCSCSÚCSZENEKAR word
+nofor correct "ronccsí" "roncscsí"	For example abroncscsíkok word
+nofor correct "RONCCSÍ" "RONCSCSÍ"	For example ABRONCSCSÍKOK word
+nofor correct "orbáccsatt" "orbácscsatt"	For example korbácscsattogtatás word
+nofor correct "ORBÁCCSATT" "ORBÁCSCSATT"	For example KORBÁCSCSATTOGTATÁS word
+nofor correct "gyolccsí" "gyolcscsí"	For example gyolcscsíkok word
+nofor correct "Gyolccsí" "Gyolcscsí"	For example Gyolcscsíkok word
+nofor correct "GYOLCCSÍ" "GYOLCSCSÍ"	For example GYOLCSCSÍKOK word
+nofor correct "úccsipk" "úcscsipk"	For example csúcscsipkét word
+nofor correct "ÚCCSIPK" "ÚCSCSIPK"	For example CSÚCSCSIPKÉT word
+nofor correct "ümölccsokr" "ümölcscsokr"	For example gyümölcscsokrot word
+nofor correct "ÜMÖLCCSOKR" "ÜMÖLCSCSOKR"	For example GYÜMÖLCSCSOKROT word
+nofor correct "ümölccsal" "ümölcscsal"	For example gyümölcscsalád word
+nofor correct "ÜMÖLCCSAL" "ÜMÖLCSCSAL"	For example GYÜMÖLLCSCSALÁD word
+nofor correct "ivaccsizm" "ivacscsizm"	For example szivacscsizmában word
+nofor correct "IVACCSIZM" "IVACSCSIZM"	For example SZIVACSCSIZMÁBAN word
 
 #ggy, gygy backtranslation rule corrections
 nofor correct "szalaggyak" *
 nofor correct "aggyakorla" "agygyakorla"	For example agygyakorlat word
+nofor correct "Aggyakorla" "Agygyakorla"	For example Agygyakorlat word
+nofor correct "AGGYAKORLA" "AGYGYAKORLA"	For example AGYGYAKORLAT word
 nofor correct "jeggyűj" "jegygyűj"	For example bankjegygyűjtő word
 nofor correct "Jeggyűj" "Jegygyűj"	For example Jegygyűjtő word
+nofor correct "JEGGYŰJ" "JEGYGYŰJ"	For example BANKJEGYGYŰJTŐ word
 nofor correct "jeggyil" "jegygyil"	For example bankjegygyilkos word
 nofor correct "jeggyűr" "jegygyűr"	For example jegygyűrű, jegygyűrűvel words backtranslation correction
 nofor correct "Jeggyűr" "Jegygyűr"	For example Jegygyűrű word
+nofor correct "JEGGYŰR" "JEGYGYŰR"	For example JEGYGYŰRŰ word
 nofor correct "árggyű" "árgygyű"	For example tárgygyűjtemény, kegytárgygyűjtemény words backtranslation corrections
+nofor correct "ÁRGGYŰ" "ÁRGYGYŰ"	For example TÁRGYGYŰJTEMÉNY word
 nofor correct "apággyá" "apágygyá"	For example csapágygyár, csapágygyártás, csapágygyárában word
+nofor correct "APÁGGYÁ" "APÁGYGYÁ"	For example CSAPÁGYGYÁR word
 nofor correct "apággyűr" "apágygyűr"	For example csapágygyűrűinek word
+nofor correct "APÁGGYŰR" "APÁGYGYŰR"	For example CSAPÁGYGYŰRŰINEK word
 nofor correct "eggyerme" "egygyerme"	For example egygyermekes word
 nofor correct "Eggyerme" "Egygyerme"	For example Egygyermekes word
+nofor correct "EGGYERME" "EGYGYERME"	For example EGYGYERMEKESEK word
 nofor correct "leggyere" *	For example leggyerekesebb word not need apply the next exception
 nofor correct "eggyere" "egygyere"	For example egygyerekes word need apply a special backtranslation correction 
 nofor correct "Leggyere" *
+nofor correct "LEGGYERE" *
 nofor correct "Eggyere" "Egygyere"	For example egygyerekes word
+nofor correct "EGGYERE" "EGYGYERE"	For example EGYGYEREKES word
 nofor correct "éggyerek" "égygyerek"	For example négygyerekes word
+nofor correct "ÉGGYEREK" "ÉGYGYEREK"	For example NÉGYGYEREKES word
 nofor correct "ogággyul" "ogágygyul"	For example fogágygyulladás word
+nofor correct "OGÁGGYULL" "OGÁGYGYULL"	For example FOGÁGYGYULLADÁS word
 nofor correct "Néggyerm" "Négygyerm"	For example Négygyermekes word
+nofor correct "NÉGGYERM" "NÉGYGYERM"	For example NÉGYGYERMEKES word
 nofor correct "néggyerm" "négygyerm"	For example négygyermekes word
 nofor correct "naggyű" "nagygyű"	For example nagygyűlés, nagygyűlésen words backtranslation correction
 nofor correct "Naggyű" "Nagygyű"	For example Nagygyűlés, Nagygyűlésen words backtranslation correction
+nofor correct "NAGGYŰ" "NAGYGYŰ"	For example NAGYGYŰLÉSEN word
 nofor correct "tőggyull" "tőgygyull"	For example tőgygyulladás word backtranslation correction
 nofor correct "Tőggyull" "Tőgygyull"	For example Tőgygyulladás word
+nofor correct "TŐGGYULL" "TŐGYGYULL"	For example TŐGYGYULLADÁS word
 nofor correct "iriggyull" "irigygyull"	For example pajzsmirigygyulladás, pajzsmirigygyulladást words
+nofor correct "IRIGGYULL" "IRIGYGYULL"	For example MIRIGYGYULLADÁS word
 nofor correct "gyönggyárt" "gyöngygyárt"	For example üveggyöngygyártás, gyöngygyártás words
 nofor correct "Gyöngygyárt" "Gyöngygyárt"	For example Gyöngygyártás word
 nofor correct "ggyökerű" "gygyökerű"	For example egygyökerű, Egygyökerű, egygyökerűség, Egygyökerűség words
 nofor correct "GGYÖKERŰ" "GYGYÖKERŰ"	For example the full uppercase version
 nofor correct "iriggyógy" "irigygyógy"	For example pajzsmirigygyógyszerek word
+nofor correct "IRIGGYÓGY" "IRIGYGYÓGY"	For example PAJZSMIRIGYGYÓGYSZERÉT word
 nofor correct "ankjeggyár" "ankjegygyár"	For example bankjegygyártó word
+nofor correct "ANKJEGGYÁR" "ANKJEGYGYÁR"	For example BANKJEGYGYÁRTÓ word
 nofor correct "aggyimó" "agygyimó"	For example Nagygyimót, nagygyimóti words
+nofor correct "AGGYIMÓ" "AGYGYIMÓ"	For example NAGYGYIMÓT word
 nofor correct "rüggyapot" "rügygyapot"	For example rügygyapot word
 nofor correct "Rüggyapot" "Rügygyapot"
+nofor correct "RÜGGYAPOT" "RÜGYGYAPOT"	For example RÜGYGYAPOT word
 nofor correct "zveggyár" "zvegygyár"	For example özvegygyártónak word
+nofor correct "ZVEGGYÁR" "ZVEGYGYÁR"	For example ÖZVEGYGYÁR word
 nofor correct "ággyártók" "ágygyártók"
 nofor correct "Ággyártók" "Ágygyártók"
 nofor correct "aggyalu" "agygyalu"	For example agygyalu word
 nofor correct "Aggyalu" "Agygyalu"	For example Agygyalu word
+nofor correct "AGGYALU" "AGYGYALU"	for example AGYGYALU word
 nofor correct "aggyanú" "agygyanú"	For example fagygyanús word
+nofor correct "AGGYANÚ" "AGYGYANÚ"	For example FAGYGYANÚS word 
 nofor correct "leggyüm" *
 nofor correct "Leggyüm" *
 nofor correct "éreggyüm" *
 nofor correct "eggyüm" "egygyüm"	For example egygyümölcsös word
+nofor correct "Eggyüm" "Egygyüm"	For example Egygyümölcsös word
+nofor correct "EGGYÜM" "EGYGYÜM"	For example EGYGYÜMÖLCSÖS word
 nofor correct "eteggy" *	For example beteggyógyász, beteggyanús, cukorbeteggyermek-táborok words
+nofor correct "ETEGGY" *	For example BETEGGYÓGYÁSZ, BETEGGYANÚS, CUKORBETEGGYERMEK-TÁBOROK words
+
 nofor correct "herceggy" *	For example herceggyermek word
+nofor correct "Herceggy" *	For example Herceggyermeket word
+nofor correct "HERCEGGY" *	For example HERCEGGYERMEKET word
 nofor correct "árggyar" "árgygyar"	For example műtárgygyarapodás word
 nofor correct "azeinjeggyár" "azeinjegygyár"	For example kazeinjegygyár word
 nofor correct "ággyull" "ágygyull"	For example körömágygyulladás word
+nofor correct "ÁGGYULL" "ÁGYGYULL"	For example KÖRÖMÁGYGYULLADÁS word
 nofor correct "ggyőzelemn" "gygyőzelemn"	For example egygyőzelem word
+nofor correct "GGYŐZELEMN" "GYGYŐZELEMN"	For example EGYGYŐZELEM word
 nofor correct "vággyil" "vágygyil"	For example vágygyilkos word
 nofor correct "Vággyil" "Vágygyil"	For example Vágygyilkos word
 nofor correct "VÁGGYIL" "VÁGYGYIL"	For example VÁGYGYILKOS word
 nofor correct "árggyor" "árgygyor"	For example tárgygyorsítás word
 nofor correct "ásszúny" "ászszúny"	For example gyászszúnyog word
 nofor correct "ÁSSZÚNY" "ÁSZSZÚNY"	For example GYÁSZSZÚNYOG word
-nofor context [@1-1456-1456-136-123-123-1-145-4-234] "agygyulladás"	For example agygyulladás word backtranslation correction
-nofor context [@46-1-1456-1456-136-123-123-1-145-4-234] "Agygyulladás"	For example agygyulladás word backtranslation correction
+nofor correct "aggyulladás" "agygyulladás"	For example agygyulladás word
+nofor correct "Aggyulladás" "Agygyulladás"	For example Agygyulladás word
+nofor correct "AGGYULLADÁS" "AGYGYULLADÁS"	For example AGYGYULLADÁS word
 nofor correct "endéggyere" *	For example vendéggyerek word
 nofor correct "ENDÉGGYERE" *	For example VENDÉGGYEREK word
 nofor correct "eggyűrűs" "egygyűrűs"	For example egygyűrűs word
@@ -177,57 +283,121 @@ nofor correct "LEGGYÖNYÖR" *	For example LEGGYÖNYÖRŰBB word not need apply 
 nofor correct "eggyönyör" "egygyönyör"	For example egygyönyör word
 nofor correct "Eggyönyör" "Egygyönyör"	For example Egygyönyörű word
 nofor correct "EGGYÖNYÖR" "EGYGYÖNYÖR"	For example EGYGYÖNYÖR word
-nofor correct "hazugsággy" *    For example hazugsággyártó word
-nofor correct "Hazugsággy" *    For example Hazugsággyártó word
-nofor correct "HAZUGSÁGGY" *    For example HAZUGSÁGGYÁRTÓ word
+nofor correct "hazugsággy" *	For example hazugsággyártó word
+nofor correct "Hazugsággy" *	For example Hazugsággyártó word
+nofor correct "HAZUGSÁGGY" *	For example HAZUGSÁGGYÁRTÓ word
 nofor correct "ággyártó" "ágygyártó"	For example ágygyártó word
 nofor correct "Ággyártó" "Ágygyártó"	For example Ágygyártó word
 nofor correct "ÁGGYÁRTÓ" "ÁGYGYÁRTÓ"	For example ÁGYGYÁRTÓ word
+nofor correct "űnüggyilk" "űnügygyilk"	For example bűnügygyilkossági word
+nofor correct "ŰNÜGGYILK" "ŰNÜGYGYILK"	For example BŰNÜGYGYILKOSSÁGI word
+nofor correct "keggyak" "kegygyak"	For example kegygyakorlás word
+nofor correct "Keggyak" "Kegygyak"	For example Kegygyakorlás word
+nofor correct "KEGGYAK" "KEGYGYAK"	For example KEGYGYAKORLÁS word
+nofor correct "árggyárt" "árgygyárt"	For example tárgygyártási word
+nofor correct "ÁRGGYÁRT" "ÁRGYGYÁRT"	For example TÁRGYGYÁRTÁSI word
+nofor correct "aggyötr" "agygyötr"	For example agygyötrő word
+nofor correct "Aggyötr" "Agygyötr"	For example Agygyötrő word
+nofor correct "AGGYÖTR" "AGYGYÖTR"	For example AGYGYÖTRŐ word
+nofor correct "űnüggyorsul" "űnügygyorsul"	For example bűnügygyorsulási word
+nofor correct "ŰNÜGGYORSUL" "ŰNÜGYGYORSUL"	For example BŰNÜGYGYORSULÁSI word
+nofor correct "szalaggyull" *	For example hangszalaggyulladás, ínszalaggyulladás words
+nofor correct "SZALAGGYULL" *	For example HANGSZALAGGYULLADÁS, ÍNSZALAGGYULLADÁS words
+nofor correct "ólyaggyull" *	For example hólyaggyulladás word
+nofor correct "ÓLYAGGYULL" *	For example HÓLYAGGYULLADÁS word
+nofor correct "jeggyártó" "jegygyártó"	For example jegygyártó word
+nofor correct "Jeggyártó" "Jegygyártó"	For example Jegygyártó word
+nofor correct "JEGGYÁRTÓ" "JEGYGYÁRTÓ"	For example JEGYGYÁRTÓ word
+nofor correct "jeggyáros" "jegygyáros"	For example jegygyáros word
+nofor correct "Jeggyáros" "Jegygyáros"	For example Jegygyáros word
+nofor correct "JEGGYÁROS" "JEGYGYÁROS"	For example JEGYGYÁROS word
+nofor correct "leggyermek" *	For example leggyermekibb word
+nofor correct "Leggyermek" *	For example Leggyermekibb word
+nofor correct "LEGGYERMEK" *	For example LEGGYERMEKIBB word
 
 #nyny, nyny letters related backtranslate corrections
 nofor correct "rannyak" "ranynyak"	For example aranynyakláncának word
+nofor correct "RANNYAK" "RANYNYAK"	For example ARANYNYAKLÁNC word
 nofor correct "rannyel" "ranynyel"	For example aranynyelű word
+nofor correct "RANNYEL" "RANYNYEL"	For example ARANYNYELŰ word
 nofor correct "rannyer" "ranynyer"	For example aranynyerges word
+nofor correct "RANNYER" "RANYNYER"	For example ARANYNYEREG word
 nofor correct "rannyom" "ranynyom"	For example aranynyomással word
+nofor correct "RANNYOM" "RANYNYOM"	For example ARANYNYOMÁS word
 nofor correct "sszonnyer" "sszonynyer"	For example asszonynyereg, Asszonynyereg words back translation
+nofor correct "SSZONNYER" "SSZONYNYER"	For example ASSZONYNYEREG word
 nofor correct "áránnyak" "áránynyak"	For example báránynyak word
+nofor correct "ÁRÁNNYAK" "ÁRÁNYNYAK"	For example BÁRÁNYNYAK word
 nofor correct "áránnyelv" "áránynyelv"	For example báránynyelv, báránynyelvből, báránynyelvvel words
-nofor correct "báránnyí" "báránynyí"	For example báránynyíróként word back translation
+nofor correct "ÁRÁNNYELV" "ÁRÁNYNYELV"	for example BÁRÁNYNYELVVEL word
+nofor correct "áránnyí" "áránynyí"	For example báránynyíróként word back translation
+nofor correct "ÁRÁNNYÍ" "ÁRÁNYNYÍ"	For example BÁRÁNYNYÍRÓ word
 nofor correct "oszorkánnyom" "oszorkánynyom"
+nofor correct "OSZORKÁNNYOM" "OSZORKÁNYNYOM"
 nofor correct "ákánnyél" "ákánynyél"	For example csákánnyél, csákánynyélből, csákánynyél words
+nofor correct "ÁKÁNNYÉL" "ÁKÁNYNYÉL"	For example CSÁKÁNYNYÉL word
 nofor correct "énnyal" "énynyal"	For example edénynyalábokban, edénynyalábokból, edénynyalábról, fénynyalábbal, fénynyalábból, fénynyalábokban, fénynyalábokkal word
+nofor correct "ÉNNYAL" "ÉNYNYAL"	For example FÉNYNYALÁB word
 nofor correct "énnyomá" "énynyomá"	For example fénynyomással, fényomás words
+nofor correct "ÉNNYOMÁ" "ÉNYNYOMÁ"	For example FÉNYNYOMÁS word
 nofor correct "énnyoma" "énynyoma"	For example fénynyomatban, fénynyomatból, fénynyomatról, fénynyomattól words
+nofor correct "ÉNNYOMA" "ÉNYNYOMA"	For example FÉNYNYOMAT word
 nofor correct "énnyomt" "énynyomt"	For example fénynyomtatás word
+nofor correct "ÉNNYOMT" "ÉNYNYOMT"	For example FÉNYNYOMTATÁS word
 nofor correct "kmánnyom" "kmánynyom"	For example okmánynyomtatásban word
+nofor correct "KMÁNNYOM" "KMÁNYNYOM"	For example OKMÁNYNYOMTATÁS word
 nofor correct "ampánnyil" "ampánynyil"	For example kampánynyilatkozat word
+nofor correct "AMPÁNNYIL" "AMPÁNYNYIL"	For example KAMPÁNYNYILATKOZAT word
 nofor correct "ampánnyit" "ampánynyit"	For example kampánynyitó word backtranslation correction
+nofor correct "AMPÁNNYIT" "AMPÁNYNYIT"	For example KAMPÁNYNYITÓ word
 nofor correct "eménnyak" "eménynyak"	For example keménynyakú word backtranslation correction
+nofor correct "EMÉNNYAK" "EMÉNYNYAK"	For example KEMÉNYNYAKÚ word
 nofor correct "ötvénnyil" "ötvénynyil"	For example kötvénynyilvántartás, kötvénynyilvántartó words
+nofor correct "ÖTVÉNNYIT" "ÖTVÉNYNYIT"	For example KÖTVÉNYNYILVÁNTARTÁS word
 nofor correct "ersennyit" "ersenynyit"	For example hangversenynyitány backtranslation correction
+nofor correct "ERSENNYIT" "ERSENYNYIT"	For example VERSENYNYITÁNY word
 nofor correct "ersennyom" "ersenynyom"	For example versenynyomásra word
+nofor correct "ERSENNYOM" "ERSENYNYOM"	For example VERSENYNYOMÁSRA word
 nofor correct "ersennyüzsg" "ersenynyüzsg"	For example versenynyüzsgéshez word
+nofor correct "ERSENNYÜZSG" "ERSENYNYÜZSG"	For example VERSENYNYÜZSGÉS word
 nofor correct "orgonnyak" "orgonynyak"	For example horgonynyak backtranslation correction
+nofor correct "ORGONNYAK" "ORGONYNYAK"	For example HORGONYNYAK word
 nofor correct "dénnyit" "dénynyit"	For example idénynyitó word
+nofor correct "DÉNNYIT" "DÉNYNYIT"	For example EDÉNYNYITÓ word
 nofor correct "rénnyit" "rénynyit"	For example szekrénynyitó word
+nofor correct "RÉNNYIT" "RÉNYNYIT"	For example SZEKRÉNYNYITÓ word
 nofor correct "énnyújt" "énynyújt"	For example élménynyújtás, teljesítménynyújtó word
+nofor correct "ÉNNYÚJT" "ÉNYNYÚJT"	For example ÉLMÉNYNYÚJTÓ word
 nofor correct "ormánnyak" "ormánynyak"	For example kormánynyakhoz, kormánynyakból words backtranslation correction
+nofor correct "ORMÁNNYAK" "ORMÁNYNYAK"	For example KORMÁNYNYAK word
 nofor correct "ormánnyil" "ormánynyil"	For example kormánynyilatkozat word backtranslation correction
+nofor correct "ORMÁNNYIL" "ORMÁNYNYIL"	For example KORMÁNYNYILATKOZAT word
 nofor correct "öpennyú" "öpenynyú"	For example köpenynyúlvánnyal word backtranslation correction
+nofor correct "ÖPENNYÚL" "ÖPENYNYÚL"	For example KÖPENYNYÚLVÁNY word
 nofor correct "eánnyel" "eánynyel"	For example leánynyelv, leánynyelvekben words backtranslation corrections
+nofor correct "EÁNYNYEL" "EÁNYNYEL"	For example LEÁNYNYELV word
 nofor correct "ősténnyú" "ősténynyú"	For example nősténynyúllal word backtranslation correction
+nofor correct "ŐSTÉNNYÚ" "ŐSTÉNYNYÚ"	For example NŐSTÉNYNYÚL word
 nofor correct "árnnyil" "árnynyil"	For example szárnynyilazás word backtranslation correction
+nofor correct "ÁRNNYIL" "ÁRNYNYIL"	For example SZÁRNYNYILAZÁS word
 nofor correct "oronnyí" "oronynyí"	For example toronynyílás, toronynyílásban word backtranslation correction
+nofor correct "ORONNYÍ" "ORONYNYÍ"	For example TORONYNYÍLÁS word
 nofor correct "éleménnyil" "éleménynyil"	For example véleménynyilvánítás, véleménynyilvánításban words backtranslation corrections
 nofor correct "ÉLEMÉNNYIL" "ÉLEMÉNYNYIL"	For example VÉLEMÉNYNYILVÁNÍTÁS, VÉLEMÉNYNYILVÁNÍTÁSBAN words backtranslation corrections
 nofor correct "övénnyír" "övénynyír"	For example sövénynyíró word
 nofor correct "eljesítménnyilat" "eljesítménynyilat"	For example teljesítménynyilatkozat, Teljesítménynyilatkozat words
+nofor correct "ELJESÍTMÉNNYILAT" "ELJESÍTMÉNYNYILAT"	For example TELJESÍTMÉNYNYILATKOZAT word
 nofor correct "átonnyelv" "átonynyelv"	For example zátonynyelv word
 nofor correct "lménnyaral" "lménynyaral"	For example élménynyaralás word
+nofor correct "LMÉNNYARAL" "LMÉNYNYARAL"	For example ÉLMÉNYNYARALÁS word
 nofor correct "árvánnyúl" "árványnyúl"	For example márványnyúl word
+nofor correct "ÁRVÁNNYÚL" "ÁRVÁNYNYÚL"	For example MÁRVÁNYNYÚL word
 nofor correct "örnnyúl" "örnynyúl"	For example szörnynyúl word
+nofor correct "ÖRNNYÚL" "ÖRNYNYÚL"	For example SZÖRNYNYÚL word
 nofor correct "sonnyak" "sonynyak"	For example bársonynyakékes word
+nofor correct "SONNYAK" "SONYNYAK"	For example BÁRSONYNYAKÉKES word
 nofor correct "ménnyit" "ménynyit"	For example intézménynyitás word
+nofor correct "MÉNNYIT" "MÉNYNYIT"	For example INTÉZMÉNYNYITÁS word
 nofor correct "övénnyú" "övénynyú"	For example növénynyúzók word
 nofor correct "árvánnyo" "árványnyo"	For example járványnyomás word
 nofor correct "ÁRVÁNNYO" "ÁRVÁNYNYO"	For example JÁRVÁNYNYOMÁS word
@@ -238,9 +408,11 @@ nofor correct "HIÁNNYEL" "HIÁNYNYEL"	For example HIÁNYNYELV word
 nofor correct "övénnyes" "övénynyes"	For example növénynyesedék, sövénynyesedék words
 nofor correct "akonnyalog" "akonynyalog"	For example takonynyalogató word
 nofor correct "regénnyusz" "regénynyusz"	For example képregénynyuszi word
+nofor correct "REGÉNNYUSZ" "REGÉNYNYUSZ"	For example KÉPREGÉNYNYUSZI word
 nofor correct "ejtvénnyelv" "ejtvénynyelv"	For example rejtvénynyelven word
 nofor correct "EJTVÉNNYELV" "EJTVÉNYNYELV"	For example REJTVÉNYNYELVEN word
 nofor correct "vénnyer" "vénynyer"	For example részvénynyereség word
+nofor correct "VÉNNYER" "VÉNYNYER"	For example RÉSZVÉNYNYERESÉG word
 nofor correct "árnnyit" "árnynyit"	For example szárnynyitás word
 nofor correct "ÁRNNYIT" "ÁRNYNYIT"	For example SZÁRNYNYITÁS" word
 nofor correct "egénnyelv" "egénynyelv"	For example regénynyelven word
@@ -268,18 +440,43 @@ nofor correct "ránnyila" "ránynyila"	For example iránynyilakkal word
 nofor correct "RÁNNYILA" "RÁNYNYILA"	For example IRÁNYNYILAKKAL word
 nofor correct "ásárosnaménny" *	For example Vásárosnaménnyal word
 nofor correct "ÁSÁROSNAMÉNNY" *	fOR example VÁSÁROSNAMÉNNYAL word
+nofor correct "ampánnyom" "ampánynyom"	For example kampánynyomor word
+nofor correct "AMPÁNNYOM" "AMPÁNYNYOM"	For example KAMPÁNYNYOMOR word
+nofor correct "asszonnyel" "asszonynyel"	For example asszonynyelv word
+nofor correct "Asszonnyel" "Asszonynyel"	For example asszonynyelv word
+nofor correct "ASSZONNYEL" "ASSZONYNYEL"	For example ASSZONYNYELV word
+nofor correct "lapítvánnyíl" "lapítványnyíl"	For example alapítványnyílt word
+nofor correct "LAPÍTVÁNNYÍL" "LAPÍTVÁNYNYÍL"	For example ALAPÍTVÁNYNYÍLT word
+nofor correct "ersennyer" "ersenynyer"	For example versenynyerés word
+nofor correct "ERSENNYER" "ERSENYNYER"	For example VERSENYNYERÉS word
+nofor correct "észvénnyugdí" "észvénynyugdí"	For example részvénynyugdíj word
+nofor correct "ÉSZVÉNNYUGDÍ" "ÉSZVÉNYNYUGDÍ"	For example RÉSZVÉNYNYUGDÍJ word
+nofor correct "iránnyí" "iránynyí"	For example iránynyíl word
+nofor correct "Iránnyí" "Iránynyí"	For example Iránynyíl word
+nofor correct "IRÁNNYÍ" "IRÁNYNYÍ"	For example IRÁNYNYÍL word
+nofor correct "ormánnyom" "ormánynyom"	For example kormánynyomás word
+nofor correct "ORMÁNNYOM" "ORMÁNYNYOM"	For example KORMÁNYNYOMÁS word
+nofor correct "azdasszonnyál" "azdasszonynyál"
+nofor correct "AZDASSZONNYÁL" "AZDASSZONYNYÁL"	For example GAZDASSZONYNYÁL word
 
 #lyly letters related backtranslate corrections
 nofor correct "amelylyel" *
 
 #szsz backtranstrated words related exceptions
 nofor correct "bortusszab" "bortuszszab"	For example abortuszszabadság, abortuszszabály words backtranslation
+nofor correct "BORTUSSZAB" "BORTUSZSZAB"	For example ABORTUSZSZABADSÁG, abortuszszabály words backtranslation correction
+nofor correct "bortusszabadsággal" "bortuszszabadsággal"
 nofor correct "bortusszabadsággal" "bortuszszabadsággal"
 nofor correct "bortusszer" "bortuszszer"
+nofor correct "BORTUSSZER" "BORTUSZSZER"
 nofor correct "bortusszá" "bortuszszá"
+nofor correct "BORTUSSZÁ" "BORTUSZSZÁ"
 nofor correct "bortusszi" "bortuszszi"
+nofor correct "BORTUSSZI" "BORTUSZSZI"
 nofor correct "bortusszolgá" "bortuszszolgá"	For example abortuszszolgáltatók word
+nofor correct "BORTUSSZOLGÁ" "BORTUSZSZOLGÁ"	For example ABORTUSZSZOLGÁLTATÓK word
 nofor correct "knásszáz" "knászszáz"
+nofor correct "KNÁSSZÁZ" "KNÁSZSZÁZ"	For example AKNÁSZSZÁZAD word
 nofor correct "ananásszal" *
 nofor correct "Ananásszal" *
 nofor correct "ANANÁSSZAL" *
@@ -290,171 +487,313 @@ nofor correct "aszszony" "asszony"
 nofor correct "árrésszab" *	Árrésszabály part not need applying the special szsz backtranslation correction
 nofor correct "érésszab" *
 nofor correct "Érésszab" *
+nofor correct "ÉRÉSSZAB" *
 nofor correct "résszabá" "részszabá"
 nofor correct "öréssza" *	For example törésszakaszon word not need apply the special backtranslation szsz correction
 nofor correct "veréssza" *	For example átverésszagú word not need apply the special backtranslation correction
+nofor correct "VERÉSSZA" *	Same the previous exception
 nofor correct "réssza" "részsza"	For example résszavaiból word
+nofor correct "Réssza" "Részsza"	For example Részszavaiból word
+nofor correct "RÉSSZA" "RÉSZSZA"	For example RÉSZSZAVAIBÓL word
 nofor correct "résszá" "részszá"	For example alkatrésszám, alkatrésszámainak, alkatrésszámaival, részszámla words
 nofor correct "Résszá" "Részszá"	Same the previous exception
+nofor correct "RÉSSZÁ" "RÉSZSZÁ"	Same the previous exception
 nofor correct "résszerel" "részszerel"	For example alkatrésszerelő word
+nofor correct "Résszerel" "Részszerel"	For example Részszerelő word
+nofor correct "RÉSSZEREL" "RÉSZSZEREL"	For example RÉSZSZERELŐ word
 nofor correct "fűrésszerű" "fűrésszerű"
 nofor correct "résszel" *	For example fűrésszel word not need applying next részsze word part related rule
+nofor correct "Résszel" *
+nofor correct "RÉSSZEL" *
 nofor correct "résszer" *	For example árverésszerű, kitörésszerű, lőrésszerű words not need applying the simple szsz backtranslation correction
+nofor correct "Résszer" *	For example Árverésszerű, Kitörésszerű, Lőrésszerű words not need applying the simple szsz backtranslation correction
+nofor correct "RÉSSZER" *	For example ÁRVERÉSSZERŰ, KITÖRÉSSZERŰ, LŐRÉSSZERŰ words not need applying the simple szsz backtranslation correction
 nofor correct "réssze" "részsze"	But for example résszempont, tulajdonrészszerzés words need applying a special replacement with backward translation
+nofor correct "Réssze" "Részsze"	For example Részszegmens word
+nofor correct "RÉSSZE" "RÉSZSZE"	For example RÉSZSZEGMENS word
 nofor correct "résszo" "részszo"	For example részszolgáltatás, alkatrészszolgáltatás words
 nofor correct "Résszo" "Részszo"
 nofor correct "résszó" "részszó"
 nofor correct "Résszó" "Részszó"
 nofor correct "övidítésszó" *	For example rövidítésszótárban word
 nofor correct "ésszó" "észszó"	For example mészszóró word
-nofor correct "atlasszala" "atlaszszala"
-nofor correct "atlasszo" "atlaszszo"
+nofor correct "atlasszala" "atlaszszala"	For example atlaszszalag word
+nofor correct "Atlasszala" "Atlaszszala"	For example Atlaszszalag word
+nofor correct "ATLASSZALA" "ATLASZSZALA"	For example ATLASZSZALAG word
+nofor correct "atlasszo" "atlaszszo"	For example atlaszszobor word
+nofor correct "Atlasszo" "Atlaszszo"	For example Atlaszszobor word
+nofor correct "ATLASSZO" "ATLASZSZO"	For example ATLASZSZOBOR word
 nofor correct "ajusszál" "ajuszszál"
+nofor correct "AJUSSZÁL" "AJUSZSZÁL"
 nofor correct "ajussző" "ajuszsző"	For example bajuszszőrtől word backtranslation correction
+nofor correct "AJUSSZŐ" "AJUSZSZŐ"
 nofor correct "imbusszá" "imbusszá"
+nofor correct "IMBUSSZÁ" "IMBUSZSZÁ"
 nofor correct "ébusszá" "ébusszá"
+nofor correct "ÉBUSSZÁ" "ÉBUSZSZÁ"
 nofor correct "ambusszál" "ambuszszál"	For example bambuszszál, bambuszszálakból words
+nofor correct "AMBUSSZÁL" "AMBUSZSZÁL"	For example BAMBUSZSZÁL word
 nofor correct "ambusszen" "ambuszszen"	For example bambuszszenes word
+nofor correct "AMBUSSZEN" "AMBUSZSZEN"	For example BAMBUSZSZENES word
+nofor correct "ambusszer" "ambuszszer"	For example bambuszszerű word
+nofor correct "AMBUSSZER" "AMBUSZSZER"	For example BAMBUSZSZERŰ word
 nofor correct "ambusszár" "ambuszszár"	For example bambuszszár word
+nofor correct "Busszé" "Buszszé"
+nofor correct "AMBUSSZÁR" "AMBUSZSZÁR"	for example BAMBUSZSZERŰ word
 nofor correct "busszé" "buszszé"
+nofor correct "BUSSZÉ" "BUSZSZÉ"
+nofor correct "BUSSZÉ" "BUSZSZÉ"
 nofor correct "busszer" "buszszer"	For example buszszerencsétlenség word
+nofor correct "Busszer" "Buszszer"	For example Buszszerencsétlenség word
+nofor correct "BUSSZER" "BUSZSZER"	For example BUSZSZERENCSÉTLENSÉG word
 nofor correct "busszolg" "buszszolg"	For example buszszolgáltatásban word
+nofor correct "Busszolg" "Buszszolg"	For example Buszszolgáltatás word
+nofor correct "BUSSZOLG" "BUSZSZOLG"	For example BUSZSZOLGÁLTATÁS word
 nofor correct "ányásszaksz" "ányászszaksz"	For example bányászszakszervezet word
+nofor correct "ÁNYÁSSZAKSZ" "ÁNYÁSZSZAKSZ"	For example BÁNYÁSZSZAKSZERVEZET word
 nofor correct "ányásszek" "ányászszek"	For example bányászszektor word back translation related
+nofor correct "ÁNYÁSSZEK" "ÁNYÁSZSZEK"	For example BÁNYÁSZSZEKTOR word
 nofor correct "ányásszob" "ányászszob"	For example bányászszobraival, Bányászszobraival word backtranslation related
+nofor correct "ÁNYÁSSZOB" "ÁNYÁSZSZOB"	For example BÁNYÁSZSZOBRAIVAL word
 nofor correct "ányásszoftv" "ányászszoftv"	
+nofor correct "ÁNYÁSSZOFTV" "ÁNYÁSZSZOFTV"	For example BÁNYÁSZSZOFTVER word
 nofor correct "ányásszt" "ányászszt"	For example bányászsztrájk word backtranslation correction
+nofor correct "ÁNYÁSSZT" "ÁNYÁSZSZT"	For example BÁNYÁSZSZTRÁJK word
 nofor correct "oksszöv" "okszszöv"	For example bokszszövetség word backtranslation correction
+nofor correct "OKSSZÖV" "OKSZSZÖV"	For example BOKSZSZÖVETSÉG word
 nofor correct "oksszak" "okszszak"	For example bokszszakértő, bokszszakmában words
+nofor correct "OKSSZAK" "OKSZSZAK"	For example BOKSZSZAKÉRTŐ word
 nofor correct "oksszerv" "okszszerv"	For example bokszszervezet word
+nofor correct "OKSSZERV" "OKSZSZERV"	For example BOKSZSZERVEZET word
 nofor correct "okssztá" "okszsztá"	For example bokszsztár word
+nofor correct "OKSSZTÁ" "OKSZSZTÁ"	For example BOKSZSZTÁR word
 nofor correct "ónusszám" "ónuszszám"	For example bónuszszám, bónuszszámaik backtranslation correction
+nofor correct "ÓNUSSZÁM" "ÓNUSZSZÁM"	For example BÓNUSZSZÁM word
 nofor correct "russzínház" *	For example kórusszínház word related not need apply the next correction rule
+nofor correct "RUSSZÍNHÁ" *	For example KÓRUSSZÍNHÁZ not need apply the SZSZ backtranslation correction
 nofor correct "usszabvá" "uszszabvá"	For example buszszabványok word
+nofor correct "USSZABVÁ" "USZSZABVÁ"	For example BUSZSZABVÁNY word
 nofor correct "usszínház" "uszszínház"	For example buszszínház word backtranslation output correction
+nofor correct "USSZÍNHÁZ" "USZSZÍNHÁZ"	For example BUSZSZÍNHÁZ word
 nofor correct "ipésszakm" "ipészszakm"	For example cipészszakmájának word backtranslation correction
+nofor correct "IPÉSSZAKM" "IPÉSZSZAKM"	For example CIPÉSZSZAKMÁJÁNAK word
 nofor correct "ipésszöv" "ipészszöv"	For example cipészszövetkezet backtranslation correction
+nofor correct "IPÉSSZÖV" "IPÉSZSZÖV"	For example CIPÉSZSZÖVETSÉG word
 nofor correct "ukrásszak" "ukrászszak"	For example cukrásszakmában word
+nofor correct "UKRÁSSZAK" "UKRÁSZSZAK"	For example CUKRÁSZSZAKMA word
 nofor correct "ukrásszöv" "ukrászszöv"	For example Cukrászszövetségben word
+nofor correct "UKRÁSSZÖV" "UKRÁSZSZÖV"	For example CUKRÁSZSZÖVETSÉG word
 nofor correct "erkésszáll" "erkészszáll"	For example cserkészszállón word
+nofor correct "ERKÉSSZÁLL" "ERKÉSZSZÁLL"	For example CSERKÉSZSZÁLLÓ word
 nofor correct "erkésszer" "erkészszer"	For example cserkészszervezet back translation correction
+nofor correct "ERKÉSSZER" "ERKÉSZSZER"	For example CSERKÉSZSZERVEZET word
 nofor correct "erkésszob" "erkészszob"	For example cserkészszoba, cserkészszobájában backtranslation correction
+nofor correct "ERKÉSSZOB" "ERKÉSZSZOB"	For example CSERKÉSZSZOBA word
 nofor correct "erkésszöv" "erkészszöv"	For example cserkészszövetkezet word backtranslation correction
+nofor correct "ERKÉSSZÖV" "ERKÉSZSZÖV"	For example CSERKÉSZSZÖVETSÉG word
 nofor correct "illagássze" "illagászsze"	For example csillagászszemmel word backtranslation correction
+nofor correct "ILLAGÁSSZE" "ILLAGÁSZSZE"	For example CSILLAGÁSZSZERVEZET word
 nofor correct "íssza" "íszsza"	For example díszszakasszal, díszszalaggal words backtranslation correction
+nofor correct "ÍSSZA" "ÍSZSZA"	For example DÍSZSZAKASZ, DÍSZSZALAGGAL words
 nofor correct "ísszeg" "íszszeg"	For example díszszegély, díszszegéllyel words backtranslation correction
+nofor correct "ÍSSZEG" "ÍSZSZEG"	For example DÍSZSZEGÉLY word
 nofor correct "ísszek" "íszszek"	For example díszszekrény, díszszekrényében words backtranslation correction
+nofor correct "ÍSSZEK" "ÍSZSZEK"	For example DÍSZSZEKERCE word
 nofor correct "ísszem" "íszszem"	For example díszszemle, díszszemléhez words backtranslation correction
+nofor correct "ÍSSZEM" "ÍSZSZEM"	For example DÍSZSZEMLÉHEZ word
 nofor correct "ísszer" "íszszer"	For example díszszertartás word backtranslation correction
+nofor correct "ÍSSZER" "ÍSZSZER"	For example DÍSZSZERTARTÁS word
 nofor correct "ísszob" "íszszob"	For example díszszobában word backtranslation correction
+nofor correct "ÍSSZOB" "ÍSZSZOB"	For example DÍSZSZOBOR, DÍSZSZOBA word
 nofor correct "egésszá" "egészszá"	For example egészszám-végrehajtás backtranslation correction
 nofor correct "Egésszá" "Egészszá"	Same the previous word, but uppercase version
+nofor correct "EGÉSSZÁ" "EGÉSZSZÁ"	For example EGÉSZSZÁM word
 nofor correct "pítésszak" "pítészszak"	For example építészszakon, építészszakmában words backtranslation correction
+nofor correct "PÍTÉSSZAK" "PÍTÉSZSZAK"	For example ÉPÍTÉSZSZAKMÁBAN word
 nofor correct "pítésszem" "pítészszem"	For example építésszemmel word backtranslation correction
+nofor correct "PÍTÉSSZEM" "PÍTÉSZSZEM"	For example ÉPÍTÉSZSZEMMEL word
 nofor correct "fesszab" "feszszab"	For example feszszabályzó word backtranslation correction
 nofor correct "Fesszab" "Feszszab"
 nofor correct "itnesszak" "itneszszak"	For example fitneszszakmában word backtranslation correction
+nofor correct "ITNESSZAK" "ITNESZSZAK"	For example FITNESZSZAKMÁBAN word
 nofor correct "itnesszala" "itneszszala"	For example fitneszszalag word backtranslation correction
+nofor correct "ITNESSZALA" "ITNESZSZALA"	For example FITNESZSZALAG word
 nofor correct "itnessztá" "itneszsztá"	For example fitneszsztár word
+nofor correct "ITNESSZTÁ" "ITNESZSZTÁ"	For example FITNESZSZTÁR word
 nofor correct "itnesszolg" "itneszszolg"	For example fitneszszolgáltatás word backtranslation correction
+nofor correct "ITNESSZOLG" "ITNESZSZOLG"	For example FITNESZSZOLGÁLTATÁS word
 nofor correct "itnesszö" "itneszszö"	For example fitneszszövetség word
+nofor correct "ITNESSZÖ" "ITNESZSZÖ"	For example FITNESZSZÖVETSÉG word
 nofor correct "itnesszüne" "itneszszüne"	For example fitneszszünet word backtranslation correction
+nofor correct "ITNESSZÜNE" "ITNESZSZÜNE"	For example FITNESZSZÜNET word
 nofor correct "odrásszak" "odrászszak"	For example fodrászszakszervezet, fodrászszakmában words backtranslation correction
+nofor correct "ODRÁSSZAK" "ODRÁSZSZAK"	For example FODRÁSZSZAKEMBER word
 nofor correct "odrásszalo" "odrászszalo"	For example fodrászszalon, fodrászszalonból words backtranslation correction
+nofor correct "ODRÁSSZALO" "ODRÁSZSZALO"	For example FODRÁSZSZALON word
 nofor correct "odrásszé" "odrászszé"	For example fodrászszék word backtranslation correction
+nofor correct "ODRÁSSZÉ" "ODRÁSZSZÉ"	For example FODRÁSZSZÉKword
 nofor correct "épésszak" "épészszak"	For example gépészszakterület backtranslation correction
+nofor correct "ÉPÉSSZAK" "ÉPÉSZSZAK"	For example GÉPÉSZSZAK word
 nofor correct "gyásszala" "gyászszala"	For example gyászszalaggal backtranslation correction
 nofor correct "Gyásszala" "Gyászszala"	For example Gyászszalaggal word
+nofor correct "GYÁSSZALA" "GYÁSZSZALA"	For example GYÁSZSZALAG word
 nofor correct "gyásszab" "gyászszab"	For example gyászszabadság word backtranslation correction
 nofor correct "Gyásszab" "Gyászszab"	Uppercase version the previous word
-nofor correct "ogyásszakértő" *	For example fogyásszakértő word not need apply the next correction rule
+nofor correct "GYÁSSZAB" "GYÁSZSZAB"	For example GYÁSZSZABADSÁG word
+nofor correct "ogyásszakért" *	For example fogyásszakértő word not need apply the next correction rule
 nofor correct "gyásszakért" "gyászszakért"	For example gyászszakértő word
+nofor correct "OGYÁSSZAKÉRT" *	For example FOGYÁSSZAKÉRTŐ word not need apply the szsz backtranslation rule correction
 nofor correct "Gyásszakért" "Gyászszakért"	For example Gyászszakértő word
+nofor correct "GYÁSSZAKÉRT" "GYÁSZSZAKÉRT"	For example GYÁSZSZAKÉRTŐ word
 nofor correct "Gyásszaka" "Gyászszaka"	For example Gyászszakaszai word
 nofor correct "gyásszaka" "gyászszaka"	For example Gyászszakaszai word
+nofor correct "GYÁSSZAKA" "GYÁSZSZAKA"	For example GYÁSZSZAKASZ word
 nofor correct "gyásszem" "gyászszem"	For example gyászszemle word
 nofor correct "Gyásszem" "Gyászszem"	For example Gyászszemle word
+nofor correct "GYÁSSZEM" "GYÁSZSZEM"	For example GYÁSZSZEMLE word
 nofor correct "gyásszer" "gyászszer"	For example gyászszertartás backtranslation correction
 nofor correct "Gyásszer" "Gyászszer"	For example Gyászszertartás backtranslation correction
+nofor correct "GYÁSSZER" "GYÁSZSZER"	For example GYÁSZSZERTARTÁS word
 nofor correct "gyásszün" "gyászszün"	For example gyászszünet word backtranslation correction
 nofor correct "Gyásszün" "Gyászszün"
+nofor correct "GYÁSSZÜN" "GYÁSZSZÜN"	For example GYÁSZSZÜNET word
 nofor correct "ipsszob" "ipszszob"	For example gipszszoborként, gipszszoborral, gipszszobraival words backtranslation correction
+nofor correct "IPSSZOB" "IPSZSZOB"	For example GIPSZSZOBRAIVAL word
 nofor correct "ipsszuszp" "ipszszuszp"	For example gipszszuszpenziós word
+nofor correct "IPSSZUSZP" "IPSZSZUSZP"	For example GIPSZSZUSZPENZIÓS word
 nofor correct "halásszáko" "halászszáko"	For example halászszákot word
 nofor correct "Halásszáko" "Halászszáko"
+nofor correct "HALÁSSZÁKO" "HALÁSZSZÁKO"	For example HALÁSZSZÁKOT word
 nofor correct "halásszám" "halászszám"	For example halászszámlálás, halászszámot words
 nofor correct "Halásszám" "Halászszám"
+nofor correct "HALÁSSZÁM" "HALÁSZSZÁM"	For example HALÁSZSZÁM word
 nofor correct "halássze" "halászsze"	For example halászszervezet, halászszerszámaikkal backtranslation correction
 nofor correct "Halássze" "Halászsze"
+nofor correct "HALÁSSZE" "HALÁSZSZE"
 nofor correct "halásszi" "halászszi"	For example halászszigony, halászszigonyokkal backtranslation correction
 nofor correct "Halásszi" "Halászszi"
+nofor correct "HALÁSSZI" "HALÁSZSZI"
 nofor correct "orgásszállá" "orgászszállá"	For example horgászszállás word
+nofor correct "ORGÁSSZÁLLÁ" "ORGÁSZSZÁLLÁ"	For example HORGÁSZSZÁLLÁS word
 nofor correct "orgásszé" "orgászszé"	For example horgászszék backtranslation correction
+nofor correct "ORGÁSSZÉ" "ORGÁSZSZÉ"	For example HORGÁSZSZÉK word
 nofor correct "morgássze" *	For example the morgásszerű word not need apply the next backtranslation correction
 nofor correct "orgássze" "orgászsze"	For example horgászszempontból backtranslation correction
+nofor correct "ORGÁSSZE" "ORGÁSZSZE"	For example HORGÁSZSZERVEZET word
 nofor correct "umusszin" "umuszszin"	For example humuszszint word backtranslation correction
+nofor correct "UMUSSZIN" "UMUSZSZIN"	For example HUMUSZSZINTEN word
 nofor correct "ússzáz" "úszszáz"	For example húszszázalék word backtranslation correction
+nofor correct "ÚSSZÁZ" "ÚSZSZÁZ"	For example HÚSZSZÁZALÉKOS word
 nofor correct "ússzemé" "úszszemé"	For example húszszemélyes word backtranslation correction
+nofor correct "ÚSSZEMÉ" "ÚSZSZEMÉ"	For example HÚSZSZEMÉLYES word
 nofor correct "jásszak" "jászszak"	For example íjászszakkör word backtranslation correction
+nofor correct "JÁSSZAK" "JÁSZSZAK"	For example ÍJÁSZSZAKKÖR word
 nofor correct "jásszá" "jászszá"	For example íjászszázad word backtranslation correction
+nofor correct "JÁSSZÁ" "JÁSZSZÁ"	For example ÍJÁSZSZÁZAD word
 nofor correct "jásszöv" "jászszöv"	for example íjászszövetség word backtranslation correction
+nofor correct "JÁSSZÖV" "JÁSZSZÖV"	For example ÍJÁSZSZÖVETSÉG word
 nofor correct "risszken" "riszszken"	For example íriszszkenner word backtranslation correction
+nofor correct "RISSZKEN" "RISZSZKEN"	For example ÍRISZSZKENNELÉSNÉL word
 nofor correct "Jásszent" "Jászszent"	For example Jászszentlászló town name backtranslation correction
 nofor correct "jásszent" "jászszent"	For example jászszentandrási word
+nofor correct "JÁSSZENT" "JÁSZSZENT"	For example JÁSZSZENTLÁSZLÓRÓL word
 nofor correct "ogásszak" "ogászszak"	For example jogászszakmában, jogászszakon backtranslation correction
+nofor correct "OGÁSSZAK" "OGÁSZSZAK"	For example JOGÁSZSZAKÉRTŐ word
 nofor correct "ogássze" "ogászsze"	For example jogászszemmel word backtranslation correction
+nofor correct "OGÁSSZE" "OGÁSZSZE"	For example JOGÁSZSZEMMEL word
 nofor correct "kaktusszár" "kaktuszszár"	for example kaktuszszár backtranslation correction
 nofor correct "Kaktusszár" "Kaktuszszár"	For example Kaktuszszár word correction
 nofor correct "KAKTUSSZÁR" "KAKTUSZSZÁR"	For example KAKTUSZSZÁR word correction
 nofor correct "ertésszakm" "ertészszakm"	For example kertészszakma word
+nofor correct "ERTÉSSZAKM" "ERTÉSZSZAKM"	For example KERTÉSZSZAKMA word
 nofor correct "ertésszen" "ertészszen"	For example kertészszenvedély word backtranslation correction
+nofor correct "ERTÉSSZEN" "ERTÉSZSZEN"	For example KERTÉSZSZENVEDÉLLYEL word
 nofor correct "sertésszemm" *	For example sertésszemmel word not need apply the general ertészszemm backtranslation exception
 nofor correct "Sertésszemm" *	Same the previous line, but uppercase word pair
+nofor correct "SERTÉSSZEMM" *
 nofor correct "ertésszemm" "ertészszemm"	For example kertészszemmel word
 nofor correct "kertésszem" "kertészszem"	For example kertészszem word
 nofor correct "Kertésszem" "Kertészszem"	For example uppercase Kertésszem word
+nofor correct "KERTÉSSZEM" "KERTÉSZSZEM"
 nofor correct "ertésszig" "ertészszig"	For example kertészszigeti word
+nofor correct "ERTÉSSZIG" "ERTÉSZSZIG"	For example KERTÉSZSZIGET word
 nofor correct "ertésszokny" "ertészszokny"	For example kertészszoknyás word backtranslation correction
+nofor correct "ERTÉSSZOKNY" "ERTÉSZSZOKNY"	For example KERTÉSZSZOKNYA word
 nofor correct "ókusszi" "ókuszszi"	For example kókuszszirup word backtranslation correction
+nofor correct "ÓKUSSZI" "ÓKUSZSZI"	For example KÓKUSZSZIRUP word
 nofor correct "ókusszö" "ókuszszö"	For example fókuszszövettel word
+nofor correct "ÓKUSSZÖ" "ÓKUSZSZÖ"	For example FÓKUSZSZÖVETTEL word
 nofor correct "kókussző" "kókuszsző"	For example kókusszőnyeg word backtranslation correction
 nofor correct "Kókussző" "Kókuszsző"	For example Kókuszszőnyeggel word
+nofor correct "KÓKUSSZŐ" "KÓKUSZSZŐ"	For example KÓKUSZSZŐNYEG word
 nofor correct "olesszo" "oleszszo"	For example koleszszobájából word backtranslation correction
+nofor correct "OLESSZO" "OLESZSZO"	For example KOLESZSZOBA word
 nofor correct "azdásszak" "azdászszak"	For example közgazdászszakmában word backtranslation correction
+nofor correct "AZDÁSSZAK" "AZDÁSZSZAK"	For example KÖZGAZDÁSZSZAKMÁBAN word
 nofor correct "azdássze" "azdászsze"	For example közgazdászszemmel word backtranslation correction
+nofor correct "AZDÁSSZE" "AZDÁSZSZE"	For example GAZDÁSZSZEMNEK word
 nofor correct "ultusszo" "ultuszszo"	For example kultuszszoborral word backtranslation correction
+nofor correct "ULTUSSZO" "ULTUSZSZO"	For example KULTUSZSZOBORRAL word
 nofor correct "ótusszi" "ótuszszi"	For example lótuszszirmokból word backtranslation correction
+nofor correct "ÓTUSSZI" "ÓTUSZSZI"	For example LÓTUSZSZIROM word
 nofor correct "összakad" "öszszakad"	For example löszszakadékokból word backtranslation correction
+nofor correct "ÖSSZAKAD" "ÖSZSZAKAD"	For example LÖSZSZAKADÉK word
 nofor correct "övéssza" "övészsza"	For example lövészszakasz, lövészszakaszban, lövészszakazhoz words backtranslation correction
+nofor correct "ÖVÉSSZA" "ÖVÉSZSZA"	For example LÖVÉSZSZAKASZ word
 nofor correct "övésszám" *	For example lövésszámmal word
+nofor correct "ÖVÉSSZÁM" *	For example LÖVÉSSZÁM word
 nofor correct "övésszá" "övészszá"	For example lövészszázad, lövészszállító words backtranslation correction
+nofor correct "ÖVÉSSZÁ" "ÖVÉSZSZÁ"	For example LÖVÉSZSZÁZAD word
 nofor correct "elassze" "elaszsze"	For example melaszszesz word backtranslation correction
+nofor correct "ELASSZE" "ELASZSZE"	For example MELASZSZESZ word
 nofor correct "késszeg" *
 nofor correct "Késszeg" *
+nofor correct "KÉSSZEG" *
 nofor correct "désszeg" *	For example szerződésszegés word not need apply the next line rule
+nofor correct "DÉSSZEG" *	For example SZERZŐDÉSSZEGÉS word
 nofor correct "ésszeg" "észszeg"	For example mészszegény word backtranslation correction
+nofor correct "ÉSSZEG" "ÉSZSZEG"	For example MÉSZSZEGÉNY word
 nofor correct "mésszi" "mészszi"	For example mészsziklákból word backtranslation correction
+nofor correct "Mésszi" "Mészszi"	For example Mészsziklából word
+nofor correct "MÉSSZI" "MÉSZSZI"	For example MÉSZSZIKLÁBÓL word
 nofor correct "ésszu" "észszu"	For example mészszurony word backtranslation correction
-nofor correct "űvésszá" "űvészszá"	For example művészszálló,  bűvésszámok words
+nofor correct "ÉSSZU" "ÉSZSZU"	For example MÉSZSZURONY word
+nofor correct "űvésszá" "űvészszá"	For example művészszálló, bűvésszámok words
+nofor correct "ŰVÉSSZÁ" "ŰVÉSZSZÁ"	For example MŰVÉSZSZÁMOK, BŰVÉSZSZÁM word
 nofor correct "űvéssza" "űvészsza"	For example bűvészszakma, művészszakszervezet, művészszakmában words backtranslation corrections
+nofor correct "ŰVÉSSZA" "ŰVÉSZSZA"	For example BŰVÉSZSZAKMA, MŰVÉSZSZAKSZERVEZET words
 nofor correct "űvésszem" "űvészszem"	For example művészszemmel word backtranslation correction
+nofor correct "ŰVÉSSZEM" "ŰVÉSZSZEM"	For example MŰVÉSZSZEMMEL word
 nofor correct "űvésszí" "űvészszí"	For example művészszínház word backtranslation correction
+nofor correct "ŰVÉSSZÍ" "ŰVÉSZSZÍ"	For example MŰVÉSZSZÍNHÁZ word
 nofor correct "űvésszob" "űvészszob"	For example művészszoba word
+nofor correct "ŰVÉSSZOB" "ŰVÉSZSZOB"	For example MŰVÉSZSZOBA word
 nofor correct "űvésszöv" "űvészszöv"	For example művészszövetséggel, Művészszövetséggel word
+nofor correct "ŰVÉSSZÖV" "ŰVÉSZSZÖV"	For example MŰVÉSZSZÖVETSÉG word
 nofor correct "násszert" "nászszert"	For example nászszertartás word backtranslation correction
+nofor correct "Násszert" "Nászszert"	For example Nászszertartás word
+nofor correct "NÁSSZERT" "NÁSZSZERT"	For example NÁSZSZERTARTÁS word
 nofor correct "omdásszak" "omdászszak"	For example nyomdászszakmában, nyomdászszakszervezetben words backtranslation corrections
+nofor correct "OMDÁSSZAK" "OMDÁSZSZAK"	For example NYOMDÁSZSZAKMA word
 nofor correct "omdássztr" "omdászsztr"	For example nyomdászsztrájk word backtranslation correction
+nofor correct "OMDÁSSZTR" "OMDÁSZSZTR"	For example NYOMDÁSZSZTRÁJK word
 nofor correct "anasszó" "anaszszó"	For example panaszszó, panaszszóval words backtranslation correction
 nofor correct "apirusszá" "apiruszszá"	For example papiruszszár, papiruszszárral words backtranslation correction
 nofor correct "enéssza" "enészsza"	For example penészszagban, penészszaggal words backtranslation corrections
+nofor correct "ENÉSSZA" "ENÉSZSZA"	For example PENÉSZSZAGBAN word
 nofor correct "enésszöv" "enészszöv"	For example penészszövedék words backtranslation correction
+nofor correct "ENÉSSZÖV" "ENÉSZSZÖV"	For example PENÉSZSZÖVEDÉK word
 nofor correct "iklusszab" *	For example ciklusszabályozás word need copying the original word the backtranslated output
 nofor correct "tílusszab" *	For example stílusszabályainak word backtranslation part not need apply the next correction rule
 nofor correct "lusszab" "luszszab"	For example pluszszabadság, pluszszabadsággal words backtranslation correction
 nofor correct "lusszav" "luszszav"	For example pluszszavazat word backtranslation correction
+nofor correct "LUSSZAV" "LUSZSZAV"	For example PLUSZSZAVAZAT word
 nofor correct "lusszáll" "luszszáll"	For example pluszszállítás word
+nofor correct "LUSSZÁLL" "LUSZSZÁLL"	For example PLUSZSZÁLLÍTÁS word
 nofor correct "lusszáz" "luszszáz"	For example pluszszázalékot, pluszszázalékokat words
+nofor correct "LUSSZÁZ" "LUSZSZÁZ"	For example PLUSZSZÁZALÉKOT word
 nofor correct "ílusszer" *	For example stílusszerű word
+nofor correct "ÍLUSSZER" *	For example STÍLUSSZERŰ word
 nofor correct "lusszerv" "luszszerv"	For example pluszszervek word
 nofor correct "lusszig" "luszszig"	For example pluszszigetelés word
 nofor correct "plusszin" "pluszszin"	For example pluszszint, pluszszinttel words backtranslation correction
@@ -463,13 +802,19 @@ nofor correct "lusszo" "luszszo"	For example pluszszolgáltatás, pluszszoba wor
 nofor correct "lusszöv" "luszszöv"	for example pluszszöveget word
 nofor correct "poggyásszál" "poggyászszál"	For example poggyászszállító word backtranslation correction
 nofor correct "Poggyásszál" "Poggyászszál"
+nofor correct "POGGYÁSSZÁL" "POGGYÁSZSZÁL"	For example POGGYÁSZSZÁLLÍTÓ word
 nofor correct "poggyássze" "poggyászsze"	For example poggyászszekerek, poggyászszett words backtranslation correction
 nofor correct "Poggyássze" "Poggyászsze"
+nofor correct "POGGYÁSSZE" "POGGYÁSZSZE"
 nofor correct "poggyásszí" "poggyászszí"	For example poggyászszíj word backtranslation correction
 nofor correct "Poggyásszí" "Poggyászszí"
+nofor correct "POGGYÁSSZÍ" "POGGYÁSZSZÍ"
 nofor correct "régésszak" "régészszak"	For example régészszakon, régészszakmában words backtranslation correction
 nofor correct "Régésszak" "Régészszak"
+nofor correct "RÉGÉSSZAK" "RÉGÉSZSZAK"	For example RÉGÉSZSZAK word
 nofor correct "régésszem" "régészszem"	For example régészszemmel word backtranslation correction
+nofor correct "Régésszem" "Régészszem"	For example Régészszemmel word
+nofor correct "RÉGÉSSZEM" "RÉGÉSZSZEM"	For example RÉGÉSZSZEMMEL word
 nofor correct "Rekesszem" "Rekeszszem"
 nofor correct "ekesszerk" "ekeszszerk"	For example rekeszszerkezet word backtranslation correction
 nofor correct "ekesszár" "ekeszszár"	For example rekeszszár word
@@ -481,21 +826,30 @@ nofor correct "akasszám" "akaszszám"	For example szakaszszám word
 nofor correct "akasszin" "akaszszin"	For example szakaszszinttel word backtranslation correction
 nofor correct "eméssza" "emészsza"	For example szemésszakember word backtranslation correction
 nofor correct "ínésszak" "ínészszak"	For example színészszakmában, színészszakszervezet words
+nofor correct "ÍNÉSSZAK" "ÍNÉSZSZAK"	For example SZÍNÉSZSZAKRA word
 nofor correct "ínésszáll" "ínészszáll"	For example színészszállást word
+nofor correct "ÍNÉSSZÁLL" "ÍNÉSZSZÁLL"	For example SZÍNÉSZSZÁLLÓ word
 nofor correct "ínésszelí" "ínészszelí"	For example színészszelídítő word backtranslation correction
+nofor correct "ÍNÉSSZELÍ" "ÍNÉSZSZELÍ"	For example SZÍNÉSZSZELÍDÍTŐ word
 nofor correct "ínésszöv" "ínészszöv"	For example színészszövetség word
+nofor correct "ÍNÉSSZÖ" "ÍNÉSZSZÖ"	For example SZÍNÉSZSZÖVETSÉG word
 nofor correct "ámasszin" "ámaszszin"	For example támaszszint, támaszszintről word
+nofor correct "ÁMASSZIN" "ÁMASZSZIN"	For example TÁMASZSZINT, TÁMASZSZINTRŐL word
 nofor correct "téesszer" "téeszszer"	For example téeszszervezés word
 nofor correct "Téesszer" "Téeszszer"
 nofor correct "enisszöv" "eniszszöv"	For example Teniszszövetség, Teniszszövetségtől word correction
+nofor correct "ENISSZÖV" "ENISZSZÖV"	For example TENISZSZÖVETSÉG word
 nofor correct "enissztá" "eniszsztá"	For example teniszsztár word backtranslation correction
 nofor correct "ENISSZTÁ" "ENISZSZTÁ"	For example TENISZSZTÁR word
 nofor correct "erasszép" "eraszszép"	For example teraszszépítés word
 nofor correct "erasszin" "eraszszin"	For example teraszszint, teraszszinttel word
 nofor correct "ojássz" *	For example tojásszán word not need applying special backtranslation
 nofor correct "örténéssza" "örténészsza"	For example történészszakmában word
+nofor correct "ÖRTÉNÉSSZA" "ÖRTÉNÉSZSZA"	For example TÖRTÉNÉSZSZAKON word
 nofor correct "ranssze" "ranszsze"	For example transzszexuális, transzszexualitás word backtranslation correction
+nofor correct "hússzabó" *	For example hússzabóság word
 nofor correct "Hússzabó" "Hússzabó"
+nofor correct "HÚSSZABÓ" *	For example HÚSSZABÓSÁG word
 nofor correct "ússzab" "úszszab"	For example túszszabadítás, túszszabadító word backtranslation
 nofor correct "hússzed"	* For example hússzedő word not need apply the general szsz letter pair translation
 nofor correct "Hússzed"	* For example hússzedő word not need apply the general szsz letter pair translation
@@ -509,14 +863,18 @@ nofor correct "vadásszem" "vadászszem"	For example vadászszemmel word backtra
 nofor correct "Vadásszem" "Vadászszem"	For example Vadászszemmel word backtranslation correction
 nofor correct "vadásszenv" "vadászszenv"	For example vadászszenvedéllyel vord
 nofor correct "Vadásszenv" "Vadászszenv"	For example vadászszenvedéllyel vord
+nofor correct "VADÁSSZENV" "VADÁSZSZENV"	For exampe VADÁSZSZENVEDÉLYÉT word
 nofor correct "ervadásszer" *	For example the hervadásszerű word not need apply the general szsz backtranslation related correction, see the next line general exception
 nofor correct "vadásszer" "vadászszer"	For example vadászszerencse word
 nofor correct "Vadásszer" "Vadászszer"	For example Vadászszerelésben word
 nofor correct "vadásszez" "vadászszez"	For example vadászszezon word
 nofor correct "Vadásszez" "Vadászszez"	For example Vadászszezon word
+nofor correct "VADÁSSZEZ" "VADÁSZSZEZ"	For example VADÁSZSZEZONON word
 nofor correct "vadásszob" "vadászszob"	For example vadászszobában word backtranslation correction
 nofor correct "Vadásszob" "Vadászszob"	For example Vadászszobában word
+nofor correct "VADÁSSZOB" "VADÁSZSZOB"	For example VADÁSZSZOBÁBAN word
 nofor correct "adásszövet" "adászszövet"	For example vadászszövetség, Vadászszövetség words
+nofor correct "ADÁSSZÖVET" "ADÁSZSZÖVET"	For example VADÁSZSZÖVETSÉG word
 nofor correct "ésszavá" "észszavá"	For example vészszavával word backtranslation correction
 nofor correct "ésszáz" "észszáz"	For example vészszázad word backtranslation correction
 nofor correct "vésszele" "vészszele"	For example vészszelep word backtranslation correction
@@ -526,18 +884,26 @@ nofor correct "iasszárm" "iaszszárm"	For example viaszszármazékok word
 nofor correct "iasszár" "iaszszár"	For example viaszszárnyak word
 nofor correct "iassze" "iaszsze"	for example viasszegély word backtranslation correction
 nofor correct "iasszob" "iaszszob"	For example viaszszobor, viaszszobrával words backtranslation correction
+nofor correct "IASSZOB" "IASZSZOB"	For example VIASZSZOBOR word
 nofor correct "enésszak" "enészszak"	For example Zenészszakszervezetében word backtranslation correction
 nofor correct "enésszem" "enészszem"	For example zenészszemmel, zenészszemélyiség words
 nofor correct "rmésszi" *
 nofor correct "alansszab" "alanszszab"	For example balanszszabályzás, Balanszszabályzó, balanszszabályzót words
+nofor correct "ALANSSZAB" "ALANSZSZAB"	For example BALANSZSZABÁLYZÓ word
 nofor correct "álasszank" "álaszszank"	For example válaszszankció, válaszszankciókat word
+nofor correct "ÁLASSZANK" "ÁLASZSZANK"	For example VÁLASZSZANKCIÓT word
 nofor correct "ásszerváj" "ászszerváj"	For example ászszerva, ászszerváikat, ászszervája words
+nofor correct "Ásszerváj" "Ászszerváj"	For example Ászszervája word
+nofor correct "ÁSSZERVÁJ" "ÁSZSZERVÁJ"	For example ÁSZSZERVÁJA word
 nofor correct "inocérossze" "inocéroszsze"	For example rinocéroszszerű word
 nofor correct "elmérésszer" *	For example felmérésszerű word
 nofor correct "aritásszer" "aritászszer"	For example karitászszervezet, karitászszervezethez words
+nofor correct "ARITÁSSZER" "ARITÁSZSZER"	For example KARITÁSZSZERVEZET word
 nofor correct "ísszáza" "íszszáza"	For example díszszázadának word
+nofor correct "ÍSSZÁZA" "ÍSZSZÁZA"	For example DÍSZSZÁZADÁNAK word
 nofor correct "gyásszám" "gyászszám"	For example gyászszámait word
 nofor correct "Gyásszám" "Gyászszám"
+nofor correct "GYÁSSZÁM" "GYÁSZSZÁM"
 nofor correct "tornásszám" "tornászszám"
 nofor correct "Tornásszám" "Tornászszám"
 nofor correct "ornássztá" "ornászsztá"	For example tornászsztár word
@@ -546,14 +912,23 @@ nofor correct "elkésszent" "elkészszent"	For example lelkészszentelés word
 nofor correct "elkésszem" "elkészszem"	For example lelkészszemmel word
 nofor correct "elkésszolg" "elkészszolg"	For example lelkészszolgálat word
 nofor correct "lkusszövet" "lkuszszövet"	For example alkuszszövetség word
+nofor correct "LKUSSZÖVET" "LKUSZSZÖVET"	For example ALKUSZSZÖVETSÉG word
 nofor correct "empésszala" "empészszala"	For example csempészszalamandrák, csempészszalamandrákat words
+nofor correct "EMPÉSSZALA" "EMPÉSZSZALA"	For example CSEMPÉSZSZALAMANDRÁKAT word
 nofor correct "gásszöv" "gászszöv"	For example Horgászszövetség, horgászszövetségek, horgászszövetségnek, Jogászszövetségtől words
+nofor correct "GÁSSZÖV" "GÁSZSZÖV"	For example HORGÁSZSZÖVETSÉG, JOGÁSZSZÖVETSÉG word
 nofor correct "umusször" "umuszször"	For example humuszszörny word
+nofor correct "UMUSSZÖR" "UMUSZSZÖR"	For example HUMUSZSZÖRNY word
 nofor correct "umusszer" "umuszszer"	For example humuszszerű word
+nofor correct "UMUSSZER" "UMUSZSZER"	For example HUMUSZSZERŰ word
 nofor correct "amasszob" "amaszszob"	For example kamaszszoba, kamaszszobában words
+nofor correct "AMASSZOB" "AMASZSZOB"	For example KAMASZSZOBÁBAN word
 nofor correct "amasszer" "amaszszer"	For example kamaszszerelem word
+nofor correct "AMASSZER" "AMASZSZER"	For example KAMASZSZERELEM word
 nofor correct "amasszok" "amaszszok"	For example kamaszszokás word
+nofor correct "AMASSZOK" "AMASZSZOK"	For example KAMASZSZOKÁS word
 nofor correct "amassztor" "amaszsztor"	For example kamaszsztori word
+nofor correct "AMASSZTOR" "AMASZSZTOR"	For example KAMASZSZTORI word
 nofor correct "rekesszám" "rekeszszám"	For example rekeszszám word
 nofor correct "Rekesszám" "Rekeszszám"	For example Rekeszszám word
 nofor correct "vadásszínp" "vadászszínp"	for example vadászszínpad word
@@ -564,194 +939,331 @@ nofor correct "EGYÉSSZA" "EGYÉSZSZA"	For example VEGYÉSZSZAKMA word
 nofor correct "válaszszák" "válasszák"
 nofor correct "Válaszszák" "Válasszák"
 nofor correct "ónusszab" "ónuszszab"	For example bónuszszabályzat word
+nofor correct "ÓNUSSZAB" "ÓNUSZSZAB"	For example BÓNUSZSZABÁLYZATUNK word
 nofor correct "ísszö" "íszszö"	For example díszszökőkút word
+nofor correct "ÍSSZÖ" "ÍSZSZÖ"	For example DÍSZSZÖKŐKÚT word
 nofor correct "ipsszilá" "ipszszilá"	For example gipszszilánk word
+nofor correct "IPSSZILÁ" "IPSZSZILÁ"	For example GIPSZSZILÁNK word
 nofor correct "ipsszerű" "ipszszerű"	For example gipszszerű word
+nofor correct "IPSSZERŰ" "IPSZSZERŰ"	For example GIPSZSZERŰ word
 nofor correct "enisszokny" "eniszszokny"	For example teniszszoknya word
+nofor correct "ENISSZOKNY" "ENISZSZOKNY"	For example TENISZSZOKNYA word
 nofor correct "avasszag" "avaszszag"	For example tavaszszag word
+nofor correct "AVASSZAG" "AVASZSZAG"	For example TAVASZSZAG word
 nofor correct "úlélészszerű" "úlélésszerű"	For example túlélésszerű word not need apply the szsz backtranslation related correction
+nofor correct "ÚLÉLÉSZSZERŰ" "ÚLÉLÉSZSZERŰ"
 nofor correct "vadásszoká" "vadászszoká"	For example vadászszokásainak word
+nofor correct "Vadásszoká" "Vadászszoká"	For example Vadászszokás word
+nofor correct "VADÁSSZOKÁ" "VADÁSZSZOKÁ"	For example VADÁSZSZOKÁS word
 nofor correct "csörömpölészszerű" "csörömpölésszerű"	For example csörömpölésszerű word not need apply the szsz backtranslation correction
 nofor correct "ultusszer" "ultuszszer"	For example kultuszszerzőket word
+nofor correct "ULTUSSZER" "ULTUSZSZER"	For example KULTUSZSZERZŐKET word
 nofor correct "elvésszak" "elvészszak"	For example nyelvészszakértő word
+nofor correct "ELVÉSSZAK" "ELVÉSZSZAK"	For example NYELVÉSZSZAKON word
 nofor correct "Résszámlá" "Részszámlá"	For example Részszámlához word
 nofor correct "ebésszakm" "ebészszakm"	For example sebészszakma, sebészszakmában words
 nofor correct "szülésszak" "szülészszak"	For example szülészszakmában word
 nofor correct "Szülésszak" "Szülészszak"
 nofor correct "asszopó" "aszszopó"
+nofor correct "ASSZOPÓ" "ASZSZOPÓ"
 nofor correct "asszopá" "aszszopá"	For example faszszopása word
+nofor correct "ASSZOPÁ" "ASZSZOPÁ"	For example FASZSZOPÁSA word
 nofor correct "erasszez" "eraszszez"	For example teraszszezonra word
 nofor correct "enisszup" "eniszszup"	For example teniszszupersztár word
 nofor correct "enisszabá" "eniszszabá"	For example teniszszabályt word
 nofor correct "ókusszab" "ókuszszab"	For example fókuszszabályzást word
+nofor correct "ÓKUSSZAB" "ÓKUSZSZAB"	For example FÓKUSZSZABÁLYZÁST word
 nofor correct "enésszt" "enészszt"	For example zenészsztár, zenészsztori words
 nofor correct "Zenéssztá" "Zenészsztá"
 nofor correct "ússzám" "úszszám"	For example húszszámos word
+nofor correct "ÚSSZÁM" "ÚSZSZÁM"	For example HÚSZSZÁMOS word
 nofor correct "koksszen" "kokszszen"	For example kokszszene word
 nofor correct "Koksszen" "Kokszszen"
 nofor correct "kosszemcsé" "koszszemcsé"	For example koszszemcsék word
 nofor correct "Kosszemcsé" "Koszszemcsé"	For example Koszszemcsék word
+nofor correct "KOSSZEMCSÉ" "KOSZSZEMCSÉ"	For example KOSZSZEMCSÉK word
 nofor correct "anasszav" "anaszszav"	For example panaszszava word
 nofor correct "anasszám" "anaszszám"	For example panaszszám, panaszszámmal word
 nofor correct "enyésszeml" "enyészszeml"	For example tenyészszemle word
+nofor correct "ENYÉSSZEML" "ENYÉSZSZEML"	For example TENYÉSZSZEMLE word
 nofor correct "örténésszem" "örténészszem"	For example történészszemmel word
 nofor correct "alásszed" "alászszed"	For example kalászszedő, Kalászszedő words
+nofor correct "ALÁSSZED" "ALÁSZSZED"	For example KALÁSZSZEDŐ word
 nofor correct "alásszí" "alászszí"	For example kalászszívvel word
+nofor correct "ALÁSSZÍ" "ALÁSZSZÍ"	For example KALÁSZSZÍVVEL word
 nofor correct "övésszövet" "övészszövet"	For example Lövészszövetség word
+nofor correct "ÖVÉSSZÖVET" "ÖVÉSZSZÖVET"	For example LÖVÉSZSZÖVETSÉG word
 nofor correct "iklusszámot" *	For example ciklusszámot word not need applying the next correction rule
+nofor correct "IKLUSSZÁMOT" *	For example CIKLUSZSZÁMOT word
 nofor correct "lusszámot" "luszszámot"	For example pluszszámot word
 nofor correct "gyésszoftver" "gyészszoftver"	For example ügyészszoftver word
 nofor correct "erpesszerű" "erpeszszerű"	For example herpeszszerű word
+nofor correct "ERPESSZERŰ" "ERPESZSZERŰ"	For example HERPESZSZERŰ word
 nofor correct "késszurká" *
 nofor correct "Késszurká" *
+nofor correct "KÉSSZURKÁ" *
 nofor correct "olbásszala" "olbászszala"	For example kolbászszalagot word
+nofor correct "OLBÁSSZALA" "OLBÁSZSZALA"	For example KOLBÁSZSZALAGOT word
 nofor correct "olbássze" "olbászsze"	For example kolbászszeletkékkel word
+nofor correct "OLBÁSSZE" "OLBÁSZSZE"	For example KOLBÁSZSZELETKÉKKEL word
 nofor correct "ölcsésszlen" "ölcsészszlen"	For example bölcsészszleng, bölcsészszlengben words
+nofor correct "ÖLCSÉSSZLEN" "ÖLCSÉSZSZLEN"	For example BÖLCSÉSZSZLENGBEN word
 nofor correct "irkusszakm" "irkuszszakm"	For example cirkuszszakmában word
+nofor correct "IRKUSSZAKM" "IRKUSZSZAKM"	For example CIRKUSZSZAKMA word
 nofor correct "pítésszövets" "pítészszövets"	For example építészszövetség word
+nofor correct "PÍTÉSSZÖVETS" "PÍTÉSZSZÖVETS"	For example ÉPÍTÉSZSZÖVETSÉG word
 nofor correct "pítésszoft" "pítészszoft"	For example építészszoftvert word
+nofor correct "PÍTÉSSZOFT" "PÍTÉSZSZOFT"	For example ÉPÍTÉSZSZOFTVER word
 nofor correct "gyásszoká" "gyászszoká"	For example gyászszokások word
 nofor correct "Gyásszoká" "Gyászszoká"
+nofor correct "GYÁSSZOKÁ" "GYÁSZSZOKÁ"	For example GYÁSZSZOKÁS word
 nofor correct "ílusszem" *	For example stílusszemmel, stílusszemle words
 nofor correct "lusszem" "luszszem"	For example pluszszemélyzetet word
 nofor correct "ínéssztá" "ínészsztá"	For example színészsztár word
 nofor correct "vezeklészszer" "vezeklésszer"
 nofor correct "eresszegé" "ereszszegé"	For example ereszszegélyt word
 nofor correct "Eresszegé" "Ereszszegé"
+nofor correct "ERESSZEGÉ" "ERESZSZEGÉ"
 nofor correct "ányásszámí" "ányászszámí"	For example bányászszámítógépek word
+nofor correct "ÁNYÁSSZÁMÍ" "ÁNYÁSZSZÁMÍ"	For example BÁNYÁSZSZÁMÍTÓGÉPEK word
 nofor correct "énisszob" "éniszszob"	For example péniszszobor, péniszszobrot words
 nofor correct "ÉNISSZOB" "ÉNISZSZOB"	For example PÉNISZSZOBOR, PÉNISZSZOBROT words
 nofor correct "oksszén" "okszszén"	For example kokszszénen word
+nofor correct "OKSSZÉN" "OKSZSZÉN"	For example KOKSZSZÉNEN word
 nofor correct "inoszaurusszer" "inoszauruszszer"	For example dinoszauruszszerű word
+nofor correct "INOSZAURUSSZER" "INOSZAURUSZSZER"	For example DINOSZAURUSZSZERŰ word
 nofor correct "inoszaurusszob" "inoszauruszszob"	For example dinoszauruszszobor word
+nofor correct "INOSZAURUSSZOB" "INOSZAURUSZSZOB"	For example DINOSZAURUSZSZOBOR word
 nofor correct "macesszabá" "maceszszabá"	For example maceszszabály word
 nofor correct "Macesszabá" "Maceszszabá"
+nofor correct "MACESSZABÁ" "MACESZSZABÁ"	
 nofor correct "rkásszáz" "rkászszáz"	For example árkászszázad word
+nofor correct "RKÁSSZÁZ" "RKÁSZSZÁZ"	For example ÁRKÁSZSZÁZAD word
 nofor correct "rkásszak" "rkászszak"	For example árkászszakasz word
+nofor correct "RKÁSSZAK" "RKÁSZSZAK"	For example ÁRKÁSZSZAKASZ word
 nofor correct "eksszalá" "ekszszalá"	For example kekszszalámi word
+nofor correct "EKSSZALÁ" "EKSZSZALÁ"	For example KEKSZSZALÁMI word
 nofor correct "eksszele" "ekszszele"	For example kekszszelet word
+nofor correct "EKSSZELE" "EKSZSZELE"	For example KEKSZSZELET word
 nofor correct "eksszend" "ekszszend"	For example kekszszendvics word
+nofor correct "EKSSZEND" "EKSZSZEND"	For example KEKSZSZENDVICS word
 nofor correct "ipsszele" "ipszszele"	For example csipszszelet word
+nofor correct "IPSSZELE" "IPSZSZELE"	For example CSIPSZSZELET word
 nofor correct "ersbussz" *	For example Versbusszá word
+nofor correct "ERSBUSSZ" *	For example VERSBUSSZÁ word
 nofor correct "ísszlovák" "íszszlovák"	For example díszszlovákot word backtranslation correction
+nofor correct "ÍSSZLOVÁK" "ÍSZSZLOVÁK"	For example DÍSZSZLOVÁK word
 nofor correct "oposszerű" "oposzszerű"	For example toposzszerű word
+nofor correct "OPOSSZERŰ" "OPOSZSZERŰ"	For example TOPOSZSZERŰ" word
 nofor correct "adásszéke" "adászszéke"	For example vadászszéke, vadászszékek words
+nofor correct "ADÁSSZÉKE" "ADÁSZSZÉKE"	For example VADÁSZSZÉKE word
 nofor correct "adásszékh" "adászszékh"	For example vadászszékhelye word
+nofor correct "ADÁSSZÉKH" "ADÁSZSZÉKH"	For example VADÁSZSZÉKHELY word
 nofor correct "ányásszer" "ányászszer"	For example bányászszerszámok word
+nofor correct "ÁNYÁSSZER" "ÁNYÁSZSZER"	For example BÁNYÁSZSZEREPLŐK word
 nofor correct "ónusszala" "ónuszszala"	For example bónuszszalagot word
+nofor correct "ÓNUSSZALA" "ÓNUSZSZALA"	For example BÓNUSZSZALAGOT word
 nofor correct "orásszakm" "orászszakm"	For example borászszakma word
+nofor correct "ORÁSSZAKM" "ORÁSZSZAKM"	For example BORÁSZSZAKMA word
 nofor correct "ombásszer" "ombászszer"	For example gombászszerenncse word
+nofor correct "OMBÁSSZER" "OMBÁSZSZER"	For example GOMBÁSZSZERENCSE word
 nofor correct "kalásszám" "kalászszám"	For example kalászszám word
 nofor correct "Kalásszám" "Kalászszám"	For example Kalászszám word
+nofor correct "KALÁSSZÁM" "KALÁSZSZÁM"	For example KALÁSZSZÁM word
 nofor correct "áosszer" "áoszszer"	For example káoszszerű word
+nofor correct "ÁOSSZER" "ÁOSZSZER"	For example KÁOSZSZERŰ word
 nofor correct "kusszel" "kuszszel"	For example kókuszszelet word
+nofor correct "KUSSZEL" "KUSZSZEL"	For example KÓKUSZSZELET word
 nofor correct "tussznob" "tuszsznob"	For example kultuszsznobizmus word
+nofor correct "TUSSZNOB" "TUSZSZNOB"	For example KULTUSZSZNOBIZMUS word
 nofor correct "szerésszöv" "szerészszöv"	For example Látszerészszövetség word
+nofor correct "SZERÉSSZÖV" "SZERÉSZSZÖV"	For example LÁTSZERÉSZSZÖVETSÉG word
 nofor correct "niszkusszak" "niszkuszszak"	For example meniszkuszszakadással word
+nofor correct "NISZKUSSZAK" "NISZKUSZSZAK"	For example MENISZKUSZSZAKADÁS word
 nofor correct "tosszál" "toszszál"	For example mítoszszál word
+nofor correct "TOSSZÁL" "TOSZSZÁL"	For example MÍTOSZSZÁL word
 nofor correct "ákásszak" "ákászszak"	For example rákászszakmáról word
+nofor correct "ÁKÁSSZAK" "ÁKÁSZSZAK"	For example RÁKÁSZSZAK word
 nofor correct "sósszer" "sószszer"	For example sószszerű word
+nofor correct "SÓSSZER" "SÓSZSZER"	For example SÓSZSZERŰ word
 nofor correct "enisszer" "eniszszer"	For example teniszszerelésben, teniszszervezetek words
+nofor correct "ENISSZER" "ENISZSZER"	For example TENISZSZERELÉS word
 nofor correct "enisszez" "eniszszez"	for example teniszszezon word
+nofor correct "ENISSZEZ" "ENISZSZEZ"	For example TENISZSZEZON word
 nofor correct "ransszi" "ranszszi"	For example transzszibériai, Transzszibériai, transzszimfónia words
+nofor correct "RANSSZI" "RANSZSZI"	For example TRANSZSZINFÓNIA word
 nofor correct "ansszí" "anszszí"	For example transzszínész word
+nofor correct "ANSSZÍ" "ANSZSZÍ"	For example TRANSZSZÍNÉSZ word
 nofor correct "adásszakm" "adászszakm"	For example vadászszakmai, Vadászszakmai words
+nofor correct "ADÁSSZAKM" "ADÁSZSZAKM"	For example VADÁSZSZAKMA word
 nofor correct "ohásszer" "ohászszer"	For example vaskohászszervezetének word
+nofor correct "OHÁSSZER" "OHÁSZSZER"	For example KOHÁSZSZERVEZET word
 nofor correct "iasszí" "iaszszí"	For example viaszszívű word
+nofor correct "IASSZÍ" "IASZSZÍ"	For example VIASZSZÍVŰ word
 nofor correct "szósszer" "szószszer"	For example szószszerű word
+nofor correct "SZÓSSZER" "SZÓSZSZER"	For example SZÓSZSZERŰ word
 nofor correct "ésszir" "észszir"	For example vészszirénázás word
+nofor correct "ÉSSZIR" "ÉSZSZIR"	For example VÉSZSZIRÉNÁZÁS word
 nofor correct "ésszárma" "észszárma"	For example mészszármazék word
-nofor correct "ölcséssza" "ölcsészsza"	For example bölcsészszagú,  bölcsészszak word
+nofor correct "ÉSSZÁRMA" "ÉSZSZÁRMA"	For example MÉSZSZÁRMAZÉK word
+nofor correct "ölcséssza" "ölcsészsza"	For example bölcsészszagú, bölcsészszak word
+nofor correct "ÖLCSÉSSZA" "ÖLCSÉSZSZA"	For example BÖLCSÉSZSZAGÚ word
 nofor correct "ísszárny" "íszszárny"	For example díszszárnyas word
+nofor correct "ÍSSZÁRNY" "ÍSZSZÁRNY"	For example DÍSZSZÁRNYAS word
 nofor correct "alásszöv" "alászszöv"	For example Halászszövetség word
+nofor correct "ALÁSSZÖV" "ALÁSZSZÖV"	For example HALÁSZSZÖVETSÉG word
 nofor correct "ajesször" "ajeszször"	For example pajesszörnyeké word
+nofor correct "AJESSZÖR" "AJESZSZÖR"	For example PAJESZSZÖRNYEKÉ word
 nofor correct "obrásszak" "obrászszak"	For example szobrászszakkörében word
+nofor correct "OBRÁSSZAK" "OBRÁSZSZAK"	For example SZOBRÁSZSZAKKÖR word
 nofor correct "avasszent" "avaszszent"	For example Tavaszszentelő word
+nofor correct "AVASSZENT" "AVASZSZENT"	For example TAVASZSZENTELŐ word
 nofor correct "ívverésszám" *
+nofor correct "ÍVVERÉSSZÁM" *	For example SZÍVVERÉSSZÁM word
 nofor correct "ipesszer" "ipeszszer"	For example csipeszszerű word
+nofor correct "IPESSZER" "IPESZSZER"	For example CSIPESZSZERŰ word
 nofor correct "allosszimbólu" "alloszszimbólu"	For example falloszszimbólum word
+nofor correct "ALLOSSZIMBÓLU" "ALLOSZSZIMBÓLU"	For example FALLOSZSZIMBÓLUM word
 nofor correct "ússzobr" *	For example hússzobrokból word not need apply the szsz backtranslation rule
+nofor correct "ÚSSZOBR" *	For example HÚSSZOBROKBÓL word
 nofor correct "ússzob" "úszszob"	For example húszszobás word
+nofor correct "ÚSSZOB" "ÚSZSZOB"	For example HÚSZSZOBÁS word
 nofor correct "amasszag" "amaszszag"	For example kamaszszaga word
+nofor correct "AMASSZAG" "AMASZSZAG"	For example KAMASZSZAG word
 nofor correct "árcisszü" "árciszszü"	For example nárciszszüret word
+nofor correct "ÁRCISSZÜ" "ÁRCISZSZÜ"	For example NÁRCISZSZÜRET word
 nofor correct "enisszak" "eniszszak"	For example teniszszakíró word
+nofor correct "ENISSZAK" "ENISZSZAK"	For example TENISZSZAKÉRTŐ word
 nofor correct "enisszív" "eniszszív"	For example teniszszív word
+nofor correct "ENISSZÍV" "ENISZSZÍV"
 nofor correct "vésszellő" "vészszellő"	For example vészszellőző, vészszellőző-nyílással
+nofor correct "Vésszellő" "Vészszellő"	For example Vészszellőző word
+nofor correct "VÉSSZELLŐ" "VÉSZSZELLŐ"	For example VÉSZSZELLŐZŐ word
 nofor correct "everéssze" *	For example heverésszen word
+nofor correct "EVERÉSSZE" *	For example HEVERÉSSZEN word
 nofor correct "átossze" "átoszsze"	For example pátoszszerű word
+nofor correct "ÁTOSSZE" "ÁTOSZSZE"	For example PÁTOSZSZEMMEL word
 nofor correct "ürkésszemm" "ürkészszemm"	For example fürkészszemmel word
+nofor correct "ÜRKÉSSZEMM" "ÜRKÉSZSZEMM"	For example FÜRKÉSZSZEMMEL word
 nofor correct "eksszere" "ekszszere"	For example kekszszerető word
+nofor correct "EKSSZERE" "EKSZSZERE"	For example KEKSZSZERETŐ word
 nofor correct "ógyásszak" "ógyászszak"	For example belgyógyászszakorvosa word
+nofor correct "ÓGYÁSSZAK" "ÓGYÁSZSZAK"	For example BELGYÓGYÁSZSZAKORVOSA word
 nofor correct "résszin" "részszin"	For example részszintidőt word
 nofor correct "Résszin" "Részszin"	For example Részszintidőt word
+nofor correct "RÉSSZIN" "RÉSZSZIN"	For example RÉSZSZINTIDŐT word
 nofor correct "ífusszer" "ífuszszer"	For example tífuszszerű word
+nofor correct "ÍFUSSZER" "ÍFUSZSZER"	For example TÍFUSZSZERŰ word
 nofor correct "éhésszer" "éhészszer"	For example méhészszervezet word
+nofor correct "ÉHÉSSZER" "ÉHÉSZSZER"	For eample MÉHÉSZSZERVEZET word
 nofor correct "éhésszöv" "éhészszöv"	For example méhészszövetség word
-nofor correct "Szesszigo" "Szeszszigo"	For example Szeszszigorításról word
+nofor correct "ÉHÉSSZÖV" "ÉHÉSZSZÖV"	For example MÉHÉSZSZÖVETSÉG word
 nofor correct "szesszigo" "szeszszigo"	For example szeszszigorításról
+nofor correct "Szesszigo" "Szeszszigo"	For example Szeszszigorításról word
+nofor correct "SZESSZIGO" "SZESZSZIGO"	For example SZESZSZIGORÍTÁSRÓL word
 nofor correct "ransszű" "ranszszű"	For example transzszűz word
+nofor correct "RANSSZŰ" "RANSZSZŰ"	For example TRANSZSZŰZ word
 nofor correct "elérésszá" *	For example elérésszám word
 nofor correct "Elérésszá" *	For example Elérésszám word
+nofor correct "ELÉRÉSSZÁ" *	For example ELÉRÉSSZÁM word
 nofor correct "ónusszolg" "ónuszszolg"	For example bónuszszolgáltatás word
+nofor correct "ÓNUSSZOLG" "ÓNUSZSZOLG"	For example BÓNUSZSZOLGÁLTATÁS word
 nofor correct "iabétesszű" "iabéteszszű"	For example diabéteszszűrés, diabéteszszűrését words
+nofor correct "IABÉTESSZŰ" "IABÉTESZSZŰ"	For example DIABÉTESZSZŰRÉS word
 nofor correct "ekesszin" "ekeszszin"	For example rekeszszindróma, rekeszszintézis words
+nofor correct "EKESSZIN" "EKESZSZIN"	For example REKESZSZINDRÓMA word
 nofor correct "enisszurk" "eniszszurk"	For example teniszszurkolók word
+nofor correct "ENISSZURK" "ENISZSZURK"	For example TENISZSZURKOLÓK word
 nofor correct "résszüne" "részszüne"	For example részszünet word
 nofor correct "Résszüne" "Részszüne"	For example Részszünet word
 nofor correct "RÉSSZÜNE" "RÉSZSZÜNE"	For example RÉSZSZÜNET word
 nofor correct "ítosszal" *
+nofor correct "ÍTOSSZAL" *	For example MÍTOSSZAL word
 nofor correct "ítossza" "ítoszsza"	For example mítoszszag word
+nofor correct "ÍTOSSZA" "ÍTOSZSZA"	For example MÍTOSZSZAG word
 nofor correct "ísszón" "íszszón"	For example díszszónokának word
+nofor correct "ÍSSZÓN" "ÍSZSZÓN"	For example DÍSZSZÓNOKAINAK word
 nofor correct "vadásszáll" "vadászszáll"	For example vadászszállás word
 nofor correct "Vadásszáll" "Vadászszáll"	For example Vadászszállás word
 nofor correct "VADÁSSZÁLL" "VADÁSZSZÁLL"	For example VADÁSSZÁLLÁS word
 nofor correct "tátusszt" "tátuszszt"	For example státuszsztori word
+nofor correct "TÁTUSSZT" "TÁTUSZSZT"	For example STÁTUSZSZTORI word
 nofor correct "busszám" "buszszám"	For example buszszámot word
 nofor correct "Busszám" "Buszszám"	For example Buszszám word
 nofor correct "BUSSZÁM" "BUSZSZÁM"	For example BUSZSZÁMOT word
 nofor correct "ókusszür" "ókuszszür"	For example kókuszszüretelő word
+nofor correct "ÓKUSSZÜR" "ÓKUSZSZÜR"	For example KÓKUSZSZÜRETELŐ word
 nofor correct "észösszegé" *	For example részösszegé word
 nofor correct "ÉSZÖSSZEGÉ" *	For example RÉSZÖSSZEGÉ word
 nofor correct "szösszegé" "szöszszegé"	For example szöszszegénysége word
 nofor correct "Szösszegé" "Szöszszegé"	For example Szöszszegénysége word
 nofor correct "SZÖSSZEGÉ" "SZÖSZSZEGÉ"	For example SZÖSZSZEGÉNYSÉGE word
 nofor correct "űvésszt" "űvészszt"	For example művészsztár word
+nofor correct "ŰVÉSSZT" "ŰVÉSZSZT"	For example BŰVÉSZSZTÁR word
 nofor correct "enisszen" "eniszszen"	For example teniszszentély word
+nofor correct "ENISSZEN" "ENISZSZEN"	For example TENISZSZENZÁCIÓ word
 nofor correct "vésszi" "vészszi"	for example vészszirénázás, vészszituáció word
+nofor correct "Vésszi" "Vészszi"	For example Vészszirénázást, Vészszituáció word
+nofor correct "VÉSSZI" "VÉSZSZI"	For example VÉSZSZIRÉNÁZÁST, VÉSZSZITUÁCIÓ word
 nofor correct "imnussze" "imnuszsze"	For example himnuszszerű word
+nofor correct "IMNUSSZE" "IMNUSZSZE"	For example HIMNUSZSZERŰ word
 nofor correct "szösszent" "szöszszent"	For example szöszszentben word
+nofor correct "Szösszent" "Szöszszent"	For example Szöszszentben word
+nofor correct "SZÖSSZENT" "SZÖSZSZENT"	For example SZÖSZSZENTBEN word
 nofor correct "pítésszt" "pítészszt"	For example építészsztár, Építészsztár words
+nofor correct "PÍTÉSSZT" "PÍTÉSZSZT"	For example ÉPÍTÉSZSZTÁR word
 nofor correct "ányásszáz" "ányászszáz"	For example bányászszázad word
+nofor correct "ÁNYÁSSZÁZ" "ÁNYÁSZSZÁZ"	For example BÁNYÁSZSZÁZAD word
 nofor correct "obrásszek" "obrászszek"	For example szobrászszekció word
+nofor correct "OBRÁSSZEK" "OBRÁSZSZEK"	For example SZOBRÁSZSZEKCIÓ word
 nofor correct "akmusszer" "akmuszszer"	For example lakmuszszerepéről word
+nofor correct "AKMUSSZER" "AKMUSZSZER"	For example LAKMUSZSZEREPÉRŐL word
 nofor correct "résszöv" "részszöv"	For example részszövetségben word
+nofor correct "Résszöv" "Részszöv"	For example Részszövetségben word
+nofor correct "RÉSSZÖV" "RÉSZSZÖV"	For example RÉSZSZÖVETSÉGBEN word
 nofor correct "neisszikl" "neiszszikl"	For example gneissziklákat word
+nofor correct "NEISSZIKL" "NEISZSZIKL"	For example GNEISZSZIKLÁKAT word
 nofor correct "űrésszá" *	For example szűrészszám word
+nofor correct "ŰRÉSSZÁ" *	For example SZŰRÉSSZÁM word
 nofor correct "rdésszak" "rdészszak"	For example erdészszakmai word
+nofor correct "RDÉSSZAK" "RDÉSZSZAK"	For example ERDÉSZSZAK word
 nofor correct "örténésszöv" "örténészszöv"	For example történészszövetség word
+nofor correct "ÖRTÉNÉSSZÖV" "ÖRTÉNÉSZSZÖV"	For example TÖRTÉNÉSZSZÖVETSÉG word
 nofor correct "rverésszá" *
+nofor correct "RVERÉSSZÁ" *
 nofor correct "ősszakál" "őszszakál"	For example őszszakállú word
 nofor correct "Ősszakál" "Őszszakál"	For example Őszszakállú word
 nofor correct "ŐSSZAKÁL" "ŐSZSZAKÁL"	For example ŐSZSZAKÁLLÚ word
 nofor correct "uhásszáll" "uhászszáll"	For example juhászszállások word
+nofor correct "UHÁSSZÁLL" "UHÁSZSZÁLL"	For example JUHÁSZSZÁLLÁS word
 nofor correct "éhésszak" "éhészszak"	For example méhészszakkör word
+nofor correct "ÉHÉSSZAK" "ÉHÉSZSZAK"	For example MÉHÉSZSZAKKÖR word
 nofor correct "enisszet" "eniszszet"	For example teniszszettje word
+nofor correct "ENISSZET" "ENISZSZET"	For example TENISZSZETTJE word
 nofor correct "ornásszez" "ornászszez"	For example tornászszezon word
+nofor correct "ORNÁSSZEZ" "ORNÁSZSZEZ"	For example TORNÁSZSZEZON word
 nofor correct "fasszar" "faszszar"	For example faszszar word
 nofor correct "Fasszar" "Faszszar"	For example Faszszar word
 nofor correct "FASSZAR" "FASZSZAR"	For example FASZSZAR word
 nofor correct "oksszen" "okszszen"	For example bokszszentháromság word
+nofor correct "OKSSZEN" "OKSZSZEN"	For examőple BOKSZSZENTÉLY word
 nofor correct "boksszab" "bokszszab"	For example bokszszabály word
 nofor correct "Boksszab" "Bokszszab"	For example Bokszszabály word
 nofor correct "BOKSSZAB" "BOKSZSZAB"	For example BOKSZSZABÁLY word
 nofor correct "alásszem" "alászszem"	For example kalászszemle word
+nofor correct "ALÁSSZEM" "ALÁSZSZEM"	For example KALÁSZSZEMLE word
 nofor correct "lusszé" "luszszé"	For example pluszszéket word
+nofor correct "LUSSZÉ" "LUSZSZÉ"	For example PLUSZSZÉKET word
 nofor correct "ihalásszer" *	For example kihalászszerű word
+nofor correct "IHALÁSSZER" *	For example KIHALÁSSZERŰ word
 nofor correct "Busszer" "Buszszer"	For example Buszszerű, Buszszerencsétlenség word
 nofor correct "BUSSZER" "BUSZSZER"	For example BUSZSZERŰ word
 nofor correct "génnyom" *	For example oxigénnyomás word
+nofor correct "GÉNNYOM" *	For example OXIGÉNNYOM word
 nofor correct "imnusszöv" "imnuszszöv"	For example himnuszszöveg word
+nofor correct "IMNUSSZÖV" "IMNUSZSZÖV"	For example HIMNUSZSZÖVEGET word
 nofor correct "iasszöv" "iaszszöv"	For example viaszszövedékből word
+nofor correct "IASSZÖV" "IASZSZÖV"	For example VIASZSZÖVEDÉKET word
 nofor correct "hajtássz" *	For example hajtásszázalék word
 nofor correct "Hajtássz" *	For example Hajtásszázalék word
 nofor correct "HAJTÁSSZ" *	For example HAJTÁSSZÁZALÉK word
@@ -759,13 +1271,16 @@ nofor correct "horgásszab" "horgászszab"	For example horgászszabályok word
 nofor correct "Horgásszab" "Horgászszab"	For example Horgászszabályok word
 nofor correct "HORGÁSSZAB" "HORGÁSZSZAB"	For example HORGÁSZSZABÁLYOK word
 nofor correct "ókusszap" "ókuszszap"	For example kókuszszappan word
+nofor correct "ÓKUSSZAP" "ÓKUSZSZAP"	For example KÓKUSZSZAPPAN word
 nofor correct "lkusszoft" "lkuszszoft"	For example alkuszszoftverek word
 nofor correct "LKUSSZOFT" "LKUSZSZOFT"	For example ALKUSZSZOFTWEREK word
 nofor correct "ísszől" "íszszől"	For example díszszőlők word
+nofor correct "ÍSSZŐL" "ÍSZSZŐL"	For example DÍSZSZŐLŐK word
 nofor correct "szülésszakér" *	For example szülésszakértő word
 nofor correct "Szülésszakér" *	For example Szülésszakértő word
 nofor correct "SZÜLÉSSZAKÉR" *	For example SZÜLÉSSZAKÉRTŐ word
 nofor correct "ússzintes" "úszszintes"	For example húszszintes word
+nofor correct "ÚSSZINTES" "ÚSZSZINTES"	For example HÚSZSZINTES word
 nofor correct "ókusszűr" "ókuszszűr"	For example fókuszszűrő word
 nofor correct "ÓKUSSZŰR" "ÓKUSZSZŰR"	For example FÓKUSZSZŰRŐ word
 nofor correct "busszáll" "buszszáll"	For example buszszállítás word
@@ -883,8 +1398,8 @@ nofor correct "übrisszindr" "übriszszindr"	For example hübriszszindróma, hü
 nofor correct "ÜBRISSZINDR" "ÜBRISZSZINDR"	For example HÜBRISZSZINDRÓMA, HÜBRISZSZINDRÓMÁBAN words
 nofor correct "ukrásszto" "ukrászszto"	For example cukrászsztori word
 nofor correct "UKRÁSSZTO" "UKRÁSZSZTO"	For example CUKRÁSZSZTORI word
-nofor correct "örösszí" *   For example vörösszínű word
-nofor correct "ÖRÖSSZÍ" *   For example VÖRÖSSZÍNŰ word
+nofor correct "örösszí" *	For example vörösszínű word
+nofor correct "ÖRÖSSZÍ" *	For example VÖRÖSSZÍNŰ word
 nofor correct "összín" "öszszín"	For example löszszín word
 nofor correct "ÖSSZÍN" "ÖSZSZÍN"	For example LÖSZSZÍN word
 nofor correct "tússzer" "túszszer"	For example túszszerű word
@@ -945,8 +1460,8 @@ nofor correct "egyésszöv" "egyészszöv"	For example Vegyészszövetség word
 nofor correct "EGYÉSSZÖV" "EGYÉSZSZÖV"	For example VEGYÉSZSZÖVETSÉG word
 nofor correct "ermésszór" *	For example termésszórás word
 nofor correct "ERMÉSSZÓR" *	For example TERMÉSSZÓRÁS word
-nofor correct "árcisszed" "árciszszed"  For example nárciszszedés word
-nofor correct "ÁRCISSZED" "ÁRCISZSZED"  For example nÁRCISZSZEDÉS word
+nofor correct "árcisszed" "árciszszed"	For example nárciszszedés word
+nofor correct "ÁRCISSZED" "ÁRCISZSZED"	For example nÁRCISZSZEDÉS word
 nofor correct "erkesszelle" "erkeszszelle"	For example cserkeszszellemiséget word
 nofor correct "ERKESSZELLE" "ERKESZSZELLE"	For example CSERKESZSZELLEMISÉGET word
 nofor correct "odrássztá" "odrászsztá"	For example fodrászsztár word
@@ -962,10 +1477,191 @@ nofor correct "ésszívat" "észszívat"	For example részszívatásátadás wor
 nofor correct "ÉSZSZÍVAT" "ÉSZSZÍVAT"	For example RÉSZSZÍVATÁSÁTADÁS word
 nofor correct "ambusszem" "ambuszszem"	For example bambuszszemcse word
 nofor correct "AMBUSSZEM" "AMBUSZSZEM"	For example bambuszszemcse word
+nofor correct "AMBUSSZEM" "AMBUSZSZEM"	For example BAMBUSZSZEMCSE word
+nofor correct "ertésszakkö" "ertészszakkö"	For example kertészszakkör word
+nofor correct "ERTÉSSZAKKÖ" "ERTÉSZSZAKKÖ"	for example KERTÉSZSZAKKÖR words
+nofor correct "ótusszülé" "ótuszszülé"	For example lótuszszülés word
+nofor correct "ÓTUSSZÜLÉ" "ÓTUSZSZÜLÉ"	For example LÓTUSZSZÜLÉS word
+nofor correct "öntéssz" *	For example döntésszegéről word
+nofor correct "ÖNTÉSSZ" *	For example DÖNTÉSSZEGÉRŐL word
+nofor correct "iznisszemlé" "izniszszemlé"	For example bizniszszemlélet word
+nofor correct "IZNISSZEMLÉ" "IZNISZSZEMLÉ"	For example BIZNISZSZEMLÉLET word
+nofor correct "oksszurkol" "okszszurkol"	For example bokszszurkolók word
+nofor correct "OKSSZURKOL" "OKSZSZURKOL"	For example BOKSZSZURKOLÓK word
+nofor correct "urzusszín" *	For example kurzusszínész, kurzusszínház words
+nofor correct "URZUSSZÍN" *	For example KURZUSSZÍNÉSZ, KURZUSSZÍNHÁZ words
+nofor correct "elentésszó" *	For example jelentésszóró word
+nofor correct "ELENTÉSSZÓ" *	For example JELENTÉSSZÓRÓ word
+nofor correct "amassze" "amaszsze"	For example kamaszszemmel word
+nofor correct "AMASSZE" "AMASZSZE"	For example KAMASZSZEMMEL word
+nofor correct "rekesszabá" "rekeszszabá"	For example rekeszszabályozás word
+nofor correct "Rekesszabá" "Rekeszszabá"	For example Rekeszszabályozás word
+nofor correct "REKESSZABÁ" "REKESZSZABÁ"	For example REKESZSZABÁLYOZÁS word
+nofor correct "ókusszo" "ókuszszo"	For example fókuszszobák word
+nofor correct "ÓKUSSZO" "ÓKUSZSZO"	For example FÓKUSZSZOBÁK word
+nofor correct "gyásszimb" "gyászszimb"	For example gyászszimbólumként word
+nofor correct "Gyásszimb" "Gyászszimb"	For example Gyászszimbólumként word
+nofor correct "GYÁSSZIMB" "GYÁSZSZIMB"	For example GYÁSZSZIMBÓLUMKÉNT word
+nofor correct "adásszaf" "adászszaf"	For example vadászszafari word
+nofor correct "ADÁSSZAF" "ADÁSZSZAF"	For example VADÁSZSZAFARIRA word
+nofor correct "posszerű" "poszszerű"	For example eposzszerű, toposzszerű words
+nofor correct "POSSZERŰ" "POSZSZERŰ"	For example EPOSZSZERŰ word
+nofor correct "ekesszö" "ekeszszö"	For example rekeszszöggel word
+nofor correct "EKESSZÖ" "EKESZSZÖ"	For example REKESZSZÖGGEL word
+nofor correct "álasszolg" "álaszszolg"	For example válaszszolgáltatásokat word
+nofor correct "ÁLASSZOLG" "ÁLASZSZOLG"	For example VÁLASZSZOLGÁLTATÁSOKAT word
+nofor correct "adásszaka" "adászszaka"	For example vadászszakasz, határvadászszakaszon words
+nofor correct "ADÁSSZAKA" "ADÁSZSZAKA"	For example VADÁSZSZAKASZ, HATÁRVADÁSZSZAKASZ words
+nofor correct "opogássz" *	For example kopogásszenzor word
+nofor correct "OPOGÁSSZ" *	For example KOPOGÁSSZENZORT words
+nofor correct "amasszak" "amaszszak"	For example kamaszszakasz, Kamaszszakasz words
+nofor correct "AMASSZAK" "AMASZSZAK"	For example KAMASZSZAKASZ words
+nofor correct "ajusszép" "ajuszszép"	For example bajuszszépség word
+nofor correct "AJUSSZÉP" "AJUSZSZÉP"	For example BAJUSZSZÉPSÉG word
+nofor correct "eresszin" "ereszszin"	For example ereszszint word
+nofor correct "Eresszin" "Ereszszin"	For example Ereszszint word
+nofor correct "ERESSZIN" "ERESZSZIN"	For example ERESZSZINT word
+nofor correct "éjanássze" "éjanászsze"	For example héjanászszerűen word
+nofor correct "ÉJANÁSSZE" "ÉJANÁSZSZE"	for example héjanászszerűen word
+nofor correct "anccsont" "ancscsont"	For example mancscsont word
+nofor correct "ANCCSONT" "ANCSCSONT"	For example MANCSCSONT word
+nofor correct "ampusszer" "ampuszszer"	For example krampuszszerep, krampuszszervezet words
+nofor correct "AMPUSSZER" "AMPUSZSZER"	For example KRAMPUSZSZEREP, KRAMPUSZSZERVEZET words
+nofor correct "ultusszim" "ultuszszim"	For example kultuszszimbólum word
+nofor correct "ULTUSSZIM" "ULTUSZSZIM"	For example KULTUSZSZIMBÓLUM word
+nofor correct "ivaccsat" "ivacscsat"	For example szivacscsatákat word
+nofor correct "IVACCSAT" "IVACSCSAT"	For example SZIVACSCSATÁKAT word
+nofor correct "álasszav" "álaszszav"	For example válaszszava word
+nofor correct "ÁLASSZAV" "ÁLASZSZAV"	For example VÁLASZSZAVAZÁS word
+nofor correct "álasszerv" "álaszszerv"	For example válaszszervezés word
+nofor correct "ÁLASSZERV" "ÁLASZSZERV"	For example VÁLASZSZERVEZÉS word
+nofor correct "összurdo" "öszszurdo"	For example löszszurdok word
+nofor correct "ÖSSZURDO" "ÖSZSZURDO"	For example LÖSZSZURDOK word
+nofor correct "ésszemecs" "észszemecs"	For example mészszemecskéket word
+nofor correct "ÉSSZEMECS" "ÉSZSZEMECS"	For example MÉSZSZEMECSKÉKET word
+nofor correct "énisszöve" "éniszszöve"	For example péniszszövethez word
+nofor correct "ÉNISSZÖVE" "ÉNISZSZÖVE"	For example PÉNISZSZÖVETHEZ word
+nofor correct "irkusszer" "irkuszszer"	For example cirkuszszerű word
+nofor correct "IRKUSSZER" "IRKUSZSZER"	For example CIRKUSZSZERŰ word
+nofor correct "vénnyilvá" "vénynyilvá"	For example vénynyilvántartás word
+nofor correct "Vénnyilvá" "Vénynyilvá"	For example Vénynyilvántartás word
+nofor correct "VÉNNYILVÁ" "VÉNYNYILVÁ"	For example VÉNYNYILVÁNTARTÁS word
+nofor correct "ubussz" *	For example tubusszámra, tubusszerű word
+nofor correct "UBUSSZ" *	For example TUBUSSZÁMRA word
+nofor correct "obrásszöv" "obrászszöv"	For example szobrászszövetség word
+nofor correct "OBRÁSSZÖV" "OBRÁSZSZÖV"	For example SZOBRÁSZSZÖVETSÉG word
+nofor correct "ússzelep" "úszszelep"	For example húszszelepes word
+nofor correct "ÚSSZELEP" "ÚSZSZELEP"	For example HÚSZSZELEPES word
+nofor correct "iznisszekt" "izniszszekt"	For example bizniszszektájában word
+nofor correct "IZNISSZEKT" "IZNISZSZEKT"	For example BIZNISZSZEKTÁJÁBAN word
+nofor correct "illagásszak" "illagászszak"	For example csillagászszakkörben word
+nofor correct "ILLAGÁSSZAK" "ILLAGÁSZSZAK"	For example CSILLAGÁSZSZAKKÖRBEN word
+nofor correct "anásszűr" "anászszűr"	For example kanászszűr word
+nofor correct "ANÁSSZŰR" "ANÁSZSZŰR"	For example KANÁSZSZŰR word
+nofor correct "oktorandusszer" "oktoranduszszer"	For example doktoranduszszervezet word
+nofor correct "OKTORANDUSSZER" "OKTORANDUSZSZER"	For example DOKTORANDUSZSZERVEZET word
+nofor correct "rikszkrakssze" "rikszkrakszsze"	For example krikszkrakszszerűség word
+nofor correct "RIKSZKRAKSSZE" "RIKSZKRAKSZSZE"	For example KRIKSZKRAKSZSZERŰSÉG word
+nofor correct "odrásszolg" "odrászszolg"	For example fodrászszolgáltatás word
+nofor correct "ODRÁSSZOLG" "ODRÁSZSZOLG"	For example FODRÁSZSZOLGÁLTATÁS word
+nofor correct "asszelet" "aszszelet"
+nofor correct "ASSZELET" "ASZSZELET"
+nofor correct "nterfésszabv" "nterfészszabv"	For example interfészszabványokkal word
+nofor correct "NTERFÉSSZABV" "NTERFÉSZSZABV"	For example INTERFÉSZSZABVÁNYOKKAL word
+nofor correct "őlésszekci" "őlészszekci"	For example szőlészszekció word
+nofor correct "ŐLÉSSZEKCI" "ŐLÉSZSZEKCI"	For example SZŐLÉSZSZEKCIÓ word
+nofor correct "enésszob" "enészszob"	For example zenészszobámban, zenészszobrocskákat word
+nofor correct "ENÉSSZOB" "ENÉSZSZOB"	For example ZENÉSZSZOBÁMBAN, ZENÉSZSZOBROCSKÁKAT word
+nofor correct "imnusszaké" "imnuszszaké"	For example himnuszszakértő word
+nofor correct "IMNUSSZAKÉ" "IMNUSZSZAKÉ"	For example HIMNUSZSZAKÉRTŐ word
+nofor correct "mésszag" "mészszag"	For example mészszagú word
+nofor correct "Mésszag" "Mészszag"	For example Mészszagú word
+nofor correct "MÉSSZAG" "MÉSZSZAG"	For example MÉSZSZAGÚ word
+nofor correct "irkusszöv" "irkuszszöv"	For example cirkuszszövetkezet word
+nofor correct "IRKUSSZÖV" "IRKUSZSZÖV"	For example CIRKUSZSZÖVETSÉG word
+nofor correct "odrásszöv" "odrászszöv"	For example fodrászszövetkezet word
+nofor correct "ODRÁSSZÖV" "ODRÁSZSZÖV"	For example FODRÁSZSZÖVETKEZET word
+nofor correct "rampusszöv" "rampuszszöv"	For example krampuszszövetség word
+nofor correct "RAMPUSSZÖV" "RAMPUSZSZÖV"	For example KRAMPUSZSZÖVETSÉG word
+nofor correct "annabisszin" "annabiszszin"	For example kannabiszszintet word
+nofor correct "ANNABISSZIN" "ANNABISZSZIN"	For example KANNABISZSZINTET word
+nofor correct "irolimusszárm" "irolimuszszárm"	For example szirolimuszszármazék word
+nofor correct "IROLIMUSSZÁRM" "IROLIMUSZSZÁRM"	For example SZIROLIMUSZSZÁRMAZÉK word
+nofor correct "ragyogyásszerű" *	For example ragyogyásszerű word
+nofor correct "Ragyogásszer" *	For example Ragyogásszerű word
+nofor correct "Ragyogásszer" *	For example Ragyogásszerű word
+nofor correct "RAGYOGÁSSZER" *	For example RAGYOGÁSSZERŰ word
+nofor correct "TÁTUSSZIMB" "TÁTUSZSZIMB"	For example STÁTUSZSZIMBÓLUM word
+nofor correct "pítésszalo" "pítészszalo"	For example építészszalon word
+nofor correct "PÍTÉSSZALO" "PÍTÉSZSZALO"	For example ÉPÍTÉSZSZALON word
+nofor correct "övegrésszókö" "övegrészszókö"	For example szövegrészszóköz word
+nofor correct "ÖVEGRÉSSZÓKÖ" "ÖVEGRÉSZSZÓKÖ"	For example SZÖVEGRÉSZSZÓKÖZ word
+nofor correct "álassztor" "álaszsztor"	For example válaszsztori word
+nofor correct "ÁLASSZTOR" "ÁLASZSZTOR"	For example VÁLASZSZTORI word
+nofor correct "bussztráj" "buszsztráj"	For example buszsztrájk word
+nofor correct "Bussztráj" "Buszsztráj"	For example Buszsztrájkos word
+nofor correct "BUSSZTRÁJ" "BUSZSZTRÁJ"	For example BUSZSZTRÁJK word
+nofor correct "horgásszim" "horgászszim"	For example horgászszimulátornál word
+nofor correct "Horgásszim" "Horgászszim"	For example Horgászszimulátor word
+nofor correct "HORGÁSSZIM" "HORGÁSZSZIM"	For example HORGÁSZSZIMULÁTOR word
+nofor correct "eksszállí" "ekszszállí"	For example kekszszállító word
+nofor correct "EKSSZÁLLÍ" "EKSZSZÁLLÍ"	For example KEKSZSZÁLLÍTÓ word
+nofor correct "kosszín" "koszszín"	For example koszszínű word
+nofor correct "Kosszín" "Koszszín"	For example Koszszínű word
+nofor correct "KOSSZÍN" "KOSZSZÍN"	For example KOSZSZÍNŰ word
+nofor correct "ajusszer" "ajuszszer"	For example bajuszszerű word
+nofor correct "AJUSSZER" "AJUSZSZER"	For example BAJUSZSZERŰ word
+nofor correct "iosszakkö" "ioszszakkö"	For example bioszszakkör word
+nofor correct "IOSSZAKKÖ" "IOSZSZAKKÖ"	For example BIOSZSZAKKÖR word
+nofor correct "ényképésszalo" "ényképészszalo"	For example fényképészszalon word
+nofor correct "ÉNYKÉPÉSSZALO" "ÉNYKÉPÉSZSZALO"	For example FÉNYKÉPÉSZSZALONJA word
+nofor correct "vadásszent" "vadászszent"	For example vadászszentély word
+nofor correct "Vadásszent" "Vadászszent"	For example Vadászszentély word
+nofor correct "VADÁSSZENT" "VADÁSZSZENT"	For example VADÁSZSZENTÉLY word
+nofor correct "oksszez" "okszszez"	For example bokszszezon word
+nofor correct "OKSSZEZ" "OKSZSZEZ"	For example BOKSZSZEZONBÓL word
+nofor correct "ényképésszöv" "ényképészszöv"	For example fényképészszövetség word
+nofor correct "ÉNYKÉPÉSSZÖV" "ÉNYKÉPÉSZSZÖV"	For example FÉNYKÉPÉSZSZÖVETSÉG word
+nofor correct "amasszlen" "amaszszlen"	For example kamaszszleng word
+nofor correct "AMASSZLEN" "AMASZSZLEN"	For example KAMASZSZLENG word
+nofor correct "ambusszöv" "ambuszszöv"	For example bambuszszövet word
+nofor correct "AMBUSSZÖV" "AMBUSZSZÖV"	For example BAMBUSZSZÖVET word
+nofor correct "orgásszol" "orgászszol"	For example horgászszolidalitás word
+nofor correct "ORGÁSSZOL" "ORGÁSZSZOL"	For example HORGÁSZSZOLIDALITÁS word
+nofor correct "ússzálas" "úszszálas"	For example húszszálas word
+nofor correct "ÚSSZÁLAS" "ÚSZSZÁLAS"	For example HÚSZSZÁLAS word
+nofor correct "obrásszoká" "obrászszoká"	For example szobrászszokás word
+nofor correct "OBRÁSSZOKÁ" "OBRÁSZSZOKÁ"	For example SZOBRÁSZSZOKÁS word
+nofor correct "enésszár" "enészszár"	For example zenészszárnyait word
+nofor correct "ENÉSSZÁR" "ENÉSZSZÁR"	For example ZENÉSZSZÁRNYAIT word
+nofor correct "amassztá" "amaszsztá"	For example kamaszsztárjának word
+nofor correct "AMASSZTÁ" "AMASZSZTÁ"	For example KAMASZSZTÁRJÁNAK word
+nofor correct "olbásszáll" "olbászszáll"	For example kolbászszállás word
+nofor correct "OLBÁSSZÁLL" "OLBÁSZSZÁLL"	For example KOLBÁSZSZÁLLÁS word
+nofor correct "fallosszer" "falloszszer"	For example falloszszerű word
+nofor correct "Fallosszer" "Falloszszer"	For example Falloszszerű word
+nofor correct "FALLOSSZER" "FALLOSZSZER"	For example FALLOSZSZERŰ word
+nofor correct "ipsszala" "ipszszala"	For example gipszszalag word
+nofor correct "IPSSZALA" "IPSZSZALA"	For example GIPSZSZALAG word
+nofor correct "szösszed" "szöszszed"	For example szöszszedő word
+nofor correct "Szösszed" "Szöszszed"	For example Szöszszedő word
+nofor correct "SZÖSSZED" "SZÖSZSZED"	For example SZÖSZSZEDŐ word
+nofor correct "ebéssziké" "ebészsziké"	For example sebészszikével word
+nofor correct "EBÉSSZIKÉ" "EBÉSZSZIKÉ"	For example SEBÉSZSZIKÉVEL word
+nofor correct "násszerz" "nászszerz"	For example nászszerződés word
+nofor correct "Násszerz" "Nászszerz"	For example Nászszerződés word
+nofor correct "NÁSSZERZ" "NÁSZSZERZ"	For example NÁSZSZERZŐDÉS word
+nofor correct "szösszűr" "szöszszűr"	For example szöszszűrőt word
+nofor correct "Szösszűr" "Szöszszűr"	For example Szöszszűrőt word
+nofor correct "SZÖSSZŰR" "SZÖSZSZŰR"	For example SZÖSZSZŰRŐT word
+nofor correct "ókusszí" "ókuszszí"	For example kókuszszívet word
+nofor correct "ÓKUSSZÍ" "ÓKUSZSZÍ"	For example KÓKUSZSZÍVET word
 
 #zszs backtranslated word corrections
 nofor correct "törzszsel" "törzzsel"
+nofor correct "TÖRZSZSEL" "TÖRZZSEL"
 nofor correct "törzszsé" "törzzsé"
+nofor correct "TÖRZSZSÉ" "TÖRZZSÉ"
 nofor correct "Törzszsel" "Törzzsel"
 nofor correct "Törzszsé" "Törzzsé"
 nofor correct "rizzsá" "rizszsá"	For example rizszsák, rizszsákokban words backtranslation correction
@@ -981,10 +1677,31 @@ nofor correct "o\x030b" "ő"
 nofor correct "—" "--"
 
 #non hungarian words corrections (for example town names)
+nofor correct "budejovic" "budějovic"	For example budějovicei town name
 nofor correct "Budejovic" "Budějovic"	For example Budějovicében, Budějovicéből words
+nofor correct "BUDEJOVIC" "BUDĚJOVIC"	The uppercase version town name
+nofor correct "bölga-" "bëlga-"
+nofor correct "Bölga-" "Bëlga-"
+nofor correct "BÖLGA-" "BËLGA-"
+nofor correct "bölgától" "bëlgától"
+nofor correct "Bölgától" "Bëlgától"
+nofor correct "BÖLGÁTÓL" "BËLGÁTÓL"
 nofor correct "Bölga-korpu" "Bëlga-korpu"
 nofor correct "Caön" "Caën" For example Caënban, Caënból town names
-nofor correct "Citroön" "Citroën"	For example Citroën, Citroënben words
 nofor correct "citroön" "citroën"
+nofor correct "Citroön" "Citroën"	For example Citroën, Citroënben words
+nofor correct "CITROÖN" "CITROËN"	For example CITROËN, CITROËNBEN words
 nofor correct "Fuzin" "Fužin"	For example Fužinában, Fužinából town names
+nofor correct "babec-" "babeș-" For example ș-bolyai university name
+nofor correct "Babec-" "Babeș-" For example Babeș-Bolyai university name
+nofor correct "BABEC-" "BABEȘ-" For example BABEȘ-BOLYAI university name
+nofor correct "eaucescu" "eaușescu" For ceaușescu non hungarian name
+nofor correct "EAUCESCU" "EAUȘESCU"
+nofor correct "chicinau" "chicinău"	For example chicină word
+nofor correct "Chicinau" "Chicinău"	For example Chicinău word
+nofor correct "CHICINAU" "CHIȘINĂU"	For example CHIȘINĂU word
+nofor correct "wroclaw" "wrocław"	For example wrocław town name (lowercase version)
+nofor correct "Wroclaw" "Wrocław"	For example Wrocław town name
+nofor correct "WROCLAW" "WROCŁAW"	For example WROCŁAW town name
 nofor correct "-_" "--"
+

--- a/tables/hu-chardefs.cti
+++ b/tables/hu-chardefs.cti
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2022 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2011-2023 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #
@@ -237,7 +237,7 @@ punctuation \x0085 3-3-3
 letter ç 14
 letter þ 245
 letter ø 12345
-letter ë 12345
+lowercase ë 12345
 punctuation º 0
 punctuation \x001e 36	If I replace this sequence with normal unicode character, lou_checktable present an error message
 letter è 15
@@ -270,6 +270,13 @@ noback always \x0075\x030b 23456
 noback always o\x030b 12456
 noback always u\x0308 123456
 noback always o\x0308 12345
+noback always e\x0301 16
+noback always u\x0308 12356
+noback always a\x0301 4
+noback always o\x0301 246
+lowercase \x0219 14
+lowercase ł 123
+lowercase ă 1
 
 # Uppercase letters
 base uppercase Á á
@@ -284,3 +291,8 @@ base uppercase Ö ö
 base uppercase Õ õ
 base uppercase Û û
 base uppercase Š š
+base uppercase Ě ě
+base uppercase Ë ë
+base uppercase \x0218 \x0219
+base uppercase Ł ł
+base uppercase Ă ă

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -1,6 +1,6 @@
 # liblouis: Hungarian Grade 1 table
 #
-#  Copyright (C) 2011-2022 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
+#  Copyright (C) 2011-2023 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu
 #
 #  This file is part of liblouis.
 #
@@ -54,8 +54,8 @@ partword tapolcsá 2345-1-1234-135-123-146-4
 begword opolcs 135-1234-135-123-146
 partword porcsé =	For example porcsérülés word
 begword szocsegé 156-135-14-234-15-1245-16	For example szocsegély word
+always orangutáncs 135-1235-1-1345-1245-136-2345-4-1345-146	For example orangutáncsalád word
 begword kóccs 13-246-14-146	For example kóccsomó word
-
 partword tánc =	For example tánccsoport word
 partword sátáncsap 234-4-2345-4-1345-146-1-1234	For example sátáncsapat word
 partword piac =	For example piaccsarnok word
@@ -146,7 +146,7 @@ partword léccs 123-16-14-146	For example díszléccsíkot word related need thi
 partword meccszá 134-15-146-146-126-4	For example meccszáró word related need this general exception
 partword csúcszen 146-346-146-126-15-1345	For example csúcszenekarának word related need this exception
 partword narancs 1345-1-1235-1-1345-146	For example narancszombi word related need this general exception
-partword platán =	For example platáncsoport, platáncsere word  need this general exception
+partword platán =	For example platáncsoport, platáncsere word need this general exception
 always csokilencs 146-135-13-24-123-15-1345-146	For example csokilencse, csokilencsét words
 always polcsalás 1234-135-123-146-1-123-4-234	For example szocpolcsalás word
 always harcstíl 125-1-1235-14-234-2345-34-123	For example harcstílus word
@@ -154,6 +154,21 @@ always metáncs 134-15-2345-4-1345-146	For example metáncsökkentéssel word
 always arcsej 1-1235-14-234-15-245	For example arcsebész, arcsejtekkel word
 always lánccsopo 123-4-1345-14-146-135-1234-135	For example lánccsoport word
 always bíbiccs 12-34-12-24-14-146	For example bíbiccsapat word
+always lánccser 123-4-1345-14-146-15-1235	For example lánccsere word
+always bérencsé 12-16-1235-15-1345-14-234-16	For example bérencséggel word
+
+#csz letters related exceptions
+always pöcszong 1234-12345-146-126-135-1345-1245	For example pöcszongorás word
+always bakancszo 12-1-13-1-1345-146-126-135	For example bakancszokni word
+always csúcszó 146-246-146-126-246	For example csúcszóna word
+always csúcszong 146-346-146-126-135-1345-1245	For example csúcszongora, csúcszongorista word
+always abroncsza 1-12-1235-135-1345-146-126-1	For example abroncszaj word
+always gyümölcsza 1456-12356-134-12345-123-146-126-1	For example gyümölcszamatú word
+always kincszab 13-24-1345-146-126-1-12	For example műkincszabráló word
+always szendvicsza 156-15-1345-145-1236-24-146-126-1	For example szendvicszabáló, szendvicszacskó words
+always bilincszuh 12-24-123-24-1345-146-126-136-125	For example bilincszuhatag word
+always szivacsz 156-24-1236-1-146-126	For example szivacszátony word
+always fröccszó 124-1235-12345-146-146-126-246	For example fröccszónában word
 
 #gy, ggy related exceptions
 #This exception section containing word parts and full words with need marking ggy letter pairs with single g and gy braille dot combination
@@ -198,17 +213,16 @@ word meggyel 134-15-1456-1456-15-123	For example meggyel word
 endword meggyel 134-15-1456-1456-15-123	For example meggyel word
 word meggyen 134-15-1456-1456-15-1345	For example meggyen word
 endword meggyen 134-15-1456-1456-15-1345	For example spanyolmeggyen word
-always meggyes 134-15-1456-1456-15-234	For example meggyes pite, Meggyesi  word parts
+always meggyes 134-15-1456-1456-15-234	For example meggyes pite, Meggyesi word parts
 always meggyet 134-15-1456-1456-15-2345	For example meggyet word
 partword meggyb 134-15-1456-1456-12	For example meggybefőtt word
 partword meggyf 134-15-1456-1456-124	For example meggyfa word part
 partword meggyh 134-15-1456-1456-125	For example meggyhez word part
 partword meggyk 134-15-1456-1456-13	For example meggyként word
 partword meggyl 134-15-1456-1456-123	For example meggylekvár word
+partword meggyny 134-15-1456-1456-1246	For example meggynyi, meggynyerő word
 partword meggyn 134-15-1456-1456-1345	For example meggynek word part
-partword meggynyi 134-15-1456-1456-1246-24	For example meggynyi word part
 word meggynyi 134-15-1456-1456-1246-24	For example meggynyi word
-
 partword meggym 134-15-1456-1456-134	For example meggymag word
 partword meggyp 134-15-1456-1456-1234	For example meggypiros word
 partword meggys 134-15-1456-1456-234	For example meggysör word
@@ -356,6 +370,45 @@ always szalaggyen 156-1-123-1-1245-1456-15-1345	For example szalaggyengeség wor
 always tréninggy 2345-1235-16-1345-24-1345-1245-1456	For example tréninggyakorlatokon word
 always sárgasággy 234-4-1235-1245-1-234-4-1245-1456	For example sárgasággyanús word
 always pitypanggy 1234-24-1256-1234-1-1345-1245-1456	For example pitypanggyökér word
+always meggyecsk 134-15-1456-1456-15-146-13	For example meggyecske, meggyecskét words
+always meggyece 134-15-1456-1456-15-14-15	For example meggyecet word
+always meggyei 134-15-1456-1456-15-24	For example meggyei, meggyeinek, babérmeggyeiből words
+always joggyilk 245-135-1245-1456-24-123-13	For example joggyilkos word
+always meggyéh 134-15-1456-1456-16-125	For example meggyéhez word
+always meggyünk 134-15-1456-1456-12356-1345-13	For example cigánymeggyünk word
+word meggyág 134-15-1456-1456-4-1245	For example meggyág word
+always meggyágy 134-15-1456-1456-4-1456
+always meggyággyal 134-15-1456-1456-4-1456-1456-1-123	For example meggyággyal word
+begword meggyág 134-15-1456-1456-4-1245	For example beginning of meggyággal word
+always meggyakt 134-15-1456-1456-1-13-2345	For example meggyakta word
+always meggyára 134-15-1456-1456-4-1235-1	For example meggyára, meggyárak words
+always meggyárr 134-15-1456-1456-4-1235-1235	For example meggyárról word
+word meggyár 134-15-1456-1456-4-1235	For example meggyár-várakozás word
+always meggyarom 134-15-1456-1456-1-1235-135-134	For example meggyaroma word
+word meggyé 134-15-1456-1456-16	For example meggyé word
+always meggyelnök 134-15-1456-1456-15-123-1345-12345-13	For example meggyelnök word
+always meggyeltev 134-15-1456-1456-15-123-2345-15-1236	For example meggyeltevési word
+always meggyex 134-15-1456-1456-15-1346	For example meggyexport word
+word meggyi 134-15-1456-1456-24	For example meggyi word
+always meggyidé 134-15-1456-1456-24-145-16	For example meggyidény word
+always meggyimád 134-15-1456-1456-24-134-4-145	For example meggyimádó word
+always meggyíz 134-15-1456-1456-34-126	For example meggyíz, meggyízű words
+always meggyjogh 134-15-1456-1456-245-135-1245-125	For example meggyjoghurt, meggyjoghurtos words
+word meggyük 134-15-1456-1456-12356-13	For example meggyük word
+partword meggyükkel 134-15-1456-1456-12356-13-13-15-123	For example meggyükkel word
+word meggyükkel 134-15-1456-1456-12356-13-13-15-123	For example meggyükkel word
+always meggyünnep 134-15-1456-1456-12356-1345-1345-15-1234	For example meggyünnep word
+always egészséggyá 15-1245-16-156-234-16-1245-1456-4	For example egészséggyártás word
+always foggyűjt 124-135-1245-1456-23456-245-2345	For example foggyűjtemény word
+always inggyűr 24-1345-1245-1456-23456-1235	For example inggyűrődés word
+always készséggyak 13-16-156-234-16-1245-1456-1-13	For example készséggyakorlás word
+always zuggyűjt 126-136-1245-1456-23456-245-2345	For example zuggyűjtőknek word
+always házassággy 125-4-126-1-234-234-4-1245-1456	For example házassággyerekek word
+always monológgy 134-135-1345-135-123-246-1245-1456	For example monológgyűjtemény word
+always szabadsággy 156-1-12-1-145-234-4-1245-1456	For example szabadsággyakorlás word
+always koronggy 13-135-1235-135-1345-1245-1456	For example koronggyűjtő word
+always szaggyá 156-1-1245-1456-4	For example szalaggyártó word
+always heggyógy 125-15-1245-1456-246-1456	For example heggyógyulás word
 
 #ny, nny related exceptions
 #Following exception parts need marking nny letter pairs with single n and nny braille dot combinations
@@ -369,6 +422,7 @@ begword filigránny 124-24-123-24-1245-1235-4-1345-1246	For example filigránnye
 partword lennyil 123-15-1345-1246-24-123	For example ellennyilatkozat word
 partword lennyom 123-15-1345-1246-135-134	For example ellennyomás word
 partword lennyug 123-15-1345-1246-136-1245
+partword nnyold 1246-1246-135-123-145   For example szennyoldó, könnyoldat, szennyoldó words
 partword nnyol 1345-1246-135-123	For example nyolcvannyolc word
 partword tennyil 2345-15-1345-1246-24-123	For example istennyila word
 partword annyú 1-1345-1246-346
@@ -483,6 +537,19 @@ always bödönny 12-12345-145-12345-1345-1246	For example bödönnyi word
 always uránnyo 136-1235-4-1345-1246-135	For example uránnyom word
 always betonny 12-15-2345-135-1345-1246	For example betonnyaralóba, betonnyílás word
 begword szénnyel 156-16-1345-1246-15-123	For example szénnyelő word
+always doménnyil 145-135-134-16-1345-1246-24-123	For example doménnyilvántartó word
+always domainny 145-135-134-1-24-1345-1246	For example domainnyilvántartás word
+always kínnyal 13-34-1345-1246-1-123	For example kínnyalók word
+begword bitcoinny 12-24-2345-14-135-24-1345-1246	For example bitcoinnyi word
+begword putyinny 1234-136-1256-24-1345-1246	For example Putyinnyaló word
+always karanténny 13-1-1235-1-1345-2345-16-1345-1246	For example karanténnyi word
+begword önnyit 12345-1345-1246-24-2345	For example önnyitó word
+always szalonnyit 156-1-123-135-1345-1246-24-2345	For example szalonnyitás word
+always színnyal 156-34-1345-1246-1-123	For example színnyalók word
+always színnyer 156-34-1345-1246-15-1235	For example színnyerés word
+always színnyil 156-34-1345-1246-24-123	For example bőrszínnyilvántartás word
+always borostyánnyak 12-135-1235-135-234-1256-4-1345-1246-1-13	For example borostyánnyaklánc word
+always szappanny 156-1-1234-1234-1-1345-1246	For example szappannyom word
 
 #ly related exceptions
 #This exception parts need marking ly letters with two single l and y letter combination
@@ -587,7 +654,7 @@ partword turizmussz 2345-136-1235-24-126-134-136-234-156	For example turizmussze
 begword adászár 1-145-4-234-126-4-1235	For example adászárásig word
 begword enyves 15-1246-1236-15-234	For example enyveszsinór word related need this exception
 partword kortárs =	For example kortárszenei word related need this general exception
-
+always tervezészs 2345-15-1235-1236-15-126-16-234-345	For example tervezészsebpénz word
 partword kórus =	For example kóruszene word related need this general exception
 begword törés =	For example törészónán word related need this general exception
 partword verbunkos =	For example verbunkoszene word related need this general exception
@@ -606,8 +673,24 @@ always webeszk 2456-15-12-15-156-13	For example webeszköznek word
 begword hőszeneka 125-12456-234-126-15-1345-15-13-1	For example hőszenével word
 begword hőszené 125-12456-234-126-15-1345-16	For example hőszenéket word
 always víruszivata 1236-34-1235-136-234-126-24-1236-1-2345-1	For example víruszivatar word
-always forrász 124-135-1235-1235-4-234-156	For example forrászóna word
+always forrássz 124-135-1235-1235-4-234-156	For example forrásszegény word
+always forrász 124-135-1235-1235-4-234-126	For example forrászárolás, forrászóna word
 begword okoszebr 135-13-135-234-126-15-12-1235	For example okoszebra word
+always hőszsáne 125-12456-234-345-4-1345-15	For example hőszsánerrel word
+always esszenciáliszs 15-156-156-15-1345-14-24-4-123-24-234-345	For example eszenciáliszsírsav word
+always citruszs 14-24-2345-1235-136-234-345 For example citruszselé word
+always grafikuszs 1245-1235-1-124-24-13-136-234-345	For example grafikuszseni word
+always haszsí 125-1-234-345-34	For example haszsír word
+always töviszsel 2345-12345-1236-24-234-345-15-123	For example homoktöviszselé word
+always kakaszsí 13-1-13-1-234-345-34	For example kakaszsírral word
+always kapuszs 13-1-1234-136-234-345	For example kapuszseni word
+always kosaraszse 13-135-234-1-1235-1-234-345-15	For example kosaraszseni word
+always kritikuszs 13-1235-24-2345-24-13-136-234-345	For example kritikuszsűri word
+always mellkaszs 134-15-123-123-13-1-234-345	For example mellkaszsebbel word
+always recészsir 1235-15-14-16-234-345-24-1235	For example recészsiráf word
+always százaszseb 156-4-126-1-234-345-15-12	For example százaszsebkendő word
+always víruszsar 1236-34-1235-136-234-345-1-1235	For example víruszsaru word
+always villamoszseb 1236-24-123-123-1-134-135-234-345-15-12	For example villamoszseblámpa word
 
 #ssz related exceptions
 #Following exception words and word parts need writing one s and one sz braille letter
@@ -859,7 +942,7 @@ always vörösessz 1236-12345-1235-12345-234-15-234-156	For example vörösessz�
 partword zuhanássz 126-136-125-1-1345-4-234-156	For example zuhanásszerű word
 partword zökkenéssz 126-12345-13-13-15-1345-16-234-156	For example zökkenésszerű word
 begword zsírossz 345-34-1235-135-234-156	For example zsírosszén word
-begmidword  lovassz 123-135-1236-1-234-156	For example lovasszázad, lovasszekeret words
+begmidword lovassz 123-135-1236-1-234-156	For example lovasszázad, lovasszekeret words
 partword vasszállít 1236-1-234-156-4-123-123-34-2345	For example vasszállítmány word
 begword barnásszür 12-1-1235-1345-4-234-156-12356-1235	For example barnásszürke word
 begword kőművessz 13-12456-134-23456-1236-15-234-156	For example kőművesszem, kőművesszerszámait words
@@ -1574,7 +1657,125 @@ begword birssz 12-24-1235-234-156	For example birsszeleteket, birsszezon word
 always hamiszá 125-1-134-24-234-126-4	For example hamiszászlós word
 always kezdeményezéssz 13-15-126-145-15-134-16-234-156	For example kezdeményezésszervezés word
 always ébredéssz 16-12-1235-15-145-16-234-156	For example ébredésszerű word
-
+always földeléssz 124-12345-123-145-15-123-16-234-156	For example földelésszerűség word
+always kerekessz 13-15-1235-15-13-15-234-156	For example kerekesszabadság word
+always perzseléssz 1234-15-1235-345-15-123-16-234-156	For example perzselésszerű word
+always evezéssz 15-1236-15-126-16-234-156	For example evezésszerű, nevezésszám words
+always ergetéssz 15-1235-1245-15-2345-16-234-156	For example csergetésszokás word
+always futássz 124-136-2345-4-234-156	For example futásszilveszter word
+always opogássz 135-1234-135-1245-4-234-156	For eexample kopogásszenzor word
+always kardiológussz 13-1-1235-145-24-135-123-246-1245-136-234-156	For example kardiológusszakmai word
+always bizsergéssz 12-24-345-15-1235-1245-16-234-156	For example bizsergésszerű word
+always zengéssz 126-15-1345-1245-16-234-156	For example égzengésszerű word
+always érkezéssz 16-1235-13-15-126-16-234-156	For example érkezésszám word
+always érdeklődéssz 16-1235-145-15-13-123-12456-145-16-234-156	For example érdeklődésszám word
+always katolikussze 13-1-2345-135-123-24-13-136-234-156-15	For example katolikusszent word
+always költözéssz 13-12345-123-2345-12345-126-16-234-156	For example költözésszám word
+always műtősszem 134-23456-2345-12456-234-156-15-134	For example műtősszemüveg word
+always tubussz 2345-136-12-136-234-156	For example tubusszámra, tubusszerű words 
+always uniformissz 136-1345-24-124-135-1235-134-24-234-156	For example uniformisszenvedély word
+always termikussz 2345-15-1235-134-24-13-136-234-156	For example termikusszén-import word
+always gondolkodássz 1245-135-1345-145-135-123-13-135-145-4-234-156	For example gondolkodásszámait word
+always szemetessz 156-15-134-15-2345-15-234-156	For example szemetessztrájk word
+always hősszéri 125-12456-234-156-16-1235-24	For example hősszériája word
+always hősszobr 125-12456-234-156-135-12-1235	For example hősszobrai word
+always hírszerzéssz 125-34-1235-156-15-1235-126-16-234-156	For example hírszerzésszerű word
+always öregedéssz 12345-1235-15-1245-15-145-16-234-156	For example öregedésszerű word
+always bizsergéssz 12-24-345-15-1235-1245-16-234-156	For example bizsergésszerű word
+always ébredéssz 16-12-1235-15-145-16-234-156	For example ébredésszerű word
+always zengéssz 126-15-1345-1245-16-234-156	For example zengésszerű word
+always várássz 1236-4-1235-4-234-156	For example elvárásszerűen word
+always zárássz 126-4-1235-4-234-156	For example zárásszerű word
+always krémessz 13-1235-16-134-15-234-156	For example krémesszerű word
+always madárlessz 134-1-145-4-1235-123-15-234-156	For example madárlesszerű word
+always perzseléssz 1234-15-1235-345-15-123-15-123-16-234-156	For example perzselésszerű word
+always posztamenssz 1234-135-156-2345-1-134-15-1345-234-156	For example posztamensszerű word
+always fogasszer 124-135-1245-1-234-156-15-1235	For example fogasszerű word
+always infarktussz 24-1345-124-1-1235-13-2345-136-234-156	For example infarktusszerű word
+always tudóssz 2345-136-145-246-234-156	For example tudósszerű word
+always vadassz 1236-1-145-1-234-156	For example vadasszerű word
+always hasszer 125-1-234-156-15-1235	For example hasszerű word
+always ajánlássz 1-245-4-1345-123-4-234-156	For example ajánlásszám word
+always árussz 4-1235-136-234-156	For example árusszám word
+always avatkozássz 1-1236-1-2345-13-135-126-4-234-156	For example beavatkozásszám word
+always küldésszá 13-12356-123-145-16-234-156-4	For example küldésszámot word
+always emeléssz 15-134-15-123-16-234-156	For example emelésszámot word
+always érdeklődéssz 16-1235-145-15-13-123-12456-145-16-234-156	For example érdeklődésszámot word
+always érkezéssz 16-1235-13-15-126-16-234-156	For example érkezésszám word
+always foglalássz 124-135-1245-123-1-123-4-234-156	For example foglalásszám word
+always jutalmazássz 245-136-2345-1-123-134-1-126-4-234-156	For example jutalmazásszámba word
+always kapcsolássz 13-1-1234-146-135-123-4-234-156	For example kapcsolásszám word
+always kínzássz 13-34-1345-126-4-234-156	For example kínzásszámba word
+always kitűzéssz 13-24-2345-23456-126-16-234-156	For example kitűzésszám word
+always költözéssz 13-12345-123-2345-12345-126-16-234-156	For example költözésszám word
+always közösszámí 13-12345-126-12345-234-156-4-134-34	For example közösszámítógép-használat word
+word lesszám 123-15-234-156-4-134	For example lesszám
+always lopássz 123-135-1234-4-234-156	For example lopásszám word
+always megosztássz 134-15-1245-135-156-2345-4-234-156	For example megosztásszám word
+always vakítássz 1236-1-13-34-2345-4-234-156	For example vakításszámba word
+always rúgássz 1235-346-1245-4-234-156	For example rúgásszám word
+always kiáltássz 13-24-4-123-2345-4-234-156	For example kiáltásszám word
+always teszteléssz 2345-15-156-2345-16-234-156	For example tesztelésszám word
+always törléssz 2345-12345-123-16-234-156	For example törlésszámot word
+always vállalássz 1236-4-123-123-1-123-4-234-156	For example vállalásszám word
+always vásárlássz 1236-4-234-4-1235-123-4-234-156	For example vásárlásszám word
+always sasszink 234-1-234-156-24-1345-13	For example sasszinkron word
+always vegetációssz 1236-15-1245-15-2345-4-14-24-246-234-156	For example vegetációsszenzor
+always csomagolássz 146-135-134-1-1245-135-123-4-234-156	For example csomagolásszemle word
+always pulmonológussz 1234-136-123-134-135-1345-135-123-246-1245-136-234-156	For example pulmonológusszakmát word
+always világítássz 1236-24-123-4-1245-34-2345-4-234-156	for example világításszabályozás word
+always fenyegetéssz 124-15-1246-15-1245-15-2345-16-234-156	For example fenyegetésszerű word
+always lízissz 123-34-126-24-234-156	For example lízisszövődmény word
+always brősszállá 12-1235-12456-234-156-4-123-123-4	For example Brősszállás word
+always ibolyásszürk 24-12-135-456-4-234-156-12356-1235-13	For example ibolyásszürke word
+always kávéssz 13-4-1236-16-234-156	For example kávésszettek word
+always kettősszig 13-15-2345-2345-12456-234-156-24-1245	For example kettősszigetelt word
+always okosszáj 135-13-135-234-156-4-245	For example okosszájmaszk word
+always teásszet 2345-15-4-234-156-15-2345	For example teásszettek word
+always geológussz 1245-15-135-123-246-1245-136-234-156	For example geológusszakma, geológusszemmel words
+always geográfussz 1245-15-135-1245-1235-4-124-136-234-156	For example geográfusszemmel word
+begword fásszatyo 124-4-234-156-1-1256-135	For example fásszatyor word
+begword kissze 13-24-234-156-15	For example Kisszeg town name
+word kisszeg 13-24-234-156-15-1245	For example Kisszeg town name
+always ormosszé 135-1235-134-135-234-156-16	For example Ormosszén town name
+always sulisszet 234-136-123-24-234-156-15-2345	For example sulisszett word
+always ügyesszem 12356-1456-15-234-156-15-134	For example ügyesszemű word
+always fólklórizmussz 124-246-123-13-123-246-1235-24-126-134-136-234-156	For example folklorizmusszemlélete word
+always sorsszimfó 234-135-1235-234-156-24-134-124-246	For example sorsszimfóniája word
+always leleplezéssz 123-15-123-15-1234-123-15-126-16-234-156	For example leleplezésszerű word
+always tévésszerepl 2345-16-1236-16-234-156-15-1235-15-1234-123	For example tévésszereplésekkel word
+always hasonmássz 125-1-234-135-1345-134-4-234-156	For example hasonmásszerep word
+always kocsissz 13-135-146-24-234-156	For example kocsisszótár word
+always különlegessz 13-12356-123-12345-1345-123-15-1245-15-234-156	For example különlegesszer-vezető word
+begword aktusszá 1-13-2345-136-234-156-4	For example aktusszám word
+always iparkodásszor 24-1234-1-1235-13-135-145-4-234-156-135-1235	For example iparkodásszorgalom word
+always növekedéssz 1345-12345-1236-15-13-15-145-16-234-156	For example növekedésszabályzó word
+always nyugdíjassz 1246-136-1245-145-34-245-1-234-156	For example nyugdíjasszervezet word
+always plébánossz 1234-123-16-12-4-1345-135-234-156	For example plébánosszerűség word
+always csipássz 146-24-1234-4-234-156	For example csipásszemű word
+always penészesszal 1234-15-1345-16-156-15-234-156-1-123	For example penészesszalámi word
+always éhenkórássz 16-125-15-1345-13-246-1235-4-156-156	For example éhenkórásszal word
+word felélesszem 124-15-123-16-123-15-156-156-15-134	For example felélesszem word
+always kaparászássz 13-1-1234-1-1235-4-156-4-234-156	For example kaparászásszerű word
+always traktussz 2345-1235-1-13-2345-136-234-156	For example traktusszélesség word
+always vasszerkez 1236-1-234-156-15-1235-13-15-126	For example betonvasszerkezet word
+always kommunizmussz 13-135-134-134-136-1345-24-126-134-136-234-156	For example kommunizmusszagú word
+always sejtéssz 234-15-245-2345-16-234-156	For example sejtésszinten word
+always kommunálissz 13-135-134-134-136-1345-4-123-24-234-156	For example kommunálisszenyvíz-eredetű word
+always hasmenéssz 125-1-234-134-15-1345-16-234-156	For example hasmenésszerű word
+always leszbikussz 123-15-156-12-24-13-136-234-156	For example lezbikusszex-póz word
+partword vasszin 1236-1-234-156-24-1345	For example szérumvasszint word
+always szükségessz 156-12356-13-234-16-1245-15-234-156	For example szükségesszerű word
+always futásszá 124-136-2345-4-234-156-4	For example futásszám, gátfutásszámában word
+always diplomássz 145-24-1234-123-135-134-4-234-156	For example diplomásszakember-hiány word
+always komponenssz 13-135-134-1234-135-1345-15-1345-234-156	For example komponensszámot word
+always tulajdonossz 2345-136-123-1-245-145-135-1345-135-234-156	For example tulajdonosszerzés word
+always ágenssze 4-1245-15-1345-234-156-15	For example ágensszer word
+always mosásszá 134-135-234-4-234-156-4	For example mosásszám word
+always ágnesszék 4-1245-1345-15-234-156-16-13	For example ágnesszéki word
+always alezredessz 1-123-15-126-1235-15-145-15-234-156	For example alezredesszóvivő word
+begword avassza 1-1236-1-234-156-1	For example avasszagú word
+always késszurk 13-16-234-156-136-1235-13	For example késszurkálás word
 #ty, tty related exceptions
 #This exception part containing english words with need presenting original english braille rules
 partword okréty =	For example Zsámbokrétyvel word
@@ -1616,7 +1817,7 @@ always kmety =	For example Kmety György Hungarian army generaly name related ne
 word lacsny 123-1-146-1345-13456	For example Lacsny Miklós name related need this general exception
 begword lacsny 123-1-146-1345-13456	Same exception for Lacsny Miklós name related if the name containing suffixes. Partword or always opcode too risk this exception
 word pesty 1234-15-234-2345-13456	For example Pesty László name related need this general exception
-begword pesty 1234-15-234-2345-13456	Same  exception with Pesty László name related if the name containing suffixes. Partword or always opcode too risk this exception
+begword pesty 1234-15-234-2345-13456	Same exception with Pesty László name related if the name containing suffixes. Partword or always opcode too risk this exception
 endnum city =
 endnum -city =
 always sztevanovity 156-2345-15-1236-1-1345-135-1236-24-2345-13456	For example Sztevanovity name related exception
@@ -1707,6 +1908,11 @@ begword ülészs 12356-123-16-234-345	For example ülészsebben word
 begword gázsikkasz 1245-4-126-234-24-13-13-1-156	For example gázsikkasztás word
 always lovaszs 123-135-1236-1-234-345	For example lovaszsonglőr word
 always birszs 12-24-1235-234-345	For example birszselé word
+always szervizsát 156-15-1235-1236-24-126-234-4-2345	For example szervizsátrához word
+always garázszen 1245-1-1235-4-345-126-15-1345	For example garázszene word
+always húszseml 125-346-234-345-15-134-123	For example húszsemle word
+always húszsí 125-346-234-345-34	For example húszsír word
+always húszsel 125-346-234-345-15-123	For example húszselé word
 
 #Historical person names related exceptions
 always táncsics 2345-4-1345-146-24-146	Táncsics Mihály is a historical person for 1848. march 15 hungarian revolution
@@ -1719,6 +1925,7 @@ always anonymu =
 always kiszely 13-24-156-15-123-13456	For example István Kiszely name related need this exception
 always hatvany =
 always skultéty =
+always kukorelly =	For example Kukorelly Endre artist name
 
 #Town names related exceptions
 #Following section containing hungarian town names
@@ -1741,4 +1948,6 @@ partword rizszab 1235-24-345-126-1-12	For example rizszabáló word
 partword rizszáp	1235-24-345-126-4-1234	For example rizszápor word
 partword masszázszuh 134-1-156-156-4-345-126-136-125	For example masszázszuhany, masszázszuhanyokkal words
 
-
+#Metrics related corrections
+noback correct "GHZ-" "GHz-"
+noback correct "IPV6-" "IPv6-"

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -409,6 +409,7 @@ always szabadsággy 156-1-12-1-145-234-4-1245-1456	For example szabadsággyakorl
 always koronggy 13-135-1235-135-1345-1245-1456	For example koronggyűjtő word
 always szaggyá 156-1-1245-1456-4	For example szalaggyártó word
 always heggyógy 125-15-1245-1456-246-1456	For example heggyógyulás word
+always adóssággy 1-145-246-234-234-4-1245-1456	For example adóssággyártás, adóssággyarapodás word
 
 #ny, nny related exceptions
 #Following exception parts need marking nny letter pairs with single n and nny braille dot combinations
@@ -422,7 +423,7 @@ begword filigránny 124-24-123-24-1245-1235-4-1345-1246	For example filigránnye
 partword lennyil 123-15-1345-1246-24-123	For example ellennyilatkozat word
 partword lennyom 123-15-1345-1246-135-134	For example ellennyomás word
 partword lennyug 123-15-1345-1246-136-1245
-partword nnyold 1246-1246-135-123-145   For example szennyoldó, könnyoldat, szennyoldó words
+partword nnyold 1246-1246-135-123-145   For example szennyoldó, könnyoldat words
 partword nnyol 1345-1246-135-123	For example nyolcvannyolc word
 partword tennyil 2345-15-1345-1246-24-123	For example istennyila word
 partword annyú 1-1345-1246-346
@@ -1776,6 +1777,9 @@ always ágnesszék 4-1245-1345-15-234-156-16-13	For example ágnesszéki word
 always alezredessz 1-123-15-126-1235-15-145-15-234-156	For example alezredesszóvivő word
 begword avassza 1-1236-1-234-156-1	For example avasszagú word
 always késszurk 13-16-234-156-136-1235-13	For example késszurkálás word
+always szennyeződéssz 156-15-1246-1246-15-126-12456-145-16-234-156	For example szennyeződésszint word
+always csatlóssz 146-1-2345-123-246-234-156	For example csatlósszerep word
+
 #ty, tty related exceptions
 #This exception part containing english words with need presenting original english braille rules
 partword okréty =	For example Zsámbokrétyvel word


### PR DESCRIPTION
Hi Boys,

I added new forward and backward translation exceptions the hungarian grade1 and grade 2 tables, and updated the testcase file (tests/braille-specs/hu-hu-g1_special_consonants.yaml file).
Changed files:
- tables/hu-exceptionwords.cti, tables/hu-chardefs.cti, tables/hu-backtranslate-word-corrections.cti file: this files containing the new or changed rules.
Typical for example previous Liblouis release already added the lowercase letter beginning word (for back-translation correction), but now during large extended corpus testing detected to need adding uppercase variant a word.
This three files review is easy, but the change affecting only the hungarian language Braille output, other languages unaffected.

- tests/braille-specs/hu-hu-g1_special_consonants.yaml: this file you not need reviewing (very large the remaining diff part after the 1759 line, during review you ignore the remaining part if you not would like lot of work. :-):-)

I used one commit, but if you would like, I separate this change with table files related commit and the testcase update related commit part to easying you the review.

Because this change containing more critical important updates, please add this change the 3.25 milestone and approve these changes.

Large corpus test results:
Extended corpus word number: 6794565 words
Not correct backward translations (this day evening): only 451 words (possible not will be fitting this remaining part the release prep time, I don't no when have freeze date to you have enough sure time preparing the 3.25 release). So, I choosed to add the already ready changes a pull request.

Regression errors with other languages: not have, only hungarian language tables happened changes

Make distwin command result: passed my machine

Attila