### PR TITLE
Fuzzing cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ TAGS
 /tests/fuzzing/*.profraw
 /tests/fuzzing/CORPUS/*
 /tests/fuzzing/crash-*
+/tests/fuzzing/fuzz_translate
 /tests/fuzzing/fuzz-*.log
 /tests/fuzzing/leak-*
 /tests/fuzzing/oom-*

--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ TAGS
 /tests/fuzzing/*.profraw
 /tests/fuzzing/CORPUS/*
 /tests/fuzzing/crash-*
+/tests/fuzzing/fuzz_backtranslate
 /tests/fuzzing/fuzz_translate
 /tests/fuzzing/fuzz_translate_generic
 /tests/fuzzing/fuzz-*.log

--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,7 @@ TAGS
 /tests/fuzzing/CORPUS/*
 /tests/fuzzing/crash-*
 /tests/fuzzing/fuzz_translate
+/tests/fuzzing/fuzz_translate_generic
 /tests/fuzzing/fuzz-*.log
 /tests/fuzzing/leak-*
 /tests/fuzzing/oom-*

--- a/configure.ac
+++ b/configure.ac
@@ -240,6 +240,7 @@ AC_CONFIG_FILES([
 	liblouis.pc
 	tests/Makefile
 	tests/braille-specs/Makefile
+	tests/fuzzing/Makefile
 	tests/resolve_table.h
 	tests/tables/Makefile
 	tests/tables/emphclass/Makefile

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = tables tablesWithMetadata yaml braille-specs ueb_test_data
+SUBDIRS = tables tablesWithMetadata yaml braille-specs ueb_test_data fuzzing
 
 AM_CPPFLAGS =					\
 	-I$(top_srcdir)/liblouis		\
@@ -7,16 +7,12 @@ AM_CPPFLAGS =					\
 	-I$(top_builddir)/gnulib		\
 	-I$(top_builddir)/tools
 
-if USE_COVERAGE
-AM_CPPFLAGS += -fprofile-instr-generate -fcoverage-mapping
-endif
-
 LDADD =							\
 	$(top_builddir)/liblouis/liblouis.la		\
 	$(top_builddir)/gnulib/libgnu.la		\
 	$(top_builddir)/tools/libbrlcheck.la		\
 	$(top_builddir)/tools/gnulib/libgnutools.la	\
-	$(LTLIBINTL) $(LIBFUZZER_NO_MAIN)
+	$(LTLIBINTL)
 
 checkTable_SOURCES = checkTable.c
 emphclass_SOURCES = emphclass.c
@@ -299,12 +295,3 @@ AM_TESTS_ENVIRONMENT =								\
 	WINEPATH=$(top_builddir)/tools						\
 	WINE=$(WINE)								\
 	EXEEXT=$(EXEEXT)
-
-if USE_FUZZER
-fuzzing_fuzz_translate_SOURCES = fuzzing/fuzz_translate.c
-fuzzing_fuzz_translate_CFLAGS = \
-	-fno-omit-frame-pointer \
-	$(AM_CPPFLAGS) 
-	-g -O2
-noinst_PROGRAMS = fuzzing/fuzz_translate
-endif

--- a/tests/fuzzing/Makefile.am
+++ b/tests/fuzzing/Makefile.am
@@ -16,6 +16,7 @@ AM_CPPFLAGS += -fprofile-instr-generate -fcoverage-mapping
 endif
 
 fuzz_translate_SOURCES = fuzz_translate.c
-noinst_PROGRAMS = fuzz_translate
+fuzz_translate_generic_SOURCES = fuzz_translate_generic.c
+noinst_PROGRAMS = fuzz_translate fuzz_translate_generic
 
 endif

--- a/tests/fuzzing/Makefile.am
+++ b/tests/fuzzing/Makefile.am
@@ -1,0 +1,21 @@
+if USE_FUZZER
+
+AM_CPPFLAGS =					\
+	-fno-omit-frame-pointer 		\
+	-I$(top_srcdir)/liblouis		\
+	-I$(top_srcdir)/gnulib			\
+	-I$(top_builddir)/gnulib		\
+	-g -O2
+
+LDADD =							\
+	$(top_builddir)/liblouis/liblouis.la		\
+	$(LIBFUZZER_NO_MAIN)
+
+if USE_COVERAGE
+AM_CPPFLAGS += -fprofile-instr-generate -fcoverage-mapping
+endif
+
+fuzz_translate_SOURCES = fuzz_translate.c
+noinst_PROGRAMS = fuzz_translate
+
+endif

--- a/tests/fuzzing/Makefile.am
+++ b/tests/fuzzing/Makefile.am
@@ -16,7 +16,8 @@ AM_CPPFLAGS += -fprofile-instr-generate -fcoverage-mapping
 endif
 
 fuzz_translate_SOURCES = fuzz_translate.c
+fuzz_backtranslate_SOURCES = fuzz_backtranslate.c
 fuzz_translate_generic_SOURCES = fuzz_translate_generic.c
-noinst_PROGRAMS = fuzz_translate fuzz_translate_generic
+noinst_PROGRAMS = fuzz_translate fuzz_backtranslate fuzz_translate_generic
 
 endif

--- a/tests/fuzzing/README.md
+++ b/tests/fuzzing/README.md
@@ -1,69 +1,150 @@
-# Table fuzzer
-
-`build.sh` and `table_fuzzer.cc` are run continously through OSS-fuzz.
-
-Link to OSS-fuzz integration: Pending
-
 # Translation fuzzers
 
-Currently, there is 2 fuzzers related to translation, **fuzz_translate** that will target **lou_translateString** and **fuzz_backtranslate** that will, in a similar way, fuzz **lou_backTranslateString**. The following sections will explain how to configure the fuzzers, how to use them and how to get a coverage report of the fuzzing result. 
+There are 3 fuzzers related to translation: [`fuzz_translate`](fuzz_translate.c) and
+[`fuzz_translate_generic`](fuzz_translate_generic.c) target `lou_translateString`,
+[`fuzz_backtranslate`](fuzz_backtranslate.c) fuzzes `lou_backTranslateString`.
 
-## Configure the project for fuzzing
+`fuzz_translate` is run continuously through a Github workflow. `fuzz_translate_generic`
+and `fuzz_backtranslate` are run continously through OSS-fuzz.
 
-We have added some switchs to configure.ac for fuzzing and coverage. The `--with-fuzzer` switch will check if your are actually using clang and clang++ as compilers (by looking at CC and CXX) and allows generation of compilation instructions for fuzzer targets. The `--with-coverage` will add `-fprofile-instr-generate -fcoverage-mapping` to AM_CPPFLAGS in tests/makefile.am and liblouis/makefile.am.
+# Table fuzzer
 
-To configure and build the project with coverage and fuzzer.
-```
+[`table_fuzzer`](table_fuzzer.cc) fuzzes the `compileFile` function. It is run continously
+through OSS-fuzz.
+
+# Configure Liblouis for fuzzing
+
+`./configure --with-fuzzer` will check if your are using clang and clang++ as compilers
+(by looking at `CC` and `CXX`) and enables generation of compilation instructions for the
+fuzzer targets (translation fuzzers only). The `--with-coverage` switch will add
+`-fprofile-instr-generate -fcoverage-mapping` to `AM_CPPFLAGS` (in
+[liblouis/Makefile.am](../../liblouis/Makefile.am) and
+[tests/fuzzing/Makefile.am](Makefile.am)).
+
+To configure and build the project with fuzzer and coverage:
+
+```sh
 ./autogen.sh
-CC=clang CXX=clang++ ./configure --with-coverage --with-fuzzer
+export CC=clang
+export CXX=clang++
+./configure --with-coverage --with-fuzzer
 make -j8
 ```
 
-## Run the fuzzers
+Now you are able to run the fuzzers.
 
-You are now able to run the fuzzer and will have to give 2 parameters to it. First, you need to choose a table (or many) to fuzz and set the `FUZZ_TABLE` environment variable to them. Then, you need to provide a corpus with files containing sample inputs that will be used by libfuzzer to craft the data passed to the fuzzing function (the idea is to keep corpus as minimal as possible). If you don't provide any corpus directory, libfuzzer just generates random inputs.
+# Run `fuzz_translate`
 
-Here is how you can start fuzzing for `lou_translateString` function.
-```
-# first we move to tests/fuzzing directory
+fuzz_translate requires two parameters. With the `FUZZ_TABLE` environment variable you set
+the table(s) to fuzz. An input corpus can optionally be provided via the first argument. A
+corpus is a directory with files containing sample inputs that will be used by libfuzzer
+to craft the data passed to the fuzzing function. The idea is to keep corpus as minimal as
+possible. If you don't provide a corpus directory, libfuzzer generates random inputs.
+
+Here is an example:
+
+```sh
+# move to tests/fuzzing directory
 cd tests/fuzzing
 
-# we consider here you have added corpus files into tests/fuzzing/CORPUS directory
-FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate CORPUS/
+# we assume here you have added corpus files into the "CORPUS" directory
+export FUZZ_TABLE=../../tables/en-us-g2.ctb
+./fuzz_translate CORPUS/
 
-# to run the fuzzer using parallelization
-# you can even set more jobs than workers (the ones that just stopped will be instantly replaced by a new fuzzer process)
-FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate CORPUS/ -workers=8 -jobs=8
+# run the fuzzer using parallelization
+# you can also set more jobs than workers (stopped jobs will instantly be replaced by a new fuzzer process)
+./fuzz_translate CORPUS/ -workers=8 -jobs=8
 
-# start the fuzzer and let it generate random input (without corpus files), here we doesn't parallelize the process
-FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate 
-
+# to start the fuzzer and let it generate random input (without corpus files):
+# here we don't parallelize the process
+./fuzz_translate
 ```
 
-After running the fuzzer multiple times with the same corpus directory, it might be possible that many corpus files added by the fuzzer explores the same paths. Hopefully, libfuzzer allows you to minimize a corpus. There is a simple bash script in tests/fuzzing that allows you to do that.
-```
+After running the fuzzer multiple times with the same corpus, it might be possible that
+many corpus files added by the fuzzer explore the same code paths. Hopefully, libfuzzer
+allows you to minimize a corpus. There is a simple bash script that allows you to do that:
+
+```sh
 ./minimize-corpus.sh CORPUS/
+```
 
-# if you have added a POC file in the corpus directory and you want to keep it intact, change his extension to .txt and use --preserve-txt switch that keep .txt files intact in the directory
+If you have added a PoC file in the corpus directory that you want to keep intact, change
+its extension to .txt and use the `--preserve-txt` switch:
+
+```sh
 ./minimize-corpus.sh --preserve-txt CORPUS/
 ```
 
-## Look at fuzzer coverage
+# Look at fuzzer coverage
 
-If you want to see what are the source code parts that are explored by the fuzzer, you can use clang coverage. So, you have to configure with coverage switch, run the fuzzer and show coverage data from the run with llvm tools. 
-To be able to use the coverage data, you need first to compile the raw profile data file of the run. By default, this file is created after execution under the name of default.profraw but you can specify it with `LLVM_PROFILE_FILE`.
-Here is how to do that.
+If you want to see what are the code parts that are explored by the fuzzer, you can use
+clang coverage. Configure with the `--with-overage` switch, run the fuzzer and show
+coverage data from the run with llvm tools. To be able to use the coverage data, you first
+need to compile the raw profile data file of the run. By default, this file is created
+after execution under the name of default.profraw but you can specify it with
+`LLVM_PROFILE_FILE`. Here is how to do that:
+
 ```
-LLVM_PROFILE_FILE=fuzz_translate.profraw FUZZ_TABLE=../../tables/en-us-g2.ctb ./fuzz_translate CORPUS/ -workers=8 -jobs=8
+export LLVM_PROFILE_FILE=fuzz_translate.profraw
+export FUZZ_TABLE=../../tables/en-us-g2.ctb
+./fuzz_translate CORPUS/ -workers=8 -jobs=8
 
-# wait for a bit and press CTRL+C
+# wait for a bit and press Ctrl+C
 
 # compile raw profile
 llvm-profdata merge -sparse fuzz_translate.profraw -o fuzz_translate.profdata
 
-# show coverage (redlines are the one wich are reached)
-# Actually tests/fuzzing/fuzz_translate is just a wrapper to tests/fuzzing/.libs/fuzz_translate, 
-# so for covering we directly pass the binary
+# show coverage (red lines are the one wich are reached)
 llvm-cov show .libs/fuzz_translate -instr-profile=fuzz_translate.profdata
-
 ```
+
+# Continous integration
+
+## OSS-Fuzz
+
+OSS-Fuzz compiles and runs [`table_fuzzer`](table_fuzzer.cc),
+[`fuzz_translate_generic`](fuzz_translate_generic.c) and
+[`fuzz_backtranslate`](fuzz_backtranslate.c) using the Dockerfile and build.sh script from
+the [Liblouis OSS-Fuzz project
+folder](https://github.com/google/oss-fuzz/blob/master/projects/liblouis). The Dockerfile
+clones the Liblouis repository and build.sh invokes
+[tests/fuzzing/build.sh](test/fuzzing/build.sh).
+
+Reported issues can be found in Google's [Monorail issue
+tracker](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=label%3AProj-liblouis). Note
+that some issues are only visible for the maintainers.
+
+### Reproducing OSS-Fuzz issues
+
+The [OSS-Fuzz
+documenation](https://google.github.io/oss-fuzz/advanced-topics/reproducing/#building-using-docker)
+explains how to reproduce OSS-Fuzz issues using the reproducer (or testcase) files and
+Docker.
+
+If you have configured Liblouis for fuzzing (with clang) you can also reproduce issues
+natively:
+
+```sh
+export CC=clang
+export CXX=clang++
+# optional: enable 'address' and 'undefined' sanitizers in order to be able to reproduce ASAN and UBSAN crashes
+export CFLAGS="-fsanitize=address,undefined"
+./configure --with-fuzzer
+make
+tests/fuzzing/fuzz_translate_generic <path/to/testcase_file>
+```
+
+## Github workflows
+
+### [`fuzzing.yml`](../../.github/workflows/fuzzing.yml)
+
+Builds and runs `fuzz_translate` for every table with extenion .utb or .ctb, and uploads
+possible crash PoC's as artifacts. This happens once a week. See [the list of previous
+runs](https://github.com/liblouis/liblouis/actions/workflows/fuzzing.yml).
+
+### [`cifuzz.yml`](../../.github/workflows/cifuzz.yml)
+
+This will do the same as OSS-Fuzz, but on Github's infrastructure. The idea is to be able
+to catch fuzzing issues in an earlier stage. Possible crash PoC's are uploaded as
+artifacts. The workflow is triggered on pull requests. See [the list of previous
+runs](https://github.com/liblouis/liblouis/actions/workflows/cifuzz.yml).

--- a/tests/fuzzing/fuzz_backtranslate.c
+++ b/tests/fuzzing/fuzz_backtranslate.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <config.h>
 #include <unistd.h>
 
 #define LANGUAGE "en"


### PR DESCRIPTION
@sthibaul @DavidKorczynski I made some changes to the build system and the README in an attempt to clarify the different fuzzers that exist and are run through CI, and make it possible to run them manually to reproduce issues.

Could you please check that I didn't mess anything up?

For example, was it a good idea to enable the 'address' and 'undefined' sanitizers on `--with-fuzzer` in order to be able to reproduce ASAN issues? Or does it have unwanted side effects?

I also tried to compile `fuzz_backtranslate` on `--with-fuzzer` (similar to how I added [fuzz_translate_generic](https://github.com/liblouis/liblouis/commit/9fa56a44bb96201e090663f94adcf17ede374a14)), but that resulted in a build failure. Any idea why? I haven't tried adding `table_fuzzer` yet.

Also note that I had to partly revert #1344 in order to get things working for me. Any idea whether this could be an incompatibility with macOS, or whether it's because I'm using an older verion of clang (10.0.1)?