### PR TITLE
Make sure all opcodes and comments start at the beginning of the line

### DIFF
--- a/tables/da-dk-g16-lit_1993.ctb
+++ b/tables/da-dk-g16-lit_1993.ctb
@@ -289,7 +289,7 @@ noback pass2 @6-46-5 @46-5 # no letsign before cap letters with accent
 noback pass2 @45-6-46 * # don't touch tilde before capnoback pass2 @6-46 @46-6 # Ensure correct order
 
 # Ensure there is only one letsign
- noback pass2 @6-6 @6
+noback pass2 @6-6 @6
 
 # Ensure there is only one emphasis sign
 noback pass2 @56-56 @56

--- a/tables/da-dk-g16.ctb
+++ b/tables/da-dk-g16.ctb
@@ -270,12 +270,12 @@ noback pass2 @56-5 @5 # no letsign before letters with accent
 noback pass2 @56-6-5 @6-5 # no letsign before cap letters with accent
 noback pass2 @56-6 @6-56 # Ensure correct order
 
- ### Pass 2 - backward
+### Pass 2 - backward
 
 ### Pass 3 - forward translation
 
 # Ensure there is only one letsign
- noback pass3 @56-56 @56
+noback pass3 @56-56 @56
 
 # Ensure there is only one emphasis sign
 noback pass3 @46-46 @46

--- a/tables/da-dk-g16_1993.ctb
+++ b/tables/da-dk-g16_1993.ctb
@@ -287,12 +287,12 @@ noback pass2 @6-5 @5 # no letsign before letters with accent
 noback pass2 @6-46-5 @46-5 # no letsign before cap letters with accent
 noback pass2 @6-46 @46-6 # Ensure correct order
 
- ### Pass 2 - backward
+### Pass 2 - backward
 
 ### Pass 3 - forward translation
 
 # Ensure there is only one letsign
- noback pass3 @6-6 @6
+noback pass3 @6-6 @6
 
 # Ensure there is only one emphasis sign
 noback pass3 @56-56 @56

--- a/tables/da-dk-g26-lit_1993.ctb
+++ b/tables/da-dk-g26-lit_1993.ctb
@@ -796,7 +796,7 @@ endword -m 36-6-134
 begword med- 146-145-36
 endword -men 36-134-126
 begword men- 134-126-36
- endword -ned 36-1246-145
+endword -ned 36-1246-145
 begword ned- 1246-145-36
 endword -når 36-1345-16-1235
 endword -n 36-6-1345
@@ -909,7 +909,7 @@ noback pass2 @6-46 @46-6 # Ensure correct order
 ### Pass 3 - forward translation
 
 # Ensure there is only one letsign
- noback pass3 @6-6 @6
+noback pass3 @6-6 @6
 
 # Ensure there is only one emphasis sign
 noback pass3 @56-56 @56

--- a/tables/da-dk-g26.ctb
+++ b/tables/da-dk-g26.ctb
@@ -1102,7 +1102,7 @@ nofor sufword dvořák 145-1236-135-5-1235-5-1-13
 nofor sufword márquez 134-5-1-1235-6-12345-136-15-6-1356
 nofor sufword miró 134-24-1235-5-135
 nofor sufword tórshavn 2345-5-135-1235-234-125-1-1236-1345
- nofor sufword václav 1236-5-1-14-123-1-1236
+nofor sufword václav 1236-5-1-14-123-1-1236
 
 # Common combinations of one word contractions with slash
 word af/på 356-34-1234
@@ -1173,7 +1173,7 @@ prfword -m 36-56-134
 sufword med- 146-145-36
 prfword -men 36-134-126
 sufword men- 134-126-36
- prfword -ned 36-1246-145
+prfword -ned 36-1246-145
 sufword ned- 1246-145-36
 prfword -når 36-1345-16-1235
 prfword -n 36-56-1345
@@ -1288,7 +1288,7 @@ noback pass2 @234f-123f-6-5 @6-5 # no letsign before cap letters with accent
 noback pass2 _$D[@56-6-56] *
 noback pass2 _$D[@56-6] *
 
