### PR TITLE
Further reduce CI load

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   analyze:
     name: Analyze
+    # Do not run this job on any forked repos
+    if: github.repository == 'liblouis/liblouis'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
+# Note: It appears that a run of codeql doesn't give you immediate
+# feedback in the action. Results of codeql seem to show up in the
+# Security tab. We only look there once in a while. So it seems
+# justified to also run the codeql just "once in a while", i.e. not on
+# every push.
 
 name: "CodeQL"
 

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -11,6 +11,8 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 jobs:
   build:
     name: Build with ${{ matrix.ucs }}
+    # Do not run this job on any forked repos
+    if: github.repository == 'liblouis/liblouis'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Add a note to `codeql` why it is only run with `schedule`
- Do not run scheduled jobs in forked repos