### PR TITLE
Fix out-of-bound write in brl_checks.c

### DIFF
--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -192,7 +192,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 				// Hm, something is not quite right. Try again with a larger outbuf
 				free(outbuf);
 				outlen = inlen * outlen_multiplier * (k + 1);
-				outbuf = malloc(sizeof(widechar) * outlen);
+				outbuf = malloc(sizeof(widechar) * (outlen + 1));
 				if (expected_inputPos) {
 					free(inputPos);
 					inputPos = malloc(sizeof(int) * outlen);


### PR DESCRIPTION
This bug was reported in https://github.com/liblouis/liblouis/issues/1346.