- ### Pass 2 - backward
+### Pass 2 - backward
 
 #special case for www
 nofor pass2 @2456-2456-2456 @24567-24567-24567
@@ -1298,7 +1298,7 @@ noback pass3 @56-6-56 @56-6 # Ensure correct order and no double letsign
 noback pass3 @6-56 @56-6 # Ensure correct order
 
 # Ensure there is only one letsign
- noback pass3 @56-56 @56
+noback pass3 @56-56 @56
 
 # Ensure there is only one emphasis sign
 noback pass3 @46-46 @46

--- a/tables/da-dk-g26_1993.ctb
+++ b/tables/da-dk-g26_1993.ctb
@@ -917,7 +917,7 @@ nofor sufword moliè 134-135-123-24-5-15
 nofor sufword norröna 1345-1346-1235-246-1345-1
 nofor sufword tannhäus 2345-1-1345-1345-125-345-136-234
 nofor sufword tórshavn 2345-5-135-1235-234-125-1-1236-1345
- nofor sufword václav 1236-5-1-14-123-1-1236
+nofor sufword václav 1236-5-1-14-123-1-1236
 nofor sufword verän 1236-156-345-1345
 nofor sufword weizsäck 6-2456-15-24-6-1356-234-345-14-13
 
@@ -991,7 +991,7 @@ endword -m 36-6-134
 begword med- 146-145-36
 endword -men 36-134-126
 begword men- 134-126-36
- endword -ned 36-1246-145
+endword -ned 36-1246-145
 begword ned- 1246-145-36
 endword -når 36-1345-16-1235
 endword -n 36-6-1345
@@ -1097,7 +1097,7 @@ noback pass2 _$D[@6-46] *
 noback pass2 @6-46-6 @46-6 # Ensure correct order and no double letsign
 noback pass2 @6-46 @46-6 # Ensure correct order
 
- ### Pass 2 - backward
+### Pass 2 - backward
 
 # Insert letsign between number (with extra punctuation) and capsletter sign
 #nofor pass2 @3456$l.$Spm$l.@3$l.@3[]@46 @6
@@ -1122,7 +1122,7 @@ noback pass2 @6-46 @46-6 # Ensure correct order
 ### Pass 3 - forward translation
 
 # Ensure there is only one letsign
- noback pass3 @6-6 @6
+noback pass3 @6-6 @6
 
 # Ensure there is only one emphasis sign
 noback pass3 @56-56 @56

--- a/tables/da-dk-g26l-lit_1993.ctb
+++ b/tables/da-dk-g26l-lit_1993.ctb
@@ -491,7 +491,7 @@ endword -m 36-6-134
 begword med- 146-145-36
 endword -men 36-134-126
 begword men- 134-126-36
- endword -ned 36-1246-145
+endword -ned 36-1246-145
 begword ned- 1246-145-36
 endword -når 36-1345-16-1235
 endword -n 36-6-1345
@@ -603,7 +603,7 @@ noback pass2 @6-46 @46-6 # Ensure correct order
 ### Pass 3 - forward translation
 
 # Ensure there is only one letsign
- noback pass3 @6-6 @6
+noback pass3 @6-6 @6
 # Ensure there is only one emphasis sign
 noback pass3 @56-56 @56
 noback pass3 @56-56-56 @56

--- a/tables/da-dk-g26l_1993.ctb
+++ b/tables/da-dk-g26l_1993.ctb
@@ -473,7 +473,7 @@ endword -m 36-6-134
 begword med- 146-145-36
 endword -men 36-134-126
 begword men- 134-126-36
- endword -ned 36-1246-145
+endword -ned 36-1246-145
 begword ned- 1246-145-36
 endword -når 36-1345-16-1235
 endword -n 36-6-1345
@@ -581,7 +581,7 @@ noback pass2 _$D[@6-46] *
 noback pass2 @6-46-6 @46-6 # Ensure correct order and no double letsign
 noback pass2 @6-46 @46-6 # Ensure correct order
 
