### PR TITLE
Do not claim that en-us-g2.ctb produces ASCII braille

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2716,12 +2716,16 @@ Do a backward translation.
 If no options are given forward translation is assumed.
 
 Use the following command to do a forward translation with translation
-table @file{en-us-g2.ctb}. The resulting braille is ASCII encoded (as
-defined in @file{en-us-g2.ctb}).
+table @file{en-us-g2.ctb}.
 
 @example
 lou_translate --forward en-us-g2.ctb < input.txt
 @end example
+
+The encoding of the resulting braille depends on the character
+definitions in the given table. It is recommended to use a display
+table, as in the following example, if you require a specific braille
+encoding.
 
 The next example illustrates a forward translation with translation
 table @file{en-us-g2.ctb} and display table @file{unicode.dis}. The

--- a/tools/lou_translate.c
+++ b/tools/lou_translate.c
@@ -101,13 +101,13 @@ Options:\n\
 Examples:\n\
   lou_translate --forward en-us-g2.ctb < input.txt\n\
   \n\
-  Do a forward translation with table en-us-g2.ctb. The resulting braille is\n\
-  ASCII encoded.\n\
+  Do a forward translation with table en-us-g2.ctb.\n\
   \n\
   lou_translate unicode.dis,en-us-g2.ctb < input.txt\n\
   \n\
-  Do a forward translation with table en-us-g2.ctb. The resulting braille is\n\
-  encoded as Unicode dot patterns.\n\
+  If you require a specific braille encoding use a display table. Here we do a\n\
+  forward translation with table en-us-g2.ctb and a display table for Unicode\n\
+  braille. The resulting braille is encoded as Unicode dot patterns.\n\
   \n\
   echo \",! qk br{n fox\" | lou_translate --backward en-us-g2.ctb\n\
   \n\


### PR DESCRIPTION
instead say that the encoding depends on the character definitions and recommend to use a display table.