### PR TITLE
Add virtual dots to Dutch output

### DIFF
--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -286,6 +286,8 @@ table_files = \
 	nl-chardefs.uti \
 	nl-comp8.utb \
 	nl-NL-g0.utb \
+	nl-print.dis \
+	nl-unicode.dis \
 	nl.tbl \
 	no-no-8dot-fallback-6dot-g0.utb \
 	no-no-8dot.utb \

--- a/tables/nl-BE.dis
+++ b/tables/nl-BE.dis
@@ -17,69 +17,150 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 
+                    # corresponding character in nl-print.dis
 display \x0020 0
-display a 1
-display , 2
-display b 12
-display . 3
-display k 13
-display ; 23
-display l 123
-display " 4
-display c 14
-display i 24
-display f 124
-display | 34
-display m 134
-display s 234
-display p 1234
-display ! 5
-display e 15
-display : 25
-display h 125
-display * 35
-display o 135
-display + 235
-display r 1235
-display > 45
-display d 145
-display j 245
-display g 1245
-display ` 345
-display n 1345
-display t 2345
-display q 12345
-display ' 6
-display 1 16
-display ? 26
-display 2 126
-display - 36
-display u 136
-display ( 236
-display v 1236
-display $ 46
-display 3 146
-display 9 246
-display 6 1246
-display 0 346
-display x 1346
-display ~ 2346
-display & 12346
-display < 56
-display 5 156
-display / 256
-display 8 1256
-display ) 356
-display z 1356
-display = 2356
-display { 12356
-display _ 456
-display 4 1456
-display w 2456
-display 7 12456
-display # 3456
-display y 13456
-display } 23456
-display % 123456
-
-
+display a 1         a
+display a 19        1
+display a 1b        α
+display a 1c        ά
+display , 2         ,
+display , 29        ₁
+display b 12        b
+display b 129       2
+display b 12b       β
+display . 3         '
+display k 13        k
+display k 13b       κ
+display ; 23        ;
+display ; 239       ₂
+display l 123       l
+display l 123b      λ
+display " 4         ⠈ (voorteken in duim-, geboorte-, graad-, minuut- en secondeteken)
+display c 14        c
+display c 149       3
+display c 14a       ©
+display i 24        i
+display i 249       9
+display i 24b       ι
+display i 24c       ί
+display f 124       f
+display f 1249      6
+display f 124b      φ
+display f 124c      ϕ
+display | 34        /
+display | 349       í
+display m 134       m
+display m 134b      μ
+display s 234       s
+display s 234b      σ
+display s 234c      ς
+display p 1234      p
+display p 1234a     £
+display p 1234b     π
+display ! 5         ⠐ (sleutelteken tweede betekenis / einderegelteken)
+display e 15        e
+display e 159       5
+display e 15a       €
+display e 15b       ε
+display : 25        :
+display : 259       ₃
+display h 125       h
+display h 1259      8
+display * 35        *
+display * 359       ₉
+display * 35a       ′
+display o 135       o
+display o 1359      >
+display o 135b      ο
+display + 235       !
+display + 2359      ₆
+display + 235a      +
+display r 1235      r
+display r 12359     ®
+display r 1235b     ρ
+display > 45        ⠘ (permanent hoofdletterteken)
+display d 145       d
+display d 1459      4
+display d 145a      $
+display d 145b      δ
+display j 245       j
+display j 2459      0
+display g 1245      g
+display g 12459     7
+display g 1245b     γ
+display ` 345       @
+display ` 3459      ä
+display n 1345      n
+display n 1345b     ν
+display t 2345      t
+display t 2345b     τ
+display q 12345     q
+display ' 6         ⠠ (herstelteken eerste betekenis)
+display 1 16        \ 
+display 1 169       â
+display ? 26        ?
+display ? 269       ₅
+display ? 26a       ~
+display 2 126       ê
+display 2 126b      ł
+display - 36        -
+display u 136       u
+display u 136b      υ
+display ( 236       (
+display ( 2369      ₈
+display ( 236a      ·
+display v 1236      v
+display $ 46        ⠨ (hoofdletterteken)
+display 3 146       î
+display 9 246       <
+display 9 2469      ö
+display 6 1246      ë
+display 0 346       ^
+display 0 3469      ó
+display 0 346a      §
+display x 1346      x
+display x 1346b     ξ
+display ~ 2346      è
+display ~ 2346b     ź
+display & 12346     &
+display & 123469    ç
+display & 12346b    χ
+display < 56        ⠰ (alfabetwisselingsteken)
+display 5 156       û
+display 5 156b      η
+display / 256       .
+display / 2569      ₄
+display / 256a      ÷
+display 8 1256      ü
+display ) 356       )
+display ) 3569      ₀
+display ) 356a      °
+display z 1356      z
+display z 1356b     ζ
+display = 2356      "
+display = 23569     ₇
+display = 2356a     =
+display { 12356     [
+display { 123569    à
+display { 12356a    á
+display { 12356b    {
+display _ 456       ⠸ (drukwijzigingsteken)
+display _ 4569      _
+display 4 1456      |
+display 4 14569     ô
+display 4 1456b     θ
+display w 2456      w
+display w 2456b     ω
+display 7 12456     ï
+display 7 124569    ñ
+display # 3456      ⠼ (cijferteken)
+display # 34569     #
+display y 13456     y
+display y 13456a    ¥
+display y 13456b    ψ
+display } 23456     ]
+display } 234569    ù
+display } 23456a    ú
+display } 23456b    }
+display % 123456    %
+display % 1234569   é

--- a/tables/nl-NL-g0.utb
+++ b/tables/nl-NL-g0.utb
@@ -37,6 +37,9 @@
 #
 # ----------------------------------------------------------------------------------------------
 
+# include a display table by default to avoid errors if the user would not include a display table
+include nl-print.dis
+
 include nl-chardefs.uti
 include braille-patterns.cti
 
@@ -66,8 +69,8 @@ midword \x003D 0-2356-0
 endword \x003D 0-2356
 
 # plusteken +
-begword \x002B   235-0
-endnum  \x002B 5-235
+begword \x002B   235a-0
+endnum  \x002B 5-235a
 
 # deelteken ÷
 begword \x00F7   256-0
@@ -101,16 +104,16 @@ noback correct ["¥"]~      "yen"
 # Geplaatst vóór het getal wordt de munteenheid door haar beginletter weergegeven, zonder spatie tussen letter en cijfer
 
 # §1.5 euroteken € (zonder spatie vóór het getal) [1]
-noback joinnum \x20AC 15
+noback joinnum \x20AC 15a
 
 # §1.4 dollarteken $ (zonder spatie vóór het getal) [1]
-noback joinnum \x0024 145
+noback joinnum \x0024 145a
 
 # §1.16 pondteken £ (zonder spatie vóór het getal) [1]
-noback joinnum \x00A3 1234
+noback joinnum \x00A3 1234a
 
 # §1.24 yenteken ¥ (zonder spatie vóór het getal) [1]
-noback joinnum \x00A5 13456
+noback joinnum \x00A5 13456a
 
 # §1.34 verticale streep | (spatie voor en na) [1]
 
@@ -119,8 +122,8 @@ midword \x007C 0-1456-0
 endword \x007C 0-1456
 
 # §3.6 Graad-, minuut- en secondeteken [1]
-noback context $d["''"] @4-35-35
-noback context $d["'"] @4-35
+noback context $d["''"] @4-35a-35a
+noback context $d["'"] @4-35a
 
 # Roman page numbers
 replace  \\_
@@ -161,9 +164,8 @@ attribute    plusamp                     +&     # 2nd class = $x
 attribute    noplusamp                   .'‘’   # 3rd class = $y
 noback pass4    %noplusamp[]%plusamp        @5
 noback pass4    $l[]%plusamp                @5
-noback pass4    [@235a]%plusamp             @235-5
+noback pass4    [@235a]%plusamp             @235a-5
 noback pass4    [@12346a]%plusamp           @12346-5
-noback pass4    [@235a]                     @235
 noback pass4    [@12346a]                   @12346
 
 numsign  3456
@@ -258,34 +260,62 @@ attribute foreign ÃãÅåÆæÌìÕõØø
 
 # Greek letters
 
-lowercase α 1           GREEK LETTER ALPHA
-lowercase ά 1           GREEK LETTER ALPHA WITH TONOS
-lowercase β 12          GREEK LETTER BETA
-lowercase γ 1245        GREEK LETTER GAMMA
-lowercase δ 145         GREEK LETTER DELTA
-lowercase ε 15          GREEK LETTER EPSILON
-lowercase ζ 1356        GREEK LETTER ZETA
-lowercase ι 24          GREEK LETTER IOTA
-lowercase ί 24          GREEK LETTER IOTA WITH TONOS
-lowercase κ 13          GREEK LETTER KAPPA
-lowercase λ 123         GREEK LETTER LAMDA
-lowercase μ 134         GREEK LETTER MU
-lowercase ν 1345        GREEK LETTER NU
-lowercase ξ 1346        GREEK LETTER XI
-lowercase ο 135         GREEK LETTER OMICRON
-lowercase π 1234        GREEK LETTER PI
-lowercase ρ 1235        GREEK LETTER RHO
-lowercase σ 234         GREEK LETTER SIGMA
-lowercase ς 234         GREEK LETTER FINAL SIGMA
-lowercase τ 2345        GREEK LETTER TAU
-lowercase υ 136         GREEK LETTER UPSILON
-lowercase φ 124         GREEK LETTER PHI
-lowercase ϕ 124         GREEK PHI SYMBOL
-lowercase ψ 13456       GREEK LETTER PSI
-lowercase ω 2456        GREEK LETTER OMEGA
-lowercase η 156         GREEK LETTER ETA
-lowercase θ 1456        GREEK LETTER THETA
-lowercase χ 12346       GREEK LETTER CHI
+noback lowercase α 1b          GREEK LETTER ALPHA
+nofor  lowercase α 1           GREEK LETTER ALPHA
+noback lowercase ά 1c          GREEK LETTER ALPHA WITH TONOS
+nofor  lowercase ά 1           GREEK LETTER ALPHA WITH TONOS
+noback lowercase β 12b         GREEK LETTER BETA
+nofor  lowercase β 12          GREEK LETTER BETA
+noback lowercase γ 1245b       GREEK LETTER GAMMA
+nofor  lowercase γ 1245        GREEK LETTER GAMMA
+noback lowercase δ 145b        GREEK LETTER DELTA
+nofor  lowercase δ 145         GREEK LETTER DELTA
+noback lowercase ε 15b         GREEK LETTER EPSILON
+nofor  lowercase ε 15          GREEK LETTER EPSILON
+noback lowercase ζ 1356b       GREEK LETTER ZETA
+nofor  lowercase ζ 1356        GREEK LETTER ZETA
+noback lowercase ι 24b         GREEK LETTER IOTA
+nofor  lowercase ι 24          GREEK LETTER IOTA
+noback lowercase ί 24c         GREEK LETTER IOTA WITH TONOS
+nofor  lowercase ί 24          GREEK LETTER IOTA WITH TONOS
+noback lowercase κ 13b         GREEK LETTER KAPPA
+nofor  lowercase κ 13          GREEK LETTER KAPPA
+noback lowercase λ 123b        GREEK LETTER LAMDA
+nofor  lowercase λ 123         GREEK LETTER LAMDA
+noback lowercase μ 134b        GREEK LETTER MU
+nofor  lowercase μ 134         GREEK LETTER MU
+noback lowercase ν 1345b       GREEK LETTER NU
+nofor  lowercase ν 1345        GREEK LETTER NU
+noback lowercase ξ 1346b       GREEK LETTER XI
+nofor  lowercase ξ 1346        GREEK LETTER XI
+noback lowercase ο 135b        GREEK LETTER OMICRON
+nofor  lowercase ο 135         GREEK LETTER OMICRON
+noback lowercase π 1234b       GREEK LETTER PI
+nofor  lowercase π 1234        GREEK LETTER PI
+noback lowercase ρ 1235b       GREEK LETTER RHO
+nofor  lowercase ρ 1235        GREEK LETTER RHO
+noback lowercase σ 234b        GREEK LETTER SIGMA
+nofor  lowercase σ 234         GREEK LETTER SIGMA
+noback lowercase ς 234c        GREEK LETTER FINAL SIGMA
+nofor  lowercase ς 234         GREEK LETTER FINAL SIGMA
+noback lowercase τ 2345b       GREEK LETTER TAU
+nofor  lowercase τ 2345        GREEK LETTER TAU
+noback lowercase υ 136b        GREEK LETTER UPSILON
+nofor  lowercase υ 136         GREEK LETTER UPSILON
+noback lowercase φ 124b        GREEK LETTER PHI
+nofor  lowercase φ 124         GREEK LETTER PHI
+noback lowercase ϕ 124c        GREEK PHI SYMBOL
+nofor  lowercase ϕ 124         GREEK PHI SYMBOL
+noback lowercase ψ 13456b      GREEK LETTER PSI
+nofor  lowercase ψ 13456       GREEK LETTER PSI
+noback lowercase ω 2456b       GREEK LETTER OMEGA
+nofor  lowercase ω 2456        GREEK LETTER OMEGA
+noback lowercase η 156b        GREEK LETTER ETA
+nofor  lowercase η 156         GREEK LETTER ETA
+noback lowercase θ 1456b       GREEK LETTER THETA
+nofor  lowercase θ 1456        GREEK LETTER THETA
+noback lowercase χ 12346b      GREEK LETTER CHI
+nofor  lowercase χ 12346       GREEK LETTER CHI
 
 base uppercase Α α
 base uppercase Ά ά
@@ -320,10 +350,12 @@ attribute foreign ΑαΆάΒβΓγΔδΕεΖζΙιΊίΚκΛλΜμΝνΞξΟοΠ
 
 attribute foreign Ññ # ñ defined in nl-chardefs.uti
 
-lowercase ł 126
+noback lowercase ł 126b
+nofor  lowercase ł 126
 base uppercase Ł ł
 attribute foreign Łł
 
-lowercase ź 2346
+noback lowercase ź 2346b
+nofor  lowercase ź 2346
 base uppercase Ź ź
 attribute foreign Źź

--- a/tables/nl-chardefs.uti
+++ b/tables/nl-chardefs.uti
@@ -47,28 +47,41 @@ include spaces.uti
 
 include latinLetterDef6Dots.uti
 
-lowercase      \x00E0 12356             à                  LATIN SMALL LETTER A WITH GRAVE
-lowercase      \x00E1 12356             á                  LATIN SMALL LETTER A WITH ACUTE
-lowercase      \x00E2 16                â                  LATIN SMALL LETTER A WITH CIRCUMFLEX
-lowercase      \x00E4 345               ä                  LATIN SMALL LETTER A WITH DIAERESIS
-lowercase      \x00E7 12346             ç                  LATIN SMALL LETTER C WITH CEDILLA
-lowercase      \x00E8 2346              è                  LATIN SMALL LETTER E WITH GRAVE
-lowercase      \x00E9 123456            é                  LATIN SMALL LETTER E WITH ACUTE
-lowercase      \x00EA 126               ê                  LATIN SMALL LETTER E WITH CIRCUMFLEX
-lowercase      \x00EB 1246              ë                  LATIN SMALL LETTER E WITH DIAERESIS
-lowercase      \x00ED 34                í                  LATIN SMALL LETTER I WITH ACUTE
-lowercase      \x00EE 146               î                  LATIN SMALL LETTER I WITH CIRCUMFLEX
-lowercase      \x00EF 12456             ï                  LATIN SMALL LETTER I WITH DIAERESIS
-lowercase      \x00F1 12456             ñ                  LATIN SMALL LETTER N WITH TILDE
-lowercase      \x00F2 346               ò                  LATIN SMALL LETTER O WITH GRAVE
-lowercase      \x00F3 346               ó                  LATIN SMALL LETTER O WITH ACUTE
-lowercase      \x00F4 1456              ô                  LATIN SMALL LETTER O WITH CIRCUMFLEX
-lowercase      \x00F6 246               ö                  LATIN SMALL LETTER O WITH DIAERESIS
-lowercase      \x00F9 23456             ù                  LATIN SMALL LETTER U WITH GRAVE
-lowercase      \x00FA 23456             ú                  LATIN SMALL LETTER U WITH ACUTE
-lowercase      \x00FB 156               û                  LATIN SMALL LETTER U WITH CIRCUMFLEX
-lowercase      \x00FC 1256              ü                  LATIN SMALL LETTER U WITH DIAERESIS
-lowercase      \x00DF 2346              ß                  LATIN SMALL LETTER SHARP S
+noback lowercase      \x00E0 123569            à                  LATIN SMALL LETTER A WITH GRAVE
+nofor  lowercase      \x00E0 12356             à                  LATIN SMALL LETTER A WITH GRAVE
+noback lowercase      \x00E1 12356a            á                  LATIN SMALL LETTER A WITH ACUTE
+nofor  lowercase      \x00E1 12356             á                  LATIN SMALL LETTER A WITH ACUTE
+noback lowercase      \x00E2 169               â                  LATIN SMALL LETTER A WITH CIRCUMFLEX
+nofor  lowercase      \x00E2 16                â                  LATIN SMALL LETTER A WITH CIRCUMFLEX
+noback lowercase      \x00E4 3459              ä                  LATIN SMALL LETTER A WITH DIAERESIS
+nofor  lowercase      \x00E4 345               ä                  LATIN SMALL LETTER A WITH DIAERESIS
+noback lowercase      \x00E7 123469            ç                  LATIN SMALL LETTER C WITH CEDILLA
+nofor  lowercase      \x00E7 12346             ç                  LATIN SMALL LETTER C WITH CEDILLA
+       lowercase      \x00E8 2346              è                  LATIN SMALL LETTER E WITH GRAVE
+noback lowercase      \x00E9 1234569           é                  LATIN SMALL LETTER E WITH ACUTE
+nofor  lowercase      \x00E9 123456            é                  LATIN SMALL LETTER E WITH ACUTE
+       lowercase      \x00EA 126               ê                  LATIN SMALL LETTER E WITH CIRCUMFLEX
+       lowercase      \x00EB 1246              ë                  LATIN SMALL LETTER E WITH DIAERESIS
+noback lowercase      \x00ED 349               í                  LATIN SMALL LETTER I WITH ACUTE
+nofor  lowercase      \x00ED 34                í                  LATIN SMALL LETTER I WITH ACUTE
+       lowercase      \x00EE 146               î                  LATIN SMALL LETTER I WITH CIRCUMFLEX
+       lowercase      \x00EF 12456             ï                  LATIN SMALL LETTER I WITH DIAERESIS
+noback lowercase      \x00F1 124569            ñ                  LATIN SMALL LETTER N WITH TILDE
+nofor  lowercase      \x00F1 12456             ñ                  LATIN SMALL LETTER N WITH TILDE
+       lowercase      \x00F2 346               ò                  LATIN SMALL LETTER O WITH GRAVE
+noback lowercase      \x00F3 3469              ó                  LATIN SMALL LETTER O WITH ACUTE
+nofor  lowercase      \x00F3 346               ó                  LATIN SMALL LETTER O WITH ACUTE
+noback lowercase      \x00F4 14569             ô                  LATIN SMALL LETTER O WITH CIRCUMFLEX
+nofor  lowercase      \x00F4 1456              ô                  LATIN SMALL LETTER O WITH CIRCUMFLEX
+noback lowercase      \x00F6 2469              ö                  LATIN SMALL LETTER O WITH DIAERESIS
+nofor  lowercase      \x00F6 246               ö                  LATIN SMALL LETTER O WITH DIAERESIS
+noback lowercase      \x00F9 234569            ù                  LATIN SMALL LETTER U WITH GRAVE
+nofor  lowercase      \x00F9 23456             ù                  LATIN SMALL LETTER U WITH GRAVE
+noback lowercase      \x00FA 23456a            ú                  LATIN SMALL LETTER U WITH ACUTE
+nofor  lowercase      \x00FA 23456             ú                  LATIN SMALL LETTER U WITH ACUTE
+       lowercase      \x00FB 156               û                  LATIN SMALL LETTER U WITH CIRCUMFLEX
+       lowercase      \x00FC 1256              ü                  LATIN SMALL LETTER U WITH DIAERESIS
+       lowercase      \x00DF 2346              ß                  LATIN SMALL LETTER SHARP S
 
 base uppercase \x00C0 \x00E0           Àà                  LATIN CAPITAL LETTER A WITH GRAVE - LATIN SMALL LETTER A WITH GRAVE
 base uppercase \x00C1 \x00E1           Áá                  LATIN CAPITAL LETTER A WITH ACUTE - LATIN SMALL LETTER A WITH ACUTE
@@ -93,93 +106,159 @@ base uppercase \x00DB \x00FB           Ûû                  LATIN CAPITAL LETTE
 base uppercase \x00DC \x00FC           Üü                  LATIN CAPITAL LETTER U WITH DIAERESIS - LATIN SMALL LETTER U WITH DIAERESIS
 base uppercase \x1E9E \x00DF           ẞß                  LATIN CAPITAL LETTER SHARP S - LATIN SMALL LETTER SHARP S
 
-punctuation \x0021        235                 !                   EXCLAMATION MARK
-punctuation \x0022        2356                "                   QUOTATION MARK
-sign        \x0023        5-3456              #                   NUMBER SIGN
-sign        \x0024        145                 $                   DOLLAR SIGN
-sign        \x0025        123456              %                   PERCENT SIGN
-sign        \x0026        12346a              &                   AMPERSAND
-punctuation \x0027        3                   '                   APOSTROPHE
-punctuation \x0028        236                 (                   LEFT PARENTHESIS
-punctuation \x0029        356                 )                   RIGHT PARENTHESIS
-sign        \x002A        35                  *                   ASTERISK
-math        \x002B        235a                +                   PLUS SIGN
-punctuation \x002C        2                   ,                   COMMA
-punctuation \x002D        36                  -                   HYPHEN-MINUS
-punctuation \x002E        256                 .                   FULL STOP
-math        \x002F        34                  /                   SOLIDUS
+       punctuation \x0021        235                 !                   EXCLAMATION MARK
+       punctuation \x0022        2356                "                   QUOTATION MARK
+noback sign        \x0023        5-34569             #                   NUMBER SIGN
+nofor  sign        \x0023        5-3456              #                   NUMBER SIGN
+noback sign        \x0024        145a                $                   DOLLAR SIGN
+nofor  sign        \x0024        145                 $                   DOLLAR SIGN
+       sign        \x0025        123456              %                   PERCENT SIGN
+       sign        \x0026        12346a              &                   AMPERSAND
+       punctuation \x0027        3                   '                   APOSTROPHE
+       punctuation \x0028        236                 (                   LEFT PARENTHESIS
+       punctuation \x0029        356                 )                   RIGHT PARENTHESIS
+       sign        \x002A        35                  *                   ASTERISK
+       math        \x002B        235a                +                   PLUS SIGN
+       punctuation \x002C        2                   ,                   COMMA
+       punctuation \x002D        36                  -                   HYPHEN-MINUS
+       punctuation \x002E        256                 .                   FULL STOP
+       math        \x002F        34                  /                   SOLIDUS
 
-include digits6Dots.uti
-include litdigits6Dots.uti
+noback digit 0 2459
+noback digit 1 19
+noback digit 2 129
+noback digit 3 149
+noback digit 4 1459
+noback digit 5 159
+noback digit 6 1249
+noback digit 7 12459
+noback digit 8 1259
+noback digit 9 249
 
-punctuation \x003A        25                  :                   COLON
-punctuation \x003B        23                  ;                   SEMICOLON
-math        \x003C        5-246               <                   LESS-THAN SIGN
-math        \x003D        2356                =                   EQUALS SIGN
-math        \x003E        5-135               >                   GREATER-THAN SIGN
-punctuation \x003F        26                  ?                   QUESTION MARK
-sign        \x0040        345                 @                   COMMERCIAL AT
-punctuation \x005B        12356               [                   LEFT SQUARE BRACKET
-sign        \x005C        5-16                \                   REVERSE SOLIDUS
-punctuation \x005D        23456               ]                   RIGHT SQUARE BRACKET
-sign        \x005E        346                 ^                   CIRCUMFLEX ACCENT
-sign        \x005F        456                 _                   LOW LINE
-punctuation \x0060        3                   `                   GRAVE ACCENT
-sign        \x007C        1456                |                   VERTICAL LINE
-sign        \x007B        5-12356             {                   LEFT CURLY BRACKET
-sign        \x007D        5-23456             }                   RIGHT CURLY BRACKET
-math        \x007E        5-26                ~                   TILDE
+nofor digit 0 245
+nofor digit 1 1
+nofor digit 2 12
+nofor digit 3 14
+nofor digit 4 145
+nofor digit 5 15
+nofor digit 6 124
+nofor digit 7 1245
+nofor digit 8 125
+nofor digit 9 24
+
+nofor litdigit 0 2459
+nofor litdigit 1 19
+nofor litdigit 2 129
+nofor litdigit 3 149
+nofor litdigit 4 1459
+nofor litdigit 5 159
+nofor litdigit 6 1249
+nofor litdigit 7 12459
+nofor litdigit 8 1259
+nofor litdigit 9 249
+
+nofor litdigit 0 245
+nofor litdigit 1 1
+nofor litdigit 2 12
+nofor litdigit 3 14
+nofor litdigit 4 145
+nofor litdigit 5 15
+nofor litdigit 6 124
+nofor litdigit 7 1245
+nofor litdigit 8 125
+nofor litdigit 9 24
+
+       punctuation \x003A        25                  :                   COLON
+       punctuation \x003B        23                  ;                   SEMICOLON
+       math        \x003C        5-246               <                   LESS-THAN SIGN
+noback math        \x003D        2356a               =                   EQUALS SIGN
+nofor  math        \x003D        2356                =                   EQUALS SIGN
+noback math        \x003E        5-1359              >                   GREATER-THAN SIGN
+nofor  math        \x003E        5-135               >                   GREATER-THAN SIGN
+       punctuation \x003F        26                  ?                   QUESTION MARK
+       sign        \x0040        345                 @                   COMMERCIAL AT
+       punctuation \x005B        12356               [                   LEFT SQUARE BRACKET
+       sign        \x005C        5-16                \                   REVERSE SOLIDUS
+       punctuation \x005D        23456               ]                   RIGHT SQUARE BRACKET
+       sign        \x005E        346                 ^                   CIRCUMFLEX ACCENT
+noback sign        \x005F        4569                _                   LOW LINE
+nofor  sign        \x005F        456                 _                   LOW LINE
+       punctuation \x0060        3                   `                   GRAVE ACCENT
+       sign        \x007C        1456                |                   VERTICAL LINE
+noback sign        \x007B        5-12356b            {                   LEFT CURLY BRACKET
+nofor  sign        \x007B        5-12356             {                   LEFT CURLY BRACKET
+noback sign        \x007D        5-23456b            }                   RIGHT CURLY BRACKET
+nofor  sign        \x007D        5-23456             }                   RIGHT CURLY BRACKET
+noback math        \x007E        5-26a               ~                   TILDE
+nofor  math        \x007E        5-26                ~                   TILDE
 
 
 # ----------------------------------------------------------------------------------------------
 # Unicode 0080..00FF  C1 Controls and Latin-1 Supplement
 # ----------------------------------------------------------------------------------------------
 
-sign        \x0080        15                  €                   <control> - ANSI: EURO-CURRENCY SIGN - MACROMAN: A DIAERESIS
-punctuation \x0082        3                   ‚                   <control> BREAK PERMITTED HERE - ANSI: SINGLE LOW-9 QUOTATION MARK - MACROMAN: C CEDILLA
-punctuation \x0084        2356                „                   <control> - ANSI: DOUBLE LOW-9 QUOTATION MARK - MACROMAN: N TILDE
-punctuation \x0085        256-256-256         …                   <control> NEXT LINE (NEL) - ANSI: HORIZONTAL ELLIPSIS - MACROMAN: O DIAERESIS
-sign        \x0086        235                 †                   <control> START OF SELECTED AREA - ANSI: DAGGER - MACROMAN: U DIAERESIS
-punctuation \x0088        34                  ˆ                   <control> CHARACTER TABULATION SET - ANSI: MODIFIER LETTER CIRCUMFLEX ACCENT - MACROMAN: A GRAVE
-sign        \x0089        123456-123456       ‰                   <control> CHARACTER TABULATION WITH JUSTIFICATION - ANSI: PER MILLE SIGN - MACROMAN: A CIRCUMFLEX
-punctuation \x008B        3                   ‹                   <control> PARTIAL LINE FORWARD - ANSI: SINGLE LEFT-POINTING ANGLE QUOTATION MARK - MACROMAN: A TILDE
-punctuation \x0091        3                   ‘                   <control> PRIVATE USE ONE - ANSI: LEFT SINGLE QUOTATION MARK - MACROMAN: E DIAERESIS
-punctuation \x0092        3                   ’                   <control> PRIVATE USE TWO - ANSI: RIGHT SINGLE QUOTATION MARK - MACROMAN: I ACUTE
-punctuation \x0093        2356                “                   <control> SET TRANSMIT STATE - ANSI: LEFT DOUBLE QUOTATION MARK - MACROMAN: I GRAVE
-punctuation \x0094        2356                ”                   <control> CANCEL CHARACTER - ANSI: RIGHT DOUBLE QUOTATION MARK - MACROMAN: I CIRCUMFLEX
-sign        \x0095        5-256               •                   <control> MESSAGE WAITING - ANSI: BULLET - MACROMAN: I DIAERESIS
-punctuation \x0096        36                  –                   <control> START OF GUARDED AREA - ANSI: EN DASH - MACROMAN: N TILDE
-punctuation \x0097        36                  —                   <control> END OF GUARDED AREA - ANSI: EM DASH - MACROMAN: O ACUTE
-sign        \x0098        5-26                ˜                   <control> START OF STRING - ANSI: SMALL TILDE - MACROMAN: O GRAVE
-sign        \x0099        5-2345-134          ™                   <control> - ANSI: TRADE MARK SIGN - MACROMAN: O CIRCUMFLEX
-punctuation \x009B        3                   ›                   <control> CONTROL SEQUENCE INTRODUCER - ANSI: SINGLE RIGHT-POINTING ANGLE QUOTATION MARK - MACROMAN: O TILDE
+noback sign        \x0080        15a                 €                   <control> - ANSI: EURO-CURRENCY SIGN - MACROMAN: A DIAERESIS
+nofor  sign        \x0080        15                  €                   <control> - ANSI: EURO-CURRENCY SIGN - MACROMAN: A DIAERESIS
+       punctuation \x0082        3                   ‚                   <control> BREAK PERMITTED HERE - ANSI: SINGLE LOW-9 QUOTATION MARK - MACROMAN: C CEDILLA
+       punctuation \x0084        2356                „                   <control> - ANSI: DOUBLE LOW-9 QUOTATION MARK - MACROMAN: N TILDE
+       punctuation \x0085        256-256-256         …                   <control> NEXT LINE (NEL) - ANSI: HORIZONTAL ELLIPSIS - MACROMAN: O DIAERESIS
+       sign        \x0086        235                 †                   <control> START OF SELECTED AREA - ANSI: DAGGER - MACROMAN: U DIAERESIS
+       punctuation \x0088        34                  ˆ                   <control> CHARACTER TABULATION SET - ANSI: MODIFIER LETTER CIRCUMFLEX ACCENT - MACROMAN: A GRAVE
+       sign        \x0089        123456-123456       ‰                   <control> CHARACTER TABULATION WITH JUSTIFICATION - ANSI: PER MILLE SIGN - MACROMAN: A CIRCUMFLEX
+       punctuation \x008B        3                   ‹                   <control> PARTIAL LINE FORWARD - ANSI: SINGLE LEFT-POINTING ANGLE QUOTATION MARK - MACROMAN: A TILDE
+       punctuation \x0091        3                   ‘                   <control> PRIVATE USE ONE - ANSI: LEFT SINGLE QUOTATION MARK - MACROMAN: E DIAERESIS
+       punctuation \x0092        3                   ’                   <control> PRIVATE USE TWO - ANSI: RIGHT SINGLE QUOTATION MARK - MACROMAN: I ACUTE
+       punctuation \x0093        2356                “                   <control> SET TRANSMIT STATE - ANSI: LEFT DOUBLE QUOTATION MARK - MACROMAN: I GRAVE
+       punctuation \x0094        2356                ”                   <control> CANCEL CHARACTER - ANSI: RIGHT DOUBLE QUOTATION MARK - MACROMAN: I CIRCUMFLEX
+       sign        \x0095        5-256               •                   <control> MESSAGE WAITING - ANSI: BULLET - MACROMAN: I DIAERESIS
+       punctuation \x0096        36                  –                   <control> START OF GUARDED AREA - ANSI: EN DASH - MACROMAN: N TILDE
+       punctuation \x0097        36                  —                   <control> END OF GUARDED AREA - ANSI: EM DASH - MACROMAN: O ACUTE
+       sign        \x0098        5-26                ˜                   <control> START OF STRING - ANSI: SMALL TILDE - MACROMAN: O GRAVE
+       sign        \x0099        5-2345-134          ™                   <control> - ANSI: TRADE MARK SIGN - MACROMAN: O CIRCUMFLEX
+       punctuation \x009B        3                   ›                   <control> CONTROL SEQUENCE INTRODUCER - ANSI: SINGLE RIGHT-POINTING ANGLE QUOTATION MARK - MACROMAN: O TILDE
 
-punctuation \x00A1        235                 ¡                   INVERTED EXCLAMATION MARK
-sign        \x00A2        14                  ¢                   CENT SIGN
-sign        \x00A3        1234                £                   POUND SIGN
-sign        \x00A5        13456               ¥                   YEN SIGN
-sign        \x00A7        346                 §                   SECTION SIGN
-sign        \x00A9        5-14                ©                   COPYRIGHT SIGN
-punctuation \x00AB        2356                «                   LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-punctuation \x00AD        36                 ­                   SOFT HYPHEN
-sign        \x00AE        5-1235              ®                   REGISTERED SIGN
-sign        \x00B0        4-356               °                   DEGREE SIGN
-sign        \x00B1        235-36              ±                   PLUS-MINUS SIGN
-math        \x00B2        346-3456-12         ²                   SUPERSCRIPT TWO
-math        \x00B3        346-3456-14         ³                   SUPERSCRIPT THREE
-sign        \x00B4        3                   ´                   ACUTE ACCENT
-sign        \x00B5        56-134              µ                   MICRO SIGN
-math        \x00B7        236                 ·                   MIDDLE DOT
-sign        \x00B8        45                  ¸                   CEDILLA
-sign        \x00B9        346-3456-1          ¹                   SUPERSCRIPT ONE
-sign        \x00BA        4-356               º                   MASCULINE ORDINAL INDICATOR
-punctuation \x00BB        2356                »                   RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-math        \x00BC        3456-1-34-3456-145  ¼                   VULGAR FRACTION ONE QUARTER
-math        \x00BD        3456-1-34-3456-12   ½                   VULGAR FRACTION ONE HALF
-math        \x00BE        3456-14-34-3456-145 ¾                   VULGAR FRACTION THREE QUARTERS
-punctuation \x00BF        26                  ¿                   INVERTED QUESTION MARK
-math        \x00D7        236                 ×                   MULTIPLICATION SIGN
-math        \x00F7        256                 ÷                   DIVISION SIGN
+       punctuation \x00A1        235                 ¡                   INVERTED EXCLAMATION MARK
+       sign        \x00A2        14                  ¢                   CENT SIGN
+noback sign        \x00A3        1234a               £                   POUND SIGN
+nofor  sign        \x00A3        1234                £                   POUND SIGN
+noback sign        \x00A5        13456a              ¥                   YEN SIGN
+nofor  sign        \x00A5        13456               ¥                   YEN SIGN
+noback sign        \x00A7        346a                §                   SECTION SIGN
+nofor  sign        \x00A7        346                 §                   SECTION SIGN
+noback sign        \x00A9        5-14a               ©                   COPYRIGHT SIGN
+nofor  sign        \x00A9        5-14                ©                   COPYRIGHT SIGN
+       punctuation \x00AB        2356                «                   LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+       punctuation \x00AD        36                 ­                   SOFT HYPHEN
+noback sign        \x00AE        5-12359             ®                   REGISTERED SIGN
+nofor  sign        \x00AE        5-1235              ®                   REGISTERED SIGN
+noback sign        \x00B0        4-356a              °                   DEGREE SIGN
+nofor  sign        \x00B0        4-356               °                   DEGREE SIGN
+noback sign        \x00B1        235a-36             ±                   PLUS-MINUS SIGN
+nofor  sign        \x00B1        235-36              ±                   PLUS-MINUS SIGN
+noback math        \x00B2        346-3456-129        ²                   SUPERSCRIPT TWO
+nofor  math        \x00B2        346-3456-12         ²                   SUPERSCRIPT TWO
+noback math        \x00B3        346-3456-149        ³                   SUPERSCRIPT THREE
+nofor  math        \x00B3        346-3456-14         ³                   SUPERSCRIPT THREE
+       sign        \x00B4        3                   ´                   ACUTE ACCENT
+       sign        \x00B5        56-134              µ                   MICRO SIGN
+noback math        \x00B7        236a                ·                   MIDDLE DOT
+nofor  math        \x00B7        236                 ·                   MIDDLE DOT
+       sign        \x00B8        45                  ¸                   CEDILLA
+       sign        \x00B9        346-3456-1          ¹                   SUPERSCRIPT ONE
+noback sign        \x00BA        4-356a              º                   MASCULINE ORDINAL INDICATOR
+nofor  sign        \x00BA        4-356               º                   MASCULINE ORDINAL INDICATOR
+       punctuation \x00BB        2356                »                   RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+noback math        \x00BC        3456-19-34-3456-1459 ¼                  VULGAR FRACTION ONE QUARTER
+nofor  math        \x00BC        3456-1-34-3456-145  ¼                   VULGAR FRACTION ONE QUARTER
+noback math        \x00BD        3456-19-34-3456-129 ½                   VULGAR FRACTION ONE HALF
+nofor  math        \x00BD        3456-1-34-3456-12   ½                   VULGAR FRACTION ONE HALF
+noback math        \x00BE        3456-149-34-3456-1459 ¾                 VULGAR FRACTION THREE QUARTERS
+nofor  math        \x00BE        3456-14-34-3456-145 ¾                   VULGAR FRACTION THREE QUARTERS
+       punctuation \x00BF        26                  ¿                   INVERTED QUESTION MARK
+noback math        \x00D7        236a                ×                   MULTIPLICATION SIGN
+nofor  math        \x00D7        236                 ×                   MULTIPLICATION SIGN
+noback math        \x00F7        256a                ÷                   DIVISION SIGN
+nofor  math        \x00F7        256                 ÷                   DIVISION SIGN
 
 
 # ----------------------------------------------------------------------------------------------
@@ -213,35 +292,46 @@ sign        \x2030        123456-123456       ‰                   PER MILLE SI
 # Unicode 2070..209F  Superscripts and Subscripts
 # ----------------------------------------------------------------------------------------------
 
-math        \x2070        346-3456-245        ⁰                   SUPERSCRIPT ZERO
-math        \x2074        346-3456-145        ⁴                   SUPERSCRIPT FOUR
-math        \x2075        346-3456-15         ⁵                   SUPERSCRIPT FIVE
-math        \x2076        346-3456-124        ⁶                   SUPERSCRIPT SIX
-math        \x2077        346-3456-1245       ⁷                   SUPERSCRIPT SEVEN
-math        \x2078        346-3456-125        ⁸                   SUPERSCRIPT EIGHT
-math        \x2079        346-3456-24         ⁹                   SUPERSCRIPT NINE
-math        \x207F        346-1345            ⁿ                   SUPERSCRIPT LATIN SMALL LETTER N
-math        \x2080        16-356              ₀                   SUBSCRIPT ZERO
-math        \x2081        16-2                ₁                   SUBSCRIPT ONE
-math        \x2082        16-23               ₂                   SUBSCRIPT TWO
-math        \x2083        16-25               ₃                   SUBSCRIPT THREE
-math        \x2084        16-256              ₄                   SUBSCRIPT FOUR
-math        \x2085        16-26               ₅                   SUBSCRIPT FIVE
-math        \x2086        16-235              ₆                   SUBSCRIPT SIX
-math        \x2087        16-2356             ₇                   SUBSCRIPT SEVEN
-math        \x2088        16-236              ₈                   SUBSCRIPT EIGHT
-math        \x2089        16-35               ₉                   SUBSCRIPT NINE
-math        \x2090        16-1                ₐ                   LATIN SUBSCRIPT SMALL LETTER A
-math        \x2091        16-15               ₑ                   LATIN SUBSCRIPT SMALL LETTER E
-math        \x2092        16-135              ₒ                   LATIN SUBSCRIPT SMALL LETTER O
-math        \x2093        16-1346             ₓ                   LATIN SUBSCRIPT SMALL LETTER X
+       math        \x2070        346-3456-245        ⁰                   SUPERSCRIPT ZERO
+       math        \x2074        346-3456-145        ⁴                   SUPERSCRIPT FOUR
+       math        \x2075        346-3456-15         ⁵                   SUPERSCRIPT FIVE
+       math        \x2076        346-3456-124        ⁶                   SUPERSCRIPT SIX
+       math        \x2077        346-3456-1245       ⁷                   SUPERSCRIPT SEVEN
+       math        \x2078        346-3456-125        ⁸                   SUPERSCRIPT EIGHT
+       math        \x2079        346-3456-24         ⁹                   SUPERSCRIPT NINE
+       math        \x207F        346-1345            ⁿ                   SUPERSCRIPT LATIN SMALL LETTER N
+noback math        \x2080        16-3569             ₀                   SUBSCRIPT ZERO
+nofor  math        \x2080        16-356              ₀                   SUBSCRIPT ZERO
+noback math        \x2081        16-29               ₁                   SUBSCRIPT ONE
+nofor  math        \x2081        16-2                ₁                   SUBSCRIPT ONE
+noback math        \x2082        16-239              ₂                   SUBSCRIPT TWO
+nofor  math        \x2082        16-23               ₂                   SUBSCRIPT TWO
+noback math        \x2083        16-259              ₃                   SUBSCRIPT THREE
+nofor  math        \x2083        16-25               ₃                   SUBSCRIPT THREE
+noback math        \x2084        16-2569             ₄                   SUBSCRIPT FOUR
+nofor  math        \x2084        16-256              ₄                   SUBSCRIPT FOUR
+noback math        \x2085        16-269              ₅                   SUBSCRIPT FIVE
+nofor  math        \x2085        16-26               ₅                   SUBSCRIPT FIVE
+noback math        \x2086        16-2359             ₆                   SUBSCRIPT SIX
+nofor  math        \x2086        16-235              ₆                   SUBSCRIPT SIX
+noback math        \x2087        16-23569            ₇                   SUBSCRIPT SEVEN
+nofor  math        \x2087        16-2356             ₇                   SUBSCRIPT SEVEN
+noback math        \x2088        16-2369             ₈                   SUBSCRIPT EIGHT
+nofor  math        \x2088        16-236              ₈                   SUBSCRIPT EIGHT
+noback math        \x2089        16-359              ₉                   SUBSCRIPT NINE
+nofor  math        \x2089        16-35               ₉                   SUBSCRIPT NINE
+       math        \x2090        16-1                ₐ                   LATIN SUBSCRIPT SMALL LETTER A
+       math        \x2091        16-15               ₑ                   LATIN SUBSCRIPT SMALL LETTER E
+       math        \x2092        16-135              ₒ                   LATIN SUBSCRIPT SMALL LETTER O
+       math        \x2093        16-1346             ₓ                   LATIN SUBSCRIPT SMALL LETTER X
 
 
 # ----------------------------------------------------------------------------------------------
 # Unicode 20A0..20CF  Currency Symbols
 # ----------------------------------------------------------------------------------------------
 
-sign        \x20AC        15                  €                   EURO SIGN
+noback sign        \x20AC        15a                 €                   EURO SIGN
+nofor  sign        \x20AC        15                  €                   EURO SIGN
 
 
 # ----------------------------------------------------------------------------------------------
@@ -276,12 +366,14 @@ math        \x215E        3456-1245-34-3456-125 ⅞                   VULGAR FRA
 # Unicode 2200..22FF  Mathematical Operators
 # ----------------------------------------------------------------------------------------------
 
-math        \x2212        36                  −                   MINUS SIGN
-math        \x2215        34                  ∕                   DIVISION SLASH
-math        \x2216        5-16                ∖                   SET MINUS
-math        \x2217        35                  ∗                   ASTERISK OPERATOR
-math        \x2219        236                 ∙                   BULLET OPERATOR
-math        \x22C5        236                 ⋅                   DOT OPERATOR
+       math        \x2212        36                  −                   MINUS SIGN
+       math        \x2215        34                  ∕                   DIVISION SLASH
+       math        \x2216        5-16                ∖                   SET MINUS
+       math        \x2217        35                  ∗                   ASTERISK OPERATOR
+noback math        \x2219        236a                ∙                   BULLET OPERATOR
+nofor  math        \x2219        236                 ∙                   BULLET OPERATOR
+noback math        \x22C5        236a                ⋅                   DOT OPERATOR
+nofor  math        \x22C5        236                 ⋅                   DOT OPERATOR
 
 
 # ----------------------------------------------------------------------------------------------

--- a/tables/nl-print.dis
+++ b/tables/nl-print.dis
@@ -1,0 +1,174 @@
+#  Copyright (C) 2023 Bert Frees <bertfrees@gmail.com>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+# nl-NL-g0.utb attaches virtual dots to the braille output in order to
+# make it possible to distinguish between identical dot patterns that
+# originate from different input. For instance, the braille pattern
+# for digit "1" has a virtual dot to distinguish it from the letter
+# "a".
+
+# nl-print.dis maps dot patterns back to their origin as much as
+# possible. Special indicator dot patterns are mapped to Unicode
+# braille.
+
+display \s 0
+display a 1
+display 1 19
+display α 1b
+display ά 1c
+display , 2
+display ₁ 29
+display b 12
+display 2 129
+display β 12b
+display ' 3
+display k 13
+display κ 13b
+display ; 23
+display ₂ 239
+display l 123
+display λ 123b
+display ⠈ 4         (voorteken in duim-, geboorte-, graad-, minuut- en secondeteken)
+display c 14
+display 3 149
+display © 14a
+display i 24
+display 9 249
+display ι 24b
+display ί 24c
+display f 124
+display 6 1249
+display φ 124b
+display ϕ 124c
+display / 34
+display í 349
+display m 134
+display μ 134b
+display s 234
+display σ 234b
+display ς 234c
+display p 1234
+display £ 1234a
+display π 1234b
+display ⠐ 5         (sleutelteken tweede betekenis / einderegelteken)
+display e 15
+display 5 159
+display € 15a
+display ε 15b
+display : 25
+display ₃ 259
+display h 125
+display 8 1259
+display * 35
+display ₉ 359
+display ′ 35a
+display o 135
+display > 1359
+display ο 135b
+display ! 235
+display ₆ 2359
+display + 235a
+display r 1235
+display ® 12359
+display ρ 1235b
+display ⠘ 45        (permanent hoofdletterteken)
+display d 145
+display 4 1459
+display $ 145a
+display δ 145b
+display j 245
+display 0 2459
+display g 1245
+display 7 12459
+display γ 1245b
+display @ 345
+display ä 3459
+display n 1345
+display ν 1345b
+display t 2345
+display τ 2345b
+display q 12345
+display ⠠ 6         (herstelteken eerste betekenis)
+display \\ 16
+display â 169
+display ? 26
+display ₅ 269
+display ~ 26a
+display ê 126
+display ł 126b
+display - 36
+display u 136
+display υ 136b
+display ( 236
+display ₈ 2369
+display · 236a
+display v 1236
+display ⠨ 46        (hoofdletterteken)
+display î 146
+display < 246
+display ö 2469
+display ë 1246
+display ^ 346
+display ó 3469
+display § 346a
+display x 1346
+display ξ 1346b
+display è 2346
+display ź 2346b
+display & 12346
+display ç 123469
+display χ 12346b
+display ⠰ 56        (alfabetwisselingsteken)
+display û 156
+display η 156b
+display . 256
+display ₄ 2569
+display ÷ 256a
+display ü 1256
+display ) 356
+display ₀ 3569
+display ° 356a
+display z 1356
+display ζ 1356b
+display " 2356
+display ₇ 23569
+display = 2356a
+display [ 12356
+display à 123569
+display á 12356a
+display { 12356b
+display ⠸ 456       (drukwijzigingsteken)
+display _ 4569
+display | 1456
+display ô 14569
+display θ 1456b
+display w 2456
+display ω 2456b
+display ï 12456
+display ñ 124569
+display ⠼ 3456      (cijferteken)
+display # 34569
+display y 13456
+display ¥ 13456a
+display ψ 13456b
+display ] 23456
+display ù 234569
+display ú 23456a
+display } 23456b
+display % 123456
+display é 1234569

--- a/tables/nl-unicode.dis
+++ b/tables/nl-unicode.dis
@@ -1,0 +1,176 @@
+#  Copyright (C) 2023 Bert Frees <bertfrees@gmail.com>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+
+# nl-NL-g0.utb attaches virtual dots to the braille output in order to
+# make it possible to distinguish between identical dot patterns that
+# originate from different input. For instance, the braille pattern
+# for digit "1" has a virtual dot to distinguish it from the letter
+# "a".
+
+# nl-unicode.dis maps dot patterns to Unicode braille character
+# corresponding to their "real" part (dots 1 to 8). Possible virtual
+# dots are ignored. Only dot patterns that can be present in the
+# output of nl-NL-g0.utb are handled.
+
+                          # corresponding character in nl-print.dis
+display \x2800 0
+display \x2801 1          a
+display \x2801 19         1
+display \x2801 1b         α
+display \x2801 1c         ά
+display \x2802 2          ,
+display \x2802 29         ₁
+display \x2803 12         b
+display \x2803 129        2
+display \x2803 12b        β
+display \x2804 3          '
+display \x2805 13         k
+display \x2805 13b        κ
+display \x2806 23         ;
+display \x2806 239        ₂
+display \x2807 123        l
+display \x2807 123b       λ
+display \x2808 4          ⠈ (voorteken in duim-, geboorte-, graad-, minuut- en secondeteken)
+display \x2809 14         c
+display \x2809 149        3
+display \x2809 14a        ©
+display \x280A 24         i
+display \x280A 249        9
+display \x280A 24b        ι
+display \x280A 24c        ί
+display \x280B 124        f
+display \x280B 1249       6
+display \x280B 124b       φ
+display \x280B 124c       ϕ
+display \x280C 34         /
+display \x280C 349        í
+display \x280D 134        m
+display \x280D 134b       μ
+display \x280E 234        s
+display \x280E 234b       σ
+display \x280E 234c       ς
+display \x280F 1234       p
+display \x280F 1234a      £
+display \x280F 1234b      π
+display \x2810 5          ⠐ (sleutelteken tweede betekenis / einderegelteken)
+display \x2811 15         e
+display \x2811 159        5
+display \x2811 15a        €
+display \x2811 15b        ε
+display \x2812 25         :
+display \x2812 259        ₃
+display \x2813 125        h
+display \x2813 1259       8
+display \x2814 35         *
+display \x2814 359        ₉
+display \x2814 35a        ′
+display \x2815 135        o
+display \x2815 1359       >
+display \x2815 135b       ο
+display \x2816 235        !
+display \x2816 2359       ₆
+display \x2816 235a       +
+display \x2817 1235       r
+display \x2817 12359      ®
+display \x2817 1235b      ρ
+display \x2818 45         ⠘ (permanent hoofdletterteken)
+display \x2819 145        d
+display \x2819 1459       4
+display \x2819 145a       $
+display \x2819 145b       δ
+display \x281A 245        j
+display \x281A 2459       0
+display \x281B 1245       g
+display \x281B 12459      7
+display \x281B 1245b      γ
+display \x281C 345        @
+display \x281C 3459       ä
+display \x281D 1345       n
+display \x281D 1345b      ν
+display \x281E 2345       t
+display \x281E 2345b      τ
+display \x281F 12345      q
+display \x2820 6          ⠠ (herstelteken eerste betekenis)
+display \x2821 16         \ 
+display \x2821 169        â
+display \x2822 26         ?
+display \x2822 269        ₅
+display \x2822 26a        ~
+display \x2823 126        ê
+display \x2823 126b       ł
+display \x2824 36         -
+display \x2825 136        u
+display \x2825 136b       υ
+display \x2826 236        (
+display \x2826 2369       ₈
+display \x2826 236a       ·
+display \x2827 1236       v
+display \x2828 46         ⠨ (hoofdletterteken)
+display \x2829 146        î
+display \x282A 246        <
+display \x282A 2469       ö
+display \x282B 1246       ë
+display \x282C 346        ^
+display \x282C 3469       ó
+display \x282C 346a       §
+display \x282D 1346       x
+display \x282D 1346b      ξ
+display \x282E 2346       è
+display \x282E 2346b      ź
+display \x282F 12346      &
+display \x282F 123469     ç
+display \x282F 12346b     χ
+display \x2830 56         ⠰ (alfabetwisselingsteken)
+display \x2831 156        û
+display \x2831 156b       η
+display \x2832 256        .
+display \x2832 2569       ₄
+display \x2832 256a       ÷
+display \x2833 1256       ü
+display \x2834 356        )
+display \x2834 3569       ₀
+display \x2834 356a       °
+display \x2835 1356       z
+display \x2835 1356b      ζ
+display \x2836 2356       "
+display \x2836 23569      ₇
+display \x2836 2356a      =
+display \x2837 12356      [
+display \x2837 123569     à
+display \x2837 12356a     á
+display \x2837 12356b     {
+display \x2838 456        ⠸ (drukwijzigingsteken)
+display \x2838 4569       _
+display \x2839 1456       |
+display \x2839 14569      ô
+display \x2839 1456b      θ
+display \x283A 2456       w
+display \x283A 2456b      ω
+display \x283B 12456      ï
+display \x283B 124569     ñ
+display \x283C 3456       ⠼ (cijferteken)
+display \x283C 34569      #
+display \x283D 13456      y
+display \x283D 13456a     ¥
+display \x283D 13456b     ψ
+display \x283E 23456      ]
+display \x283E 234569     ù
+display \x283E 23456a     ú
+display \x283E 23456b     }
+display \x283F 123456     %
+display \x283F 1234569    é

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -18,7 +18,9 @@
 #
 # ----------------------------------------------------------------------------------------------
 
-display: unicode-without-blank.dis
+display: |
+  display \s 0
+  include nl-unicode.dis
 table:
   language: nl
   grade: 0
@@ -371,3 +373,419 @@ tests:
   - - Digits followed by lowercase letters
     - ⠼⠁⠠⠁ ⠼⠁⠲⠠⠁ ⠼⠁⠂⠠⠁ ⠼⠁⠒⠠⠁
     - 1a 1.a 1,a 1:a
+
+# Test virtual dots
+# The forward tests from above (except the xfail ones) are repeated
+# but with display table nl-print.dis instead of nl-unicode.dis.
+display: nl-print.dis
+table:
+  language: nl
+  grade: 0
+  __assert-match: nl.tbl # nl-NL-g0.utb
+flags: {testmode: forward}
+tests:
+  - - a b c d e f g h i j k l m n o p q r s t u v w x y z
+    - a b c d e f g h i j k l m n o p q r s t u v w x y z
+  - - 1 2 3 4 5 6 7 8 9 0
+    - ⠼1 ⠼2 ⠼3 ⠼4 ⠼5 ⠼6 ⠼7 ⠼8 ⠼9 ⠼0
+  - - 1a 1.a 1,a 1:a
+    - ⠼1⠠a ⠼1.⠠a ⠼1,⠠a ⠼1:⠠a
+  - - '. , ? ! ; : - … [ ]'
+    - ". , ? ! ; : - ... [ ]"
+  - - '@ # % ‰ ^ & * = + _ / \\ < > ~ | ±'
+    - '@ ⠐# % %% ^ & * = + _ / ⠐\\ ⠐< ⠐> ⠐~ | +-'
+  - - ä â à
+    - ä â à
+  - - ç
+    - ç
+  - - é ë ê è
+    - é ë ê è
+  - - ï î
+    - ï î
+  - - ñ Ñ
+    - ⠰ñ ⠰⠨ñ
+  - - ó ö ô
+    - ó ö ô
+  - - ü û ù
+    - ü û ù
+  - - beletselteken ...
+    - beletselteken ...
+  - - 'Vul in ei of ij: p..n, r..s.'
+    - '⠨vul in ei of ij: p..n, r..s.'
+  - - '''enkele aanhalingstekens'''
+    - '''enkele aanhalingstekens'''
+  - - '"dubbele aanhalingstekens"'
+    - '"dubbele aanhalingstekens"'
+  - - “dubbele aanhalingstekens”
+    - '"dubbele aanhalingstekens"'
+  - - "SMS'je"
+    - ⠘sms'⠠je
+  - - SMS’je
+    - ⠘sms'⠠je
+  - - (ronde haakjes)
+    - (ronde haakjes)
+  - - '[vierkante haakjes]'
+    - '[vierkante haakjes]'
+  - - copyright ©
+    - copyright ⠐©
+  - - paragraaf §
+    - paragraaf §
+  - - registered ®
+    - registered ⠐®
+  - - trademark ™
+    - trademark ⠐tm
+  - - dollar $
+    - dollar dollar
+  - - euro €
+    - euro euro
+  - - pond £
+    - pond pond
+  - - yen ¥
+    - yen yen
+  - - '€ 12,35'
+    - '€⠼12,35'
+  - - '€12,35'
+    - '€⠼12,35'
+  - - '$ 10,00'
+    - '$⠼10,00'
+  - - '$10,00'
+    - '$⠼10,00'
+  - - '£ 65,47'
+    - '£⠼65,47'
+  - - '£65,47'
+    - '£⠼65,47'
+  - - ¥ 100.000
+    - ¥⠼100.000
+  - - ¥100.000
+    - ¥⠼100.000
+  - - '1.234.567,89'
+    - '⠼1.234.567,89'
+  - - 050-12 34 56
+    - ⠼050-⠼12 ⠼34 ⠼56
+  - - 050/78 90 12
+    - ⠼050/⠼78 ⠼90 ⠼12
+  - - 050-34.56.78
+    - ⠼050-⠼34.56.78
+  - - BE03 4747 0637 8184
+    - ⠘be⠼03 ⠼4747 ⠼0637 ⠼8184
+  - - + 32 11 32 43 54
+    - + ⠼32 ⠼11 ⠼32 ⠼43 ⠼54
+  - - '1e, 1ste'
+    - '⠼1⠠e, ⠼1ste'
+  - - '2e, 2de'
+    - '⠼2⠠e, ⠼2⠠de'
+  - - '3e, 3de'
+    - '⠼3⠠e, ⠼3⠠de'
+  - - '15e, 27ste'
+    - '⠼15⠠e, ⠼27ste'
+  - - '10a, 10A'
+    - '⠼10⠠a, ⠼10⠨a'
+  - - 12.b
+    - ⠼12.⠠b
+  - - 31-07-2010
+    - ⠼31-⠼07-⠼2010
+  - - 31/07/2010
+    - ⠼31/⠼07/⠼2010
+  - - 16.30 tot 21.30 uur
+    - ⠼16.30 tot ⠼21.30 uur
+  - - '16:30 tot 21:30 uur'
+    - '⠼16:⠼30 tot ⠼21:⠼30 uur'
+  - - x_1 = 0
+    - x_⠼1 = ⠼0
+  - - 'x,1'
+    - 'x,⠼1'
+  - - 1 + 2 = 3
+    - ⠼1 + ⠼2 = ⠼3
+  - - 9 - 5 = 4
+    - ⠼9 - ⠼5 = ⠼4
+  - - 3 x 3 = 9
+    - ⠼3 x ⠼3 = ⠼9
+  - - 3 * 3 = 9
+    - ⠼3 * ⠼3 = ⠼9
+  - - 3 · 3 = 9
+    - ⠼3 · ⠼3 = ⠼9
+  - - 3 ∙ 3 = 9
+    - ⠼3 · ⠼3 = ⠼9
+  - - 3 ⋅ 3 = 9
+    - ⠼3 · ⠼3 = ⠼9
+  - - 3 × 3 = 9
+    - ⠼3 · ⠼3 = ⠼9
+  - - '8 : 4 = 2'
+    - '⠼8 : ⠼4 = ⠼2'
+  - - 8 / 4 = 2
+    - ⠼8 / ⠼4 = ⠼2
+  - - 8 ÷ 4 = 2
+    - ⠼8 ÷ ⠼4 = ⠼2
+  - - 65+-kaart
+    - ⠼65⠐+-kaart
+  - - "65+'er"
+    - "⠼65⠐+'er"
+  - - 40-jarige
+    - ⠼40-jarige
+  - - '79,5 %'
+    - '⠼79,5 %'
+  - - 15%
+    - ⠼15 %
+  - - '79,5 ‰'
+    - '⠼79,5 %%'
+  - - 15‰
+    - ⠼15 %%
+  - - '37,8° C'
+    - '⠼37,8⠈° ⠨c'
+  - - "Een hoek van 27° 30'."
+    - "⠨een hoek van ⠼27⠈° ⠼30⠈′."
+  - - "Het record is 3' 5''."
+    - "⠨het record is ⠼3⠈′ ⠼5⠈′′."
+  - - "57° 38' noorderbreedte"
+    - "⠼57⠈° ⠼38⠈′ noorderbreedte"
+  - - 65 m²
+    - ⠼65 m^⠼2
+  - - 65 m^2
+    - ⠼65 m^⠼2
+  - - 1.000 cm³
+    - ⠼1.000 cm^⠼3
+  - - 1.000 cm^3
+    - ⠼1.000 cm^⠼3
+  - - ½ kg - 1/2 kg
+    - ⠼1/⠼2 kg - ⠼1/⠼2 kg
+  - - ¼ l - 1/4 l
+    - ⠼1/⠼4 l - ⠼1/⠼4 l
+  - - Winston Churchill
+    - ⠨winston ⠨churchill
+  - - MacLean
+    - ⠨mac⠨lean
+  - - AMSTERDAM en BRUSSEL
+    - ⠘amsterdam en ⠘brussel
+  - - 'WMO, VDAB'
+    - '⠘wmo, ⠘vdab'
+  - - abCDef
+    - ab⠘cd⠠ef
+  - - ONZE DIRECTEUR-GENERAAL WOONT IN BRUSSEL
+    - ⠘⠘onze directeur-generaal woont in ⠘brussel
+  - - IN BRUSSEL WOONT ONZE DIRECTEUR-GENERAAL
+    - ⠘⠘in brussel woont onze directeur-⠘generaal
+  - - HUIS-TUIN-EN-KEUKEN-MIDDELTJES
+    - ⠘⠘huis-tuin-en-keuken-⠘middeltjes
+  - - Eghezée of Éghezée
+    - ⠨eghezée of ⠨éghezée
+  - - EGHEZEE of ÉGHEZÉE
+    - ⠘eghezee of ⠘éghezée
+  - - Saint-Etienne of Saint-Étienne
+    - ⠨saint-⠨etienne of ⠨saint-⠨étienne
+  - - SAINT-ETIENNE of SAINT-ÉTIENNE
+    - ⠘saint-⠘etienne of ⠘saint-⠘étienne
+  - - BELGIE of BELGIË
+    - ⠘belgie of ⠘belgië
+  - - Benedictus XVI
+    - ⠨benedictus ⠘xvi
+  - - Jozef II-straat
+    - ⠨jozef ⠘ii-straat
+  - - WO II
+    - ⠘wo ⠘ii
+  - - E.T.A.
+    - ⠘e.t.a.
+  - - EEN woord in hoofdletters
+    - ⠘een woord in hoofdletters
+  - - TWEE WOORDEN in hoofdletters
+    - ⠘twee ⠘woorden in hoofdletters
+  - - DRIE WOORDEN IN hoofdletters
+    - ⠘drie ⠘woorden ⠘in hoofdletters
+  - - MEER DAN DRIE WOORDEN in hoofdletters
+    - ⠘⠘meer dan drie ⠘woorden in hoofdletters
+  - - WAT IS FOUT - De fout...
+    - ⠘wat ⠘is ⠘fout - ⠨de fout...
+  - - WAT IS FOUT - de fout...
+    - ⠘wat ⠘is ⠘fout - de fout...
+  - - WAT IS FOUT De fout...
+    - ⠘wat ⠘is ⠘fout ⠨de fout...
+  - - "'IK DACHT DAT IK HIER DE ENIGE KONINGIN ZOU ZIJN'"
+    - "'⠘⠘ik dacht dat ik hier de enige koningin zou ⠘zijn'"
+  - - BTW-TARIEF volledig in hoofdletters
+    - ⠘btw-⠘tarief volledig in hoofdletters
+  - - BTW-tarief alleen btw in hoofdletters
+    - ⠘btw-tarief alleen btw in hoofdletters
+  - - VN-verdrag
+    - ⠘vn-verdrag
+  - - VN-Zeeverdrag
+    - ⠘vn-⠨zeeverdrag
+  - - P+R park and ride
+    - ⠘p⠐+r park and ride
+  - - N-VA Nieuw-Vlaamse Alliantie
+    - ⠨n-⠘va ⠨nieuw-⠨vlaamse ⠨alliantie
+  - - Firma Bossuyt & Zonen
+    - ⠨firma ⠨bossuyt & ⠨zonen
+  - - 'C&A'
+    - '⠘c⠐&a'
+  - - 'CD&V Christen-Democratisch en Vlaams'
+    - '⠘cd⠐&v ⠨christen-⠨democratisch en ⠨vlaams'
+  - - W.F. Hermans
+    - ⠘w.f. ⠨hermans
+  - - FAQ's
+    - ⠘faq'⠠s
+  - - VTM'er
+    - ⠘vtm'⠠er
+  - - 'SLAAT DE VLAM IN DE PAN, DEK DE VUURHAARD DAN AF MET EEN BRANDWERENDE DEKEN OF EEN VOCHTIGE DOEK.'
+    - '⠘⠘slaat de vlam in de pan, dek de vuurhaard dan af met een brandwerende deken of een vochtige ⠘doek.'
+  - - Eén
+    - ⠨eén
+  - - É-U
+    - ⠨é-⠨u
+  - - 1e
+    - ⠼1⠠e
+  - - 1E
+    - ⠼1⠨e
+  - - 2DE
+    - ⠼2⠘de
+  - - BIJ MEER DAN DRIE WOORDEN IN HOOFDLETTERS WORDT 2DE NIET CORRECT OMGEZET
+    - ⠘⠘bij meer dan drie woorden in hoofdletters wordt ⠼2⠠de niet correct ⠘omgezet
+  - - lisa_dirk@yahoo.com
+    - lisa_dirk@yahoo.com
+  - - 'http://www.avh.asso.fr/'
+    - 'http://www.avh.asso.fr/'
+  - - 'C:\\Documents and Settings'
+    - '⠨c:⠐\\⠨documents and ⠨settings'
+  - - 'Naam | Adresstraat 1 | 2018 Plaats'
+    - '⠨naam | ⠨adresstraat ⠼1 | ⠼2018 ⠨plaats'
+  - - 'ja | nee'
+    - 'ja | nee'
+  - - 'ja |nee'
+    - 'ja | nee'
+  - - 'ja| nee'
+    - 'ja | nee'
+  - - 'ja|nee'
+    - 'ja | nee'
+  - - no_reply@skynet.be
+    - no_reply@skynet.be
+  - - cañon
+    - ca⠰ñon
+  - - "De eerste drie letters van het Griekse alfabet zijn: alfa (α), bèta (β) en gamma (γ)."
+    - "⠨de eerste drie letters van het ⠨griekse alfabet zijn: alfa (⠰α), bèta (⠰β) en gamma (⠰γ)."
+  - - De Poolse stad Łódź
+    - ⠨de ⠨poolse stad ⠰⠨łódź
+  - - Σας καλωσορίζουμε στην Ελλάδα!
+    - ⠰⠰⠨σας καλωσορίζουμε στην ⠰⠨ελλάδα!
+  - - '''s morgens, baby''s, Alex'' boeken, de jaren ''90'
+    - '''s morgens, baby''s, ⠨alex'' boeken, de jaren ''⠼90'
+  - - Een typist(e) moet heel precies werken.
+    - ⠨een typist(e) moet heel precies werken.
+  - - 'Deze wandkaart heeft een schaal van 1 : 7.500.'
+    - '⠨deze wandkaart heeft een schaal van ⠼1 : ⠼7.500.'
+  - - Op zijn laatste rapport stond voor wiskunde een 6+.
+    - ⠨op zijn laatste rapport stond voor wiskunde een ⠼6⠐+.
+  - - Hij vertelde – zonder het te beseffen – een goede mop.
+    - ⠨hij vertelde - zonder het te beseffen - een goede mop.
+  - - groente- en fruithandel
+    - groente- en fruithandel
+  - - Landt je vader op Schiphol?
+    - ⠨land⠸t je vader op ⠨schiphol?
+    - typeform:
+        bold: '    +                      '
+  - - Amsterdam en Brussel
+    - ⠸⠨amsterdam en ⠸⠨brussel
+    - typeform:
+        bold: '+++++++++    +++++++'
+  - - Heb je Vlucht langs de Anapoer al gelezen?
+    - ⠨heb je ⠸⠸⠨vlucht langs de ⠸⠨anapoer al gelezen?
+    - typeform:
+        bold: '       +++++++++++++++++++++++            '
+  - - '''t Is tijd om naar huis te gaan.'
+    - '⠸⠸''t ⠨is tijd om naar huis te ⠸gaan.'
+    - typeform:
+        bold: '++++++++++++++++++++++++++++++++'
+  - - waterplant
+    - ⠸water⠠plant
+    - typeform:
+        underline: '+++++     '
+  - - Koppelteken heft werking op van zowel drukwijzigingsteken als permanent hoofdletterteken
+    - ZUID-AFRIKA was zijn droom.
+    - ⠸⠘zuid-⠸⠘afrika was zijn droom.
+    - typeform:
+        {bold: '+++++++++++                '}
+  - - Koppelteken heft werking op van zowel drukwijzigingsteken dus geen herstelteken nodig
+    - BTW-tarieven
+    - ⠸⠘btw-tarieven
+    - typeform:
+        {italic: '+++         '}
+  - - Koppelteken heft werking op van drukwijzigingsteken
+    - Zuid-Afrika
+    - ⠸⠨zuid-⠸⠨afrika
+    - typeform:
+        {bold: '+++++++++++'}
+  - - 3de
+    - ⠼3⠸de
+    - typeform:
+        bold: ' ++'
+  - - cursief
+    - ⠸cursief
+    - typeform:
+        italic: '+++++++'
+  - - onderstreept
+    - ⠸onderstreept
+    - typeform:
+        underline: '++++++++++++'
+  - - vetgedrukt
+    - ⠸vetgedrukt
+    - typeform:
+        bold: '++++++++++'
+  - - vier woorden in cursief
+    - ⠸⠸vier woorden in ⠸cursief
+    - typeform:
+        italic: '+++++++++++++++++++++++'
+  - - Priester-dichter Guido Gezelle schreef in het West-Vlaams.
+    - ⠸⠸⠨priester-dichter ⠨guido ⠨gezelle schreef in het ⠨west-⠸⠨vlaams.
+    - typeform:
+        italic: '++++++++++++++++++++++++++++++++++++++++++++++++++++++++++'
+  - - "'cursief'"
+    - "'⠸cursief'"
+    - typeform:
+        italic: '+++++++++'
+  - - "'cursief'"
+    - "'⠸cursief'"
+    - typeform:
+        italic: ' +++++++ '
+  - - (cursief)
+    - (⠸cursief)
+    - typeform:
+        italic: '+++++++++'
+  - - (cursief)
+    - (⠸cursief)
+    - typeform:
+        italic: ' +++++++ '
+  - - "'meer dan drie woorden in cursief'"
+    - "'⠸⠸meer dan drie woorden in ⠸cursief'"
+    - typeform:
+        italic: '++++++++++++++++++++++++++++++++++'
+  - - "'meer dan drie woorden in cursief'"
+    - "'⠸⠸meer dan drie woorden in ⠸cursief'"
+    - typeform:
+        italic: ' ++++++++++++++++++++++++++++++++ '
+  - - CURSIEF
+    - ⠸⠘cursief
+    - typeform:
+        italic: '+++++++'
+  - - VIER WOORDEN IN CURSIEF
+    - ⠸⠸⠘⠘vier woorden in ⠸⠘cursief
+    - typeform:
+        italic: '+++++++++++++++++++++++'
+  - - "'IK DACHT DAT IK HIER DE ENIGE KONINGIN ZOU ZIJN.'"
+    - "'⠸⠸⠘⠘ik dacht dat ik hier de enige koningin zou ⠸⠘zijn.'"
+    - typeform:
+        italic: ' ++++++++++++++++++++++++++++++++++++++++++++++++ '
+  - - 'CO₂-uitstoot: 158 g CO₂/km'
+    - '⠘co\\₂-uitstoot: ⠼158 g ⠘co\\₂/km'
+  - - á é í ó ú
+    - á é í ó ú
+  - - "Dáár!"
+    - "⠨dáár!"
+  - - "Geef het hém."
+    - "⠨geef het hém."
+  - - "Dat is léúk."
+    - "⠨dat is léúk."
+  - - "Je móét komen."
+    - "⠨je móét komen."
+  - - "Ga búíten spelen."
+    - "⠨ga búíten spelen."
+  - - "Móéilijk gaat óók."
+    - "⠨móéilijk gaat óók."
+  - - "{ }"
+    - "⠐{ ⠐}"


### PR DESCRIPTION
The idea is to attach virtual dots to the braille output in order to make it possible to distinguish between identical dot patterns that originate from different input. For instance, the braille pattern for digit "1" will have a virtual dot to distinguish it from the letter "a".

The tests illustrate the idea nicely. An excerpt: https://github.com/liblouis/liblouis/blob/f8a1de50845d7ed6096f68e493b906aed4d7ba96/tests/braille-specs/nl-g0_harness.yaml#L610-L615