- ### Pass 2 - backward
+### Pass 2 - backward
 
 # Insert letsign between number (with extra punctuation) and capsletter sign
 #nofor pass2 @3456$l.$Spm$l.@3$l.@3[]@46 @6
@@ -603,7 +603,7 @@ noback pass2 @6-46 @46-6 # Ensure correct order
 ### Pass 3 - forward translation
 
 # Ensure there is only one letsign
- noback pass3 @6-6 @6
+noback pass3 @6-6 @6
 
 # Ensure there is only one emphasis sign
 noback pass3 @56-56 @56

--- a/tables/de-de.dis
+++ b/tables/de-de.dis
@@ -25,7 +25,7 @@
 # This is to be used with German translation tables.
 
 
-        #Hex   Dots				Dec		Char Description
+#       Hex    Dots				Dec		Char Description
 display \x0020 0					#32					space
 display \x0021   5				#33		!			exclamation mark
 display \x0022    4				#34		"			quotation mark
@@ -62,7 +62,7 @@ display \x003E 45			#62  >	greater-than sign
 display \x003F  26		#63 ?			question mark
 display \x0040 345				#64  @	commercial at
 
-        #Hex   Dots		Dec	Char Description
+#	Hex    Dots		Dec	Char Description
 display \x0041 17				#65	A Latin capital letter a
 display \x0042 127			#66	B Latin capital letter b
 display \x0043 147			#67	C Latin capital letter c
@@ -199,7 +199,7 @@ display \x001D 1245678 #29^]group separator
 display \x001E 4578 #30^^record separator
 display \x001F 45678 #31^_unit separator
 
-				#Hex	 Dots			Dec	Char	Description
+#	Hex    Dots			Dec	Char	Description
 display \x00A1 23467  #	161 ¡			inverted exclamation mark
 display \x00A2 58			#162	¢			cent sign 
 display \x00A3 34567  # 163	£			pound sign

--- a/tables/kannada.cti
+++ b/tables/kannada.cti
@@ -117,47 +117,47 @@ litdigit  \x0CEE	125	# KANNADA DIGIT EIGHT
 litdigit   \x0CEF	24	# KANNADA DIGIT NINE
 
 
-  # Half characters 
+# Half characters 
 always   \x0C95\x0CCD	4-13	# KANNADA LETTER KA
- always   \x0C96\x0CCD	 4-46         # KANNADA LETTER KHA
- always   \x0C97\x0CCD 4-1245	# KANNADA LETTER GA
- always   \x0C98\x0CCD  4-126	# KANNADA LETTER GHA
- always   \x0C99\x0CCD	4-346	# KANNADA LETTER NGA
+always   \x0C96\x0CCD	 4-46         # KANNADA LETTER KHA
+always   \x0C97\x0CCD 4-1245	# KANNADA LETTER GA
+always   \x0C98\x0CCD  4-126	# KANNADA LETTER GHA
+always   \x0C99\x0CCD	4-346	# KANNADA LETTER NGA
 
- always   \x0C9A\x0CCD	4-14	# KANNADA LETTER CA
- always   \x0C9B\x0CCD	4-16	# KANNADA LETTER CHA
- always   \x0C9C\x0CCD	4-245	# KANNADA LETTER JA
- always   \x0C9D\x0CCD	4-356	# KANNADA LETTER JHA
- always   \x0C9E\x0CCD	4-25	# KANNADA LETTER NYA
+always   \x0C9A\x0CCD	4-14	# KANNADA LETTER CA
+always   \x0C9B\x0CCD	4-16	# KANNADA LETTER CHA
+always   \x0C9C\x0CCD	4-245	# KANNADA LETTER JA
+always   \x0C9D\x0CCD	4-356	# KANNADA LETTER JHA
+always   \x0C9E\x0CCD	4-25	# KANNADA LETTER NYA
 
