### PR TITLE
In Docker files modify Debian image with latest stable Bookworm release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest@sha256:f2150eba68619015058b26d50e47f9fba81213d1cb81633be7928c830f72d180
+FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637
 
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:latest@sha256:f2150eba68619015058b26d50e47f9fba81213d1cb81633be7928c
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
 # Fetch build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     autoconf \
     automake \
     curl \
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-distutils \
     texinfo \
-   && rm -rf /var/lib/apt/lists/*
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # compile and install liblouis
 ADD . /usr/src/liblouis

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -73,10 +73,11 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
    && rm -rf /var/lib/apt/lists/*
 
 ENV SRCDIR=/usr/src/liblouis
+env LOUIS_TABLEPATH=/usr/src/liblouis/share/liblouis/tables
 WORKDIR ${SRCDIR}
 COPY --from=builder ${SRCDIR}/liblouis.zip .
 RUN unzip liblouis.zip
 
-# just run any old self-contained yaml test that doesn't need any env setup
-ADD tests/yaml/letterDefTest_harness.yaml .
-RUN wine bin/lou_checkyaml.exe letterDefTest_harness.yaml
+# run spaces.yaml test to we ensure cross-compile build works right with 32 bit Windows versions
+ADD tests/braille-specs/spaces.yaml .
+RUN wine bin/lou_checkyaml.exe spaces.yaml

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -3,7 +3,7 @@ FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2a
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
 # Fetch build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     autoconf \
     automake \
     curl \
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     texinfo \
     zip \
     patch \
-   && rm -rf /var/lib/apt/lists/*
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install wine for 32-bit architecture
 RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get install -y \
@@ -23,7 +23,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
     mingw-w64-i686-dev \
     wine \
     wine32 \
-   && rm -rf /var/lib/apt/lists/*
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
 ENV HOST=i686-w64-mingw32 PREFIX=/usr/build/win32 SRCDIR=/usr/src/
@@ -62,7 +62,7 @@ RUN ./autogen.sh && \
 FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637
 
 # install wine for 32-bit architecture
-RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get install -y \
+RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     fonts-wine \
     libc6-dev-i386-x32-cross \
     mingw-w64 \
@@ -70,7 +70,7 @@ RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get 
     wine \
     wine32 \
     unzip \
-   && rm -rf /var/lib/apt/lists/*
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV SRCDIR=/usr/src/liblouis
 env LOUIS_TABLEPATH=/usr/src/liblouis/share/liblouis/tables

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -42,7 +42,7 @@ RUN ./autogen.sh && \
         --prefix=${PREFIX}/liblouis \
         CPPFLAGS="-I${PREFIX}/libyaml/include/" LDFLAGS="-L${PREFIX}/libyaml/lib/" && \
     make LDFLAGS="-L${PREFIX}/libyaml/lib/ -avoid-version -Xcompiler -static-libgcc" && \
-    make check WINE=wine64 || cat tests/test-suite.log && \
+    make check WINE=/usr/lib/wine/wine64 || cat tests/test-suite.log && \
     make install && \
     cd ${PREFIX}/liblouis && \
     zip -r ${SRCDIR}/liblouis/liblouis.zip *
@@ -66,4 +66,4 @@ RUN unzip liblouis.zip
 
 # just run any old self-contained yaml test that doesn't need any env setup
 ADD tests/yaml/letterDefTest_harness.yaml .
-RUN wine64 bin/lou_checkyaml.exe letterDefTest_harness.yaml
+RUN /usr/lib/wine/wine64 bin/lou_checkyaml.exe letterDefTest_harness.yaml

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -3,7 +3,7 @@ FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2a
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
 # Fetch build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     autoconf \
     automake \
     curl \
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
     wine64 \
     zip \
     patch \
-   && rm -rf /var/lib/apt/lists/*
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG LIBYAML_VERSION=0.1.4
 ENV HOST=x86_64-w64-mingw32 PREFIX=/usr/build/win64 SRCDIR=/usr/src/
@@ -53,11 +53,11 @@ RUN ./autogen.sh && \
 FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637
 
 # install wine
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     mingw-w64 \
     wine64 \
     unzip \
-   && rm -rf /var/lib/apt/lists/*
+   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV SRCDIR=/usr/src/liblouis
 env LOUIS_TABLEPATH=/usr/src/liblouis/share/liblouis/tables

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -60,10 +60,11 @@ RUN apt-get update && apt-get install -y \
    && rm -rf /var/lib/apt/lists/*
 
 ENV SRCDIR=/usr/src/liblouis
+env LOUIS_TABLEPATH=/usr/src/liblouis/share/liblouis/tables
 WORKDIR ${SRCDIR}
 COPY --from=builder ${SRCDIR}/liblouis.zip .
 RUN unzip liblouis.zip
 
-# just run any old self-contained yaml test that doesn't need any env setup
-ADD tests/yaml/letterDefTest_harness.yaml .
-RUN /usr/lib/wine/wine64 bin/lou_checkyaml.exe letterDefTest_harness.yaml
+# run spaces.yaml test to we ensure cross-compile build works right with 64 bit Windows versions
+ADD tests/braille-specs/spaces.yaml .
+RUN /usr/lib/wine/wine64 bin/lou_checkyaml.exe spaces.yaml


### PR DESCRIPTION
Hi Boys,

In June 11 Debian 12.0 Bookworm are released, this is the new stable release until five year support (three year security support and two year LTS support).
I updated the three docker files the Debian:latest image referrence with Debian 12.0 point release (of course I pinned the sha256sum value) the correct value.

In Dockerfile, Dockerfile.win32 files enough to change the image reference value, but the Dockerfile.win64 need me change the wine64 related command line parameter related lines.

In Debian Bookworm release wine64 command awailable into the /usr/lib/wine/wine64 path, not available with /usr/bin.
Please carefully review this change, and if you would like, feel free merge this change to the master branch.

My machine ran make distwin command succesfull, both 32 bit Windows version and 64 bit Windows version launched in Wine correct.

A question:
In Liblouis UTDML docker files need replace the image names?
Into the Liblouis UTDML Github repository Dockerfile.win32 and Dockerfile.win64 uses debian:latest image name, with now pulls with Debian 12.0 stable release based image.
In Dockerfile the image name defined with following from line with Liblouis UTDML Github repository:
FROM liblouis/liblouis

If you would like, I will doing a pull request in Liblouis UTDML repo the image replacement related if you would like same pinned style images, based in Liblouis repository Dockerfile.win32 and Dockerfile.win64 style image names.

Attila