### PR TITLE
Update README for Python bindings

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -4,20 +4,28 @@ These bindings allow you to use liblouis from within Python. The
 package is called "louis". See the documentation included in the
 module for usage instructions.
 
-These bindings use ctypes to access the liblouis shared library. The
+These bindings use `ctypes` to access the liblouis shared library. The
 liblouis shared library needs to be located in the library search
 path. In most cases, if liblouis has been installed in a standard
 location on your system, this is already the case and the bindings
 will work without any additional steps.
 
-A standard distutils setup.py script is provided for installation
-tasks. To install this package for system wide use, run (as root):
+A standard distutils `setup.py` script is provided for installation
+tasks. To install this package for system wide use, after installing
+`liblouis` itself, switch to the `python` directory and run (as root):
 
 ``` python
 sudo python3 setup.py install
 ```
-Some tests are located in `tests`. Run them with
+
+Some tests are located in `tests`. Note that these require that
+you have compiled `liblouis` with support for 32-bit Unicode
+characters.  See the top-level README for instructions on this option.
+
+Remain in the `python` directory and run the tests with the
+following command.  If successful, output will be brief, and note
+that some tests are designed to have "expected failures".
 
 ``` console
-pytest
+sudo python3 tests/test_louis.py
 ```


### PR DESCRIPTION
Summary of changes:

* Clarifications about specifics of installation
* Need to compile with 32-bit Unicode for tests to run successfully
* Filename and default directory need to be right for tests