- always   \x0C9F\x0CCD	4-23456  # KANNADA LETTER TTA
- always   \x0CA0\x0CCD	4-2456	# KANNADA LETTER TTHA
- always   \x0CA1\x0CCD	4-1246	# KANNADA LETTER DDA
- always   \x0CA2\x0CCD	4-123456	# KANNADA LETTER DDHA
- always   \x0CA3\x0CCD	4-3456	# KANNADA LETTER NNA
+always   \x0C9F\x0CCD	4-23456  # KANNADA LETTER TTA
+always   \x0CA0\x0CCD	4-2456	# KANNADA LETTER TTHA
+always   \x0CA1\x0CCD	4-1246	# KANNADA LETTER DDA
+always   \x0CA2\x0CCD	4-123456	# KANNADA LETTER DDHA
+always   \x0CA3\x0CCD	4-3456	# KANNADA LETTER NNA
 
- always   \x0CA4\x0CCD	4-2345	# KANNADA LETTER TA
- always   \x0CA5\x0CCD	4-1456	# KANNADA LETTER THA
- always   \x0CA6\x0CCD	4-145	# KANNADA LETTER DA
- always   \x0CA7\x0CCD	4-2346	# KANNADA LETTER DHA
- always   \x0CA8\x0CCD	4-1345	# KANNADA LETTER NA
+always   \x0CA4\x0CCD	4-2345	# KANNADA LETTER TA
+always   \x0CA5\x0CCD	4-1456	# KANNADA LETTER THA
+always   \x0CA6\x0CCD	4-145	# KANNADA LETTER DA
+always   \x0CA7\x0CCD	4-2346	# KANNADA LETTER DHA
+always   \x0CA8\x0CCD	4-1345	# KANNADA LETTER NA
 
- always   \x0CAA\x0CCD	4-1234	# KANNADA LETTER PA
- always   \x0CAB\x0CCD	4-235	# KANNADA LETTER PHA
- always   \x0CAC\x0CCD	4-12	# KANNADA LETTER BA
- always   \x0CAD\x0CCD	4-45	# KANNADA LETTER BHA
- always   \x0CAE\x0CCD	4-135	# KANNADA LETTER MA
+always   \x0CAA\x0CCD	4-1234	# KANNADA LETTER PA
+always   \x0CAB\x0CCD	4-235	# KANNADA LETTER PHA
+always   \x0CAC\x0CCD	4-12	# KANNADA LETTER BA
+always   \x0CAD\x0CCD	4-45	# KANNADA LETTER BHA
+always   \x0CAE\x0CCD	4-135	# KANNADA LETTER MA
 
- always   \x0CAF\x0CCD	4-13456	# KANNADA LETTER YA
- always   \x0CB0\x0CCD	4-1235	# KANNADA LETTER RA
- always   \x0CB2\x0CCD	4-123	# KANNADA LETTER LA
- always   \x0CB3\x0CCD	4-456	# KANNADA LETTER LLA
- always   \x0CB5\x0CCD	4-1236	# KANNADA LETTER VA
- always   \x0CB6\x0CCD	4-146	# KANNADA LETTER SHA
- always   \x0CB7\x0CCD	4-12346	# KANNADA LETTER SSA
- always   \x0CB8\x0CCD	4-234	# KANNADA LETTER SA
- always   \x0CB9\x0CCD	4-125	# KANNADA LETTER HA
- always   \x0CC4\x0CCD	4-6-1235	# KANNADA VOWEL SIGN VOCALIC RR
+always   \x0CAF\x0CCD	4-13456	# KANNADA LETTER YA
+always   \x0CB0\x0CCD	4-1235	# KANNADA LETTER RA
+always   \x0CB2\x0CCD	4-123	# KANNADA LETTER LA
+always   \x0CB3\x0CCD	4-456	# KANNADA LETTER LLA
+always   \x0CB5\x0CCD	4-1236	# KANNADA LETTER VA
+always   \x0CB6\x0CCD	4-146	# KANNADA LETTER SHA
+always   \x0CB7\x0CCD	4-12346	# KANNADA LETTER SSA
+always   \x0CB8\x0CCD	4-234	# KANNADA LETTER SA
+always   \x0CB9\x0CCD	4-125	# KANNADA LETTER HA
+always   \x0CC4\x0CCD	4-6-1235	# KANNADA VOWEL SIGN VOCALIC RR
 
 #ksha and gya
 
