### PR TITLE
Don't use lou_getDataPath in _lou_getTablePath

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4632,7 +4632,7 @@ _lou_getTablePath(void) {
 		envset = 1;
 		cp += sprintf(cp, ",%s", path);
 	}
-	path = lou_getDataPath();
+	path = dataPathPtr;
 	if (path != NULL && path[0] != '\0')
 		cp += sprintf(cp, ",%s%c%s%c%s", path, DIR_SEP, "liblouis", DIR_SEP, "tables");
 	if (!envset) {


### PR DESCRIPTION
`lou_getDataPath` is still used by `_lou_getTablePath` so shouldn't have the deprecation warning.

This partly reverts commit 778aff1e.