@@ -170,42 +170,42 @@ always \x0C95\x0CCD\x0CB7 12345 #ksha
 attribute KannadaVowel \x0C87\x0C88\x0C89\x0C8A\x0C8B\x0C8E\x0C8F\x0C90\x0C92\x0C93\x0C94
 attribute Halant \x0CCD
 before KannadaVowel always      \x0C95   13-1	# KANNADA LETTER KA
- before KannadaVowel always   \x0C96 	  46-1         # KANNADA LETTER KHA
- before KannadaVowel always   \x0C97	   1245-1	# KANNADA LETTER GA
- before KannadaVowel always   \x0C98	    126-1	# KANNADA LETTER GHA
+before KannadaVowel always   \x0C96 	  46-1         # KANNADA LETTER KHA
+before KannadaVowel always   \x0C97	   1245-1	# KANNADA LETTER GA
+before KannadaVowel always   \x0C98	    126-1	# KANNADA LETTER GHA
 
- before KannadaVowel always   \x0C9A 	 14-1	# KANNADA LETTER CA
- before KannadaVowel always   \x0C9B 	 16-1	# KANNADA LETTER CHA
- before KannadaVowel always   \x0C9C 	 245-1	# KANNADA LETTER JA
- before KannadaVowel always   \x0C9D 	 356-1	# KANNADA LETTER JHA
+before KannadaVowel always   \x0C9A 	 14-1	# KANNADA LETTER CA
+before KannadaVowel always   \x0C9B 	 16-1	# KANNADA LETTER CHA
+before KannadaVowel always   \x0C9C 	 245-1	# KANNADA LETTER JA
+before KannadaVowel always   \x0C9D 	 356-1	# KANNADA LETTER JHA
 
- before KannadaVowel always   \x0C9F 		 23456-1	# KANNADA LETTER TTA
- before KannadaVowel always   \x0CA0 	 2456-1	 # KANNADA LETTER TTHA
- before KannadaVowel always   \x0CA1 	 1246-1	 # KANNADA LETTER DDA
- before KannadaVowel always   \x0CA2 	 123456-1	# KANNADA LETTER DDHA
- before KannadaVowel always   \x0CA3 	 3456-1	# KANNADA LETTER NNA
+before KannadaVowel always   \x0C9F 		 23456-1	# KANNADA LETTER TTA
+before KannadaVowel always   \x0CA0 	 2456-1	 # KANNADA LETTER TTHA
+before KannadaVowel always   \x0CA1 	 1246-1	 # KANNADA LETTER DDA
+before KannadaVowel always   \x0CA2 	 123456-1	# KANNADA LETTER DDHA
+before KannadaVowel always   \x0CA3 	 3456-1	# KANNADA LETTER NNA
 
- before KannadaVowel always   \x0CA4 	 2345-1	# KANNADA LETTER TA
- before KannadaVowel always   \x0CA5 	 1456-1	# KANNADA LETTER THA
- before KannadaVowel always   \x0CA6 	 145-1	# KANNADA LETTER DA
- before KannadaVowel always   \x0CA7 	 2346-1	# KANNADA LETTER DHA
- before KannadaVowel always   \x0CA8 	 1345-1	# KANNADA LETTER NA
+before KannadaVowel always   \x0CA4 	 2345-1	# KANNADA LETTER TA
+before KannadaVowel always   \x0CA5 	 1456-1	# KANNADA LETTER THA
+before KannadaVowel always   \x0CA6 	 145-1	# KANNADA LETTER DA
+before KannadaVowel always   \x0CA7 	 2346-1	# KANNADA LETTER DHA
+before KannadaVowel always   \x0CA8 	 1345-1	# KANNADA LETTER NA
 
- before KannadaVowel always   \x0CAA 	 1234-1	# KANNADA LETTER PA
- before KannadaVowel always   \x0CAB 	 235-1	# KANNADA LETTER PHA
- before KannadaVowel always   \x0CAC 	 12-1	# KANNADA LETTER BA
- before KannadaVowel always   \x0CAD 	 45-1	# KANNADA LETTER BHA
- before KannadaVowel always   \x0CAE 	 135-1	# KANNADA LETTER MA
+before KannadaVowel always   \x0CAA 	 1234-1	# KANNADA LETTER PA
+before KannadaVowel always   \x0CAB 	 235-1	# KANNADA LETTER PHA
+before KannadaVowel always   \x0CAC 	 12-1	# KANNADA LETTER BA
+before KannadaVowel always   \x0CAD 	 45-1	# KANNADA LETTER BHA
+before KannadaVowel always   \x0CAE 	 135-1	# KANNADA LETTER MA
 
- before KannadaVowel always   \x0CAF 	 13456-1	# KANNADA LETTER YA
- before KannadaVowel always   \x0CB0 	 1235-1	# KANNADA LETTER RA
- before KannadaVowel always   \x0CB2 	 123-1	# KANNADA LETTER LA
- before KannadaVowel always   \x0CB3 	 456-1	# KANNADA LETTER LLA
- noback before KannadaVowel always   \x0CB5 	 1236	# KANNADA LETTER VA
- before KannadaVowel always   \x0CB6 	 146-1	# KANNADA LETTER SHA
- before KannadaVowel always   \x0CB7 	 12346-1	# KANNADA LETTER SSA
- before KannadaVowel always   \x0CB8 	 234-1	# KANNADA LETTER SA
- before KannadaVowel always   \x0CB9 	 125-1	# KANNADA LETTER HA
+before KannadaVowel always   \x0CAF 	 13456-1	# KANNADA LETTER YA
+before KannadaVowel always   \x0CB0 	 1235-1	# KANNADA LETTER RA
+before KannadaVowel always   \x0CB2 	 123-1	# KANNADA LETTER LA
+before KannadaVowel always   \x0CB3 	 456-1	# KANNADA LETTER LLA
+noback before KannadaVowel always   \x0CB5 	 1236	# KANNADA LETTER VA
+before KannadaVowel always   \x0CB6 	 146-1	# KANNADA LETTER SHA
+before KannadaVowel always   \x0CB7 	 12346-1	# KANNADA LETTER SSA
+before KannadaVowel always   \x0CB8 	 234-1	# KANNADA LETTER SA
+before KannadaVowel always   \x0CB9 	 125-1	# KANNADA LETTER HA
 
 before KannadaVowel always   \x0CC4 	 6-1235-1	# KANNADA VOWEL SIGN VOCALIC RR
 

--- a/tables/km-g1.utb
+++ b/tables/km-g1.utb
@@ -259,7 +259,7 @@ match - \x17A2\x17BE - 146-135
 noback pass2 @135-124 @124-135
 match - \x17A2\x17C2 - 126-135
 match - \x17A2\x17C3 - 24-135
- # regular consonants Dot pattern for regular consonants
+# regular consonants Dot pattern for regular consonants
 letter \x1780 1245
 letter \x1781 13
 #letter \x1782 6-1245
@@ -310,7 +310,7 @@ letter \x17AF 5
 letter \x17B0 124-1
 letter \x17B1 156-1
 letter \x17B2 156-1
- 	#dependent vowels	# Dot paterns for dependent vowels
+#dependent vowels	# Dot paterns for dependent vowels
 letter	\x17B6	16
 letter	\x17B7	34
 letter	\x17B8	15


### PR DESCRIPTION
The liblouis table parser is quite lenient in what it accepts. Opcodes or comments do not have to start at the beginning of the line. To make parsing easier just drop the few cases where a table doesn't conform to this informal standard:

- make sure all opcodes start at the beginning of the line
- make sure all comments start at the beginning of the line
