### PR TITLE
Add new forward and backward translation exceptions and testcases with hungarian Braille tables

### DIFF
--- a/tables/hu-backtranslate-word-corrections.cti
+++ b/tables/hu-backtranslate-word-corrections.cti
@@ -178,6 +178,18 @@ nofor correct "úccsoma" "úcscsoma"	For example csúcscsomagja word
 nofor correct "ÚCCSOMA" "ÚCSCSOMA"	For example CSÚCSCSOMAGJA word
 nofor correct "ekerccser" "ekercscser"	For example tekercscsere word
 nofor correct "EKERCCSER" "EKERCSCSER"	For example TEKERCSCSERE word
+nofor correct "ipaccso" "ipacscso"	For example pipacscsokor word
+nofor correct "IPACCSO" "IPACSCSO"	For example PIPACSCSOKOR word
+nofor correct "ekerccsom" "ekercscsom"	For example tekercscsomag word
+nofor correct "EKERCCSOM" "EKERCSCSOM"	For example TEKERCSCSOMAG word
+nofor correct "ümölccsok" "ümölcscsok"	For example gyümölcscsokor word
+nofor correct "ÜMÖLCCSOK" "ÜMÖLCSCSOK"	For example GYÜMÖLCSCSOKOR word
+nofor correct "akopánccsalá" "akopáncscsalá"	For example fakopáncscsaládig word
+nofor correct "AKOPÁNCCSALÁ" "AKOPÁNCSCSALÁ"	For example FAKOPÁNCSCSALÁDIG word
+nofor correct "olmáccsapa" "olmácscsapa"	For example tolmácscsapat word
+nofor correct "OLMÁCCSAPA" "OLMÁCSCSAPA"	For example TOLMÁCSCSAPAT WORD
+nofor correct "akanccsatt" "akancscsatt"	For example bakancscsattogtatók word
+nofor correct "AKANCCSATT" "AKANCSCSATT"	For example BAKANCSCSATTOGTATÓK word
 
 #ggy, gygy backtranslation rule corrections
 nofor correct "szalaggyak" *
@@ -353,6 +365,18 @@ nofor correct "Aggyűjtemé" "Agygyűjtemé"	For example Agygyűjtemény word
 nofor correct "AGGYŰJTEMÉ" "AGYGYŰJTEMÉ"	For example AGYGYŰJTEMÉNY word
 nofor correct "ezzeggyere" *	For example bezzeggyerek word
 nofor correct "EZZEGGYERE" *	For example BEZZEGGYEREK word
+nofor correct "ölggyűjt" "ölgygyűjt"	for example tölgygyűjtemény word
+nofor correct "ÖLGGYŰJT" "ÖLGYGYŰJT"	For example TÖLGYGYŰJTEMÉNY word
+nofor correct "üggyó" "ügygyó"	For example ügygyógyászati word
+nofor correct "Üggyó" "Ügygyó"	For example ügygyógyászati word
+nofor correct "ÜGGYÓ" "ÜGYGYÓ"	For example ÜGYGYÓGYÁSZATI word
+nofor correct "gészséggyere" *	For example egészséggyerekkori word
+nofor correct "GÉSZSÉGGYERE" *	For example EGÉSZSÉGGYEREKKORI word
+nofor correct "endéggyőz" *	For example vendéggyőzelem word
+nofor correct "ENDÉGGYŐZ" *	For example VENDÉGGYŐZELEM word
+nofor correct "ággyárakba" "ágygyárakba"	For example ágygyárakba word
+nofor correct "Ággyárakba" "Ágygyárakba"	For example Ágygyárakba word
+nofor correct "ÁGGYÁRAKBA" "ÁGYGYÁRAKBA"	For example ÁGYGYÁRAKBA word
 
 #nyny, nyny letters related backtranslate corrections
 nofor correct "rannyak" "ranynyak"	For example aranynyakláncának word
@@ -531,6 +555,32 @@ nofor correct "oronnyitó" "oronynyitó"	For example toronynyitó word
 nofor correct "ORONNYITÓ" "ORONYNYITÓ"	For example TORONYNYITÓ word
 nofor correct "oronnyitá" "oronynyitá"  For example toronynyitás word
 nofor correct "ORONNYITÁ" "ORONYNYITÁ"  For example TORONYNYITÁS word
+nofor correct "özlönnyil" "özlönynyil"	For example közlönynyilatkozat word
+nofor correct "ÖZLÖNNYIL" "ÖZLÖNYNYIL"	For example KÖZLÖNYNYILATKOZAT word
+nofor correct "edőnnyo" "edőnynyo"	For example redőnynyomógomb word
+nofor correct "EDŐNNYO" "EDŐNYNYO"	For example REDŐNYNYOMÓGOMB word
+nofor correct "ormánnyel" "ormánynyel"	For example kormánynyelvben word
+nofor correct "ORMÁNNYEL" "ORMÁNYNYEL"	For example KORMÁNYNYELVBEN word
+nofor correct "gazolvánnyo" "gazolványnyo"	For example igazolványnyomtatója word
+nofor correct "GAZOLVÁNNYO" "GAZOLVÁNYNYO"	For example IGAZOLVÁNYNYOMTATÓJA word
+nofor correct "akománnyo" "akománynyo"	For example rakománynyomok word
+nofor correct "AKOMÁNNYO" "AKOMÁNYNYO"	For example RAKOMÁNYNYOMOK word
+nofor correct "redménnyer" "redménynyer"	For example eredménynyereséggel word
+nofor correct "REDMÉNNYER" "REDMÉNYNYER"	For example EREDMÉNYNYERESÉGGEL word
+nofor correct "ársonnye" "ársonynye"	For example bársonynyerges word
+nofor correct "ÁRSONNYE" "ÁRSONYNYE"	For example BÁRSONYNYERGES word
+nofor correct "ágánnyomtá" "ágánynyomtá"	For example vágánynyomtáv word
+nofor correct "ÁGÁNNYOMTÁ" "ÁGÁNYNYOMTÁ"	For example VÁGÁNYNYOMTÁV word
+nofor correct "izonyítvánnyomta" "izonyítványnyomta"	For example bizonyítványnyomtatvány word
+nofor correct "IZONYÍTVÁNNYOMTA" "IZONYÍTVÁNYNYOMTA"	For example BIZONYÍTVÁNYNYOMTATVÁNY word
+nofor correct "illannyo" "illanynyo"	For example villanynyomaték word
+nofor correct "ILLANNYO" "ILLANYNYO"	For example VILLANYNYOMATÉK word
+nofor correct "illannyú" "illanynyú"	For example villanynyúl word
+nofor correct "ILLANNYÚ" "ILLANYNYÚ"	For example VILLANYNYÚL word
+nofor correct "árnnyír" "árnynyír"	For example szárnynyíráson word
+nofor correct "ÁRNNYÍR" "ÁRNYNYÍR"	For example SZÁRNYNYÍRÁSON word
+nofor correct "ersennyelv" "ersenynyelv"	For example versenynyelvben word
+nofor correct "ERSENNYELV" "ERSENYNYELV"	For example VERSENYNYELVBEN word
 
 #lyly letters related backtranslate corrections
 nofor correct "amelylyel" *
@@ -774,8 +824,8 @@ nofor correct "ússzemé" "úszszemé"	For example húszszemélyes word backtran
 nofor correct "ÚSSZEMÉ" "ÚSZSZEMÉ"	For example HÚSZSZEMÉLYES word
 nofor correct "jásszak" "jászszak"	For example íjászszakkör word backtranslation correction
 nofor correct "JÁSSZAK" "JÁSZSZAK"	For example ÍJÁSZSZAKKÖR word
-nofor correct "jásszá" "jászszá"	For example íjászszázad word backtranslation correction
-nofor correct "JÁSSZÁ" "JÁSZSZÁ"	For example ÍJÁSZSZÁZAD word
+nofor correct "jásszáz" "jászszáz"	For example íjászszázad word backtranslation correction
+nofor correct "JÁSSZÁZ" "JÁSZSZÁZ"	For example ÍJÁSZSZÁZAD word
 nofor correct "jásszöv" "jászszöv"	for example íjászszövetség word backtranslation correction
 nofor correct "JÁSSZÖV" "JÁSZSZÖV"	For example ÍJÁSZSZÖVETSÉG word
 nofor correct "risszken" "riszszken"	For example íriszszkenner word backtranslation correction
@@ -1964,6 +2014,129 @@ nofor correct "épésszelle" "épészszelle"	For example gépészszellem word
 nofor correct "ÉPÉSSZELLE" "ÉPÉSZSZELLE"	For example GÉPÉSZSZELLEM word
 nofor correct "ipsszá" "ipszszá"	For example gipszszálakból word
 nofor correct "IPSSZÁ" "IPSZSZÁ"	For example GIPSZSZÁLAKBÓL word
+nofor correct "aránusszű" "aránuszszű"	For example varánuszszűznemzés word
+nofor correct "ARÁNUSSZŰ" "ARÁNUSZSZŰ"	For example VARÁNUSZSZŰZNEMZÉS word
+nofor correct "alásszé" "alászszé"	For example halászszékeket word
+nofor correct "ALÁSSZÉ" "ALÁSZSZÉ"	For example HALÁSZSZÉKEKET word
+nofor correct "tátusszöv" "tátuszszöv"	For example státuszszövésben word
+nofor correct "TÁTUSSZÖV" "TÁTUSZSZÖV"	For example STÁTUSZSZÖVÉSBEN word
+nofor correct "ambusszil" "ambuszszil"	For example bambuszszilánk word
+nofor correct "AMBUSSZIL" "AMBUSZSZIL"	For example BAMBUSZSZILÁNK word
+nofor correct "pluszössze" *	For example pluszösszegért word
+nofor correct "Pluszössze" *	For example Pluszösszegért word
+nofor correct "PLUSZÖSSZE" *	For example PLUSZÖSSZEGÉRT word
+nofor correct "ámasszé" "ámaszszé"	For example támaszszélességű word
+nofor correct "ÁMASSZÉ" "ÁMASZSZÉ"	For example TÁMASZSZÉLESSÉGŰ word
+nofor correct "orgásszakí" "orgászszakí"	For example horgászszakíró word
+nofor correct "ORGÁSSZAKÍ" "ORGÁSZSZAKÍ"	For example HORGÁSZSZAKÍRÓ word
+nofor correct "adásszí" "adászszí"	For example vadásszívvel word
+nofor correct "ADÁSSZÍ" "ADÁSZSZÍ"	For example VADÁSZSZÍVVEL word
+nofor correct "olbásszag" "olbászszag"	For example kolbászszag word
+nofor correct "OLBÁSSZAG" "OLBÁSZSZAG"	For example KOLBÁSZSZAG word
+nofor correct "illenéssza" *	For example billenésszabályozás word
+nofor correct "ILLENÉSSZA" *	For example BILLENÉSSZABÁLYOZÁS word
+nofor correct "kókusszó" "kókuszszó"	For example kókuszszószban word
+nofor correct "Kókusszó" "Kókuszszó"	For example Kókuszszószban word
+nofor correct "KÓKUSSZÓ" "KÓKUSZSZÓ"	For example KÓKUSZSZÓSZBAN word
+nofor correct "utásszemp" "utászszemp"	For example utászszempontból word
+nofor correct "Utásszemp" "Utászszemp"	For example Utászszempontból word
+nofor correct "UTÁSSZEMP" "UTÁSZSZEMP"	For example UTÁSZSZEMPONTBÓL word
+nofor correct "gyásszállod" "gyászszállod"	For example gyászszálloda word
+nofor correct "Gyásszállod" "Gyászszállod"	For example Gyászszálloda word
+nofor correct "GYÁSSZÁLLOD" "GYÁSZSZÁLLOD"	For example GYÁSZSZÁLLODA word
+nofor correct "enisszex" "eniszszex"	For example teniszszexszimbólum word
+nofor correct "ENISSZEX" "ENISZSZEX"	For example TENISZSZEXSZIMBÓLUM word
+nofor correct "eksszak" "ekszszak"	For example kekszszakértő word
+nofor correct "EKSSZAK" "EKSZSZAK"	For example KEKSZSZAKÉRTŐ word
+nofor correct "ajusszakért" "ajuszszakért"	For example bajuszszakértő word
+nofor correct "AJUSSZAKÉRT" "AJUSZSZAKÉRT"	For example BAJUSZSZAKÉRTŐ word
+nofor correct "iklusszerv" *	For example ciklusszervezésnek word
+nofor correct "IKLUSSZERV" *	For example CIKLUSSZERVEZÉSNEK word
+nofor correct "erkésszelle" "erkészszelle"	For example cserkészszellem word
+nofor correct "ERKÉSSZELLE" "ERKÉSZSZELLE"	For example CSERKÉSZSZELLEM word
+nofor correct "ínéssztráj" "ínészsztráj"	For example színészsztrájk word
+nofor correct "ÍNÉSSZTRÁJ" "ÍNÉSZSZTRÁJ"	For example SZÍNÉSZSZTRÁJK word
+nofor correct "érésszá" *	For example érésszámú word
+nofor correct "Érésszá" *	For example Érésszámú word
+nofor correct "ÉRÉSSZÁ" *	For example ÉRÉSSZÁMÚ word
+nofor correct "itnessza" "itneszsza"	For example fitneszszalonba word
+nofor correct "ITNESSZA" "ITNESZSZA"	For example FITNESZSZALONBA word
+nofor correct "empésszolg" "empészszolg"	For example csempészszolgáltatások word
+nofor correct "EMPÉSSZOLG" "EMPÉSZSZOLG"	For example CSEMPÉSZSZOLGÁLTATÁSOK word
+nofor correct "erkésszül" "erkészszül"	For example cserkészszülő word
+nofor correct "ERKÉSSZÜL" "ERKÉSZSZÜL"	For example CSERKÉSZSZÜLŐ word
+nofor correct "penésszí" "penészszí"	For example penészszínek word
+nofor correct "Penésszí" "Penészszí"	For example Penészszín word
+nofor correct "PENÉSSZÍ" "PENÉSZSZÍ"	For example PENÉSZSZÍN word
+nofor correct "régésszöv" "régészszöv"	For example régészszövetség word
+nofor correct "Régésszöv" "Régészszöv"	For example Régészszövetség word
+nofor correct "RÉGÉSSZÖV" "RÉGÉSZSZÖV"	For example RÉGÉSZSZÖVETSÉG word
+nofor correct "résszemfed" *	For example résszemfedők word
+nofor correct "Résszemfed" *	For example Résszemfedő word
+nofor correct "RÉSSZEMFED" *	For example RÉSSZEMFEDŐK word
+nofor correct "enésszínté" "enészszínté"	For example zenészszíntéren word
+nofor correct "ENÉSSZÍNTÉ" "ENÉSZSZÍNTÉ"	For example ZENÉSZSZÍNTÉREN word
+nofor correct "empéssziva" "empészsziva"	For example csempészszivar word
+nofor correct "EMPÉSSZIVA" "EMPÉSZSZIVA"	For example CSEMPÉSZSZIVAR word
+nofor correct "enisszék" "eniszszék"	For example teniszszék word
+nofor correct "ENISSZÉK" "ENISZSZÉK"	For example TENISZSZÉK word
+nofor correct "elasszi" "elaszszi"	For example melaszszirup word
+nofor correct "ELASSZI" "ELASZSZI"	For example MELASZSZIRUP word
+nofor correct "énisszá" "éniszszá"	For example péniszszár word
+nofor correct "ÉNISSZÁ" "ÉNISZSZÁ"	For example PÉNISZSZÁR word
+nofor correct "épésszí" "épészszí"	For example gégészszív word
+nofor correct "ÉPÉSSZÍ" "ÉPÉSZSZÍ"	For example GÉGÉSZSZÍV word
+nofor correct "busszeg" "buszszeg"	For example buszszegmensben word
+nofor correct "Busszeg" "Buszszeg"	For example Buszszegmensben word
+nofor correct "BUSSZEG" "BUSZSZEG"	For example BUSZSZEGMENSBEN word
+nofor correct "oklásszez" "oklászszez"	For example toklászszezon word
+nofor correct "OKLÁSSZEZ" "OKLÁSZSZEZ"	For example TOKLÁSZSZEZON word
+nofor correct "ambusszig" "ambuszszig"	For example bambuszsziget word
+nofor correct "AMBUSSZIG" "AMBUSZSZIG"	For example BAMBUSZSZIGET word
+nofor correct "eresszéle" "ereszszéle"	For example ereszszélesítés word
+nofor correct "Eresszéle" "Ereszszéle"	For example Ereszszélesítés word
+nofor correct "ERESSZÉLE" "ERESZSZÉLE"	For example ERESZSZÉLESÍTÉS word
+nofor correct "odrásszim" "odrászszim"	For example fodrászszimulátor word
+nofor correct "ODRÁSSZIM" "ODRÁSZSZIM"	For example FODRÁSZSZIMULÁTOR word
+nofor correct "tlasszer" "tlaszszer"	For example atlaszszerű word
+nofor correct "TLASSZER" "TLASZSZER"	For example ATLASZSZERŰ word
+nofor correct "irkusszó" "irkuszszó"	For example cirkuszszórakozás word
+nofor correct "IRKUSSZÓ" "IRKUSZSZÓ"	For example CIRKUSZSZÓRAKOZÁS word
+nofor correct "ovasíjásszá" *	For example lovasíjásszá word
+nofor correct "OVASÍJÁSSZÁ" *	For example LOVASÍJÁSSZÁ word
+nofor correct "ertésszok" "ertészszok"	For example kertészszokás word
+nofor correct "ERTÉSSZOK" "ERTÉSZSZOK"	For example KERTÉSZSZOKÁS word
+nofor correct "ozmosszelle" "ozmoszszelle"	For example kozmoszszellem word
+nofor correct "OZMOSSZELLE" "OZMOSZSZELLE"	For example KOZMOSZSZELLEM word
+nofor correct "igassze" "igaszsze"	For example vigaszszexnek word
+nofor correct "IGASSZE" "IGASZSZE"	For example VIGASZSZEXNEK word
+nofor correct "ásszóza" "ászszóza"	For example gyászszózat word
+nofor correct "ÁSSZÓZA" "ÁSZSZÓZA"	For example GYÁSZSZÓZAT word
+nofor correct "orlasszer" "orlaszszer"	For example torlaszszerűen word
+nofor correct "ORLASSZER" "ORLASZSZER"	For example TORLASZSZERŰEN word
+nofor correct "tílusszédel" *	For example stílusszédelgők word
+nofor correct "TÍLUSSZÉDEL" *	For example STÍLUSSZÉDELGŐK word
+nofor correct "gyásszöve" "gyászszöve"	For example gyászszöveget word
+nofor correct "Gyásszöve" "Gyászszöve"	For example Gyászszöveget word
+nofor correct "GYÁSSZÖVE" "GYÁSZSZÖVE"	For example GYÁSZSZÖVEGET word
+nofor correct "ezgésszegé" *	For example rezgésszegény word
+nofor correct "EZGÉSSZEGÉ" *	For example REZGÉSSZEGÉNY word
+nofor correct "ányásszí" "ányászszí"	For example bányászszívekben word
+nofor correct "ÁNYÁSSZÍ" "ÁNYÁSZSZÍ"	For example BÁNYÁSZSZÍVEKBEN word
+nofor correct "űrésszin" *	For example tűrésszintjét word
+nofor correct "ŰRÉSSZIN" *	For example TŰRÉSSZINTJÉT word
+nofor correct "amasszin" "amaszszin"	For example kamaszszintű word
+nofor correct "AMASSZIN" "AMASZSZIN"	For example KAMASZSZINTŰ word
+nofor correct "mókusszob" *	For example mókusszobrokat word
+nofor correct "Mókusszob" *	For example Mókusszobrokat word
+nofor correct "MÓKUSSZOB" *	For example MÓKUSSZOBROKAT word
+nofor correct "ovásszerel" "ovászszerel"	For example kovászszerelmes word
+nofor correct "OVÁSSZEREL" "OVÁSZSZEREL"	For example KOVÁSZSZERELMES word
+nofor correct "obrásszimp" "obrászszimp"	For example szobrászszimpózium word
+nofor correct "OBRÁSSZIMP" "OBRÁSZSZIMP"	For example SZOBRÁSZSZIMPÓZIUMRÓL word
+nofor correct "tavasszagú" "tavaszszagú"	For example tavaszszagú word
+nofor correct "Tavasszagú" "Tavaszszagú"	For example Tavaszszagú word
+nofor correct "TAVASSZAGÚ" "TAVASZSZAGÚ"	For example TAVASZSZAGÚ word
 
 #zszs backtranslated word corrections
 nofor correct "törzszsel" "törzzsel"

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -26,7 +26,6 @@
 
 #This file containing exception words with different need appliing general hungarian combined braille letters, for example cs, ccs, ty, tty rules
 #cs, ccs related exceptions
-endnum -csúcs 36-146-346-146
 noback pass2 @36-146-346-146-6 @36-146-346-146
 partword arccs 1-1235-14-146	For example arccsont, harccsoport, harccselekmény words
 partword arcsérül =	For example arcsérülés word
@@ -156,6 +155,12 @@ always lánccsopo 123-4-1345-14-146-135-1234-135	For example lánccsoport word
 always bíbiccs 12-34-12-24-14-146	For example bíbiccsapat word
 always lánccser 123-4-1345-14-146-15-1235	For example lánccsere word
 always bérencsé 12-16-1235-15-1345-14-234-16	For example bérencséggel word
+always arcsmink 1-1235-14-234-134-24-1345-13	For example arcsminkünk word
+always lánccsom 123-4-1345-14-146-135-134	For example lánccsomag word
+always porcsej 1234-135-1235-14-234-15-234	For example fülporcsejt, porcsejtjeit words
+always percskál 1234-15-1235-14-234-13-4-123	For example percskáláján word
+always boncseg 12-135-1345-14-234-15-1245	For example boncsegédet word
+always láncstr 123-4-1345-14-234-2345-1235	For example blokláncstruktúrából, láncstruktúra words
 
 #csz letters related exceptions
 always pöcszong 1234-12345-146-126-135-1345-1245	For example pöcszongorás word
@@ -435,6 +440,26 @@ always magyarsággy 134-1-1456-1-1235-234-4-1245-1456	For example magyarsággyű
 always taggyárt 2345-1-1245-1456-4-1235-2345	For example taggyártó word
 always éggyön 16-1245-1456-12345-1345	For example jéggyöngy word
 word meggyi 134-15-1456-1456-24 For example single meggyi word need writing different output
+always képességgy 13-16-1234-15-234-234-16-1245-1456	For example képességgyorsítás word
+always meggygé 134-15-1456-1456-1245-16	For example meggygél word
+always izzadtsággy 24-126-126-1-145-2345-234-4-1245-1456	For example izzadtsággyűjtő word
+always minőséggy 134-24-1345-12456-234-16-1245-1456	For example minőséggyengítés word
+always személyiséggy 156-15-134-16-456-24-234-16-1245-1456	For example személyiséggyurmázást word
+always egészséggy 15-1245-16-156-234-16-1245-1456	For example egészséggyerekkori word
+always emberiséggy 15-134-12-15-1235-24-234-16-1245-1456	For example emberiséggyűlölő word
+always dalszöveggy 145-1-123-156-12345-1236-15-1245-1456	For example dalszöveggyűjtemény word
+always zuggyógy 126-136-1245-1456-246-1456	For example zuggyógyszerfüggők word
+always gyurgyalaggy 1456-136-1235-1456-1-123-1-1245-1456	For example gyurgyalaggyűrűzés word
+always nadrággy 1345-1-145-1235-4-1245-1456	For example nadrággyár word
+always műveltséggy 134-23456-1236-15-123-2345-234-16-1245-1456	For example műveltséggyanús word
+always tevékenységgy 2345-15-1236-16-13-15-1246-234-16-1245-1456	For example tevékenységgyűrű word
+always igazgatósággy 24-1245-1-126-1245-1-2345-246-234-4-1245-1456	For example igazgatósággyilkos word
+always meggyelő 134-15-1456-1456-15-123-12456	For example meggyelőállítás word
+always ócskasággy 246-146-13-1-234-4-1245-1456	For example ócskasággyűjtemény word
+always igazságossággy 24-1245-1-126-234-4-1245-135-234-234-4-1245-1456	For example igazságossággyár word
+always analóggy 1-1345-1-123-246-1245-1456	For example analóggyűjtemény word
+always parlaggy 1234-1-1235-123-1-1245-1456	For example parlaggyújtogató word
+always zuggyárt 126-136-1245-1456-4-1235-2345	For example zuggyártásban word
 
 #ny, nny related exceptions
 #Following exception parts need marking nny letter pairs with single n and nny braille dot combinations
@@ -584,6 +609,14 @@ begword kannyul 13-1-1345-1246-136-123	For example kannyulakat word
 always pánnyuga 1234-4-1345-1246-136-1245-1	For example pánnyugat word
 always önnyak 12345-1345-1246-1-13	For example önnyakába word
 always önnyal 12345-1345-1246-1-123	For example önnyalással word
+always génnyom 1245-16-1345-1246-135-134	For example génnyom word
+always magánnyilv 134-1-1245-4-1345-1246-24-123-1236	For example magánnyilvántartás word
+always planktonny 1234-123-1-1345-13-2345-135-1345-1246	For example planktonnyi word
+always pavilonny 1234-1-1236-24-123-135-1345-1246	For example pavilonnyi word
+always katlanny 13-1-2345-123-1-1345-1246	For example katlannyitány word
+always édennyal 16-145-15-1345-1246-1-123	For example édennyalábokra word
+always szalonnyil 156-1-123-135-1345-1246-24-123	For example szalonnyilas word
+endword alonnyi 1-123-135-1345-1246-24	For example fodrásszalonnyi word
 
 #ly related exceptions
 #This exception parts need marking ly letters with two single l and y letter combination
@@ -663,6 +696,9 @@ always légzés 123-16-1245-126-16-234	For example légzésszám, légzésszerű
 partword szavar 234-126-1-1236-1-1235	General exception with handles more szavar style words
 always meglepetés =	For example meglepetésszoftver word need this exception
 always vaszy 1236-1-156-13456
+always üvegnyílászár 12356-1236-15-1245-1246-34-123-4-234-126-4-1235	For example üvegnyílászárókra word
+always földrengész 124-12345-123-145-1235-15-1345-1245-16-234-126	For example földrengészónák word
+always számítógépeszen 156-4-134-34-2345-246-1245-16-1234-15-234-126-15-1345	For example számítógépeszene word
 
 #szs related exceptions
 #This exception list containing some words with need using single s and zs braille dots
@@ -728,6 +764,18 @@ always villamoszseb 1236-24-123-123-1-134-135-234-345-15-12	For example villamos
 always nyerszsí 1246-15-1235-234-345-34	For example nyerszsír word
 always fogyasztássz 124-135-1456-1-156-2345-4-234-156	For example fogyasztásszerű word
 always fogyasztász 124-135-1456-1-156-2345-4-234-126	For example fogyasztászuhanás word
+always matematikuszs 134-1-2345-15-134-1-2345-24-13-136-234-345	For example matematikuszseni word
+always fizetőszón 124-24-126-15-2345-12456-234-126-246-1345	For example fizetőszóna word
+always ílászár 34-123-4-234-126-4-1235	For example ablaknyílászárókra word
+always részáró 1235-16-234-126-4-1235-246	For example részáró word
+always dobozsár 145-135-12-135-126-234-4-1235	For example dobozsárkány word
+always riasztásziv 1235-24-1-156-2345-4-234-126-24-1236	For example riasztászivatar word
+begword prószavari 1234-1235-246-156-1-1236-1-1235-24	For example prószavariáció word
+always luxuszong 123-136-1346-136-234-126-135-1345-1245	For example luxuszongora word
+always nyomászó 1246-135-134-4-234-126-246	For example nyomászónáinak word
+always táltoszen 2345-4-123-2345-135-234-126-15-1345	For example táltoszenei word
+always prímászen 1234-1235-34-134-4-234-126-15-1345	For example prímászene, prímászenével word
+always fétiszen 124-16-2345-24-234-126-15-1345	For example fétiszenekar word
 
 #ssz related exceptions
 #Following exception words and word parts need writing one s and one sz braille letter
@@ -1916,6 +1964,76 @@ always hívásza 125-34-1236-4-234-126-1	For example hívászaj exception
 always lovaszar 123-135-1236-1-234-126-1-1235	For example lovaszarándok word
 always rasszizmussz 1235-1-156-156-24-126-134-136-234-156	For example rasszizmusszakértő word
 always ütőszen 12356-2345-12456-234-126-15-1345	For example ütőszenei word
+always ritkulássz 1235-24-2345-13-136-123-4-234-156	For example csontritkulásszűrés word
+begword sorsszikl 234-135-1235-234-156-24-13-123	For example sorssziklák word
+begword sorsszob 234-135-1235-234-156-135-12	For example sorsszobrok word
+begword sorsszim 234-135-1235-234-156-24-134	For example sorsszimbólum word
+begword sorsszur 234-135-1235-234-156-136-1235	For example sorsszurdok word
+always borulássz 12-135-1235-136-123-4-234-156	For example borulásszimulátor word
+always elektronikuszen 15-123-15-13-2345-1235-135-1345-24-13-136-234-126-15-1345	For example elektronikuszene word
+always intézkedéssz 24-1345-2345-16-126-13-15-145-16-234-156	For example intészkedésszabvány
+always kivégezéssz 13-24-1236-16-1245-15-126-16-234-156	For example kivégezésszerű word
+always melegedéssz 134-15-123-15-1245-15-145-16-234-156	For example bemelegedésszabályzóval word
+always szivárványoszá 156-24-1236-4-1235-1236-4-1246-135-234-126-4	For example szivárványoszászló word
+always fogyássz 124-135-1456-4-234-156   For example fogyásszakértő word
+begword társzen 2345-4-1235-234-126-15-1345	For example társzenekar word
+always hősszin 125-12456-234-156-24-1345	For example szuperhősszindróma word
+always hősszto 125-12456-234-156-2345-135	For example szuperhősszindróma word
+always vonószá 1236-135-1345-246-156-4	For example vonószárára word
+always lehúzássz 123-15-1235-346-126-4-234-156	For example lehúzásszagú word
+always jelentész 245-15-123-15-1345-2345-16-234-126	For example jelentészaj, jelentészavarás word
+always billenéssz 12-24-123-123-15-1345-16-234-156	For example billenésszabályozás word
+always keléssz 13-15-123-16-234-156	For example kelésszám word
+always ősszén 12456-234-156-16-1345	For example ősszél word
+always ősszél 12456-234-156-16-123	For example ősszén word
+always sebzéssz 234-15-12-126-16-234-156	For example sebzésszorzók word
+always keveredéssz 13-15-1236-15-1235-15-145-16-234-156	For example keveredésszerű word
+always étkezéssz 16-2345-13-15-126-16-234-156	For example étkezésszám word
+always kapuszicc 13-1-1234-136-234-126-24-14-14	For example kapusziccer word
+always fagyossz 124-1-1456-135-234-156	For example fagyosszeder word
+always fejéssz 124-15-245-16-234-156	For example fejésszám word
+always fényűzéssz 124-16-1246-23456-126-16-234-156	For example fényűzésszámba word
+always rongálássz 1235-135-1345-1245-4-123-4-234-156	For example rongálásszerű word
+always ékelődéssz 16-13-15-123-12456-145-16-234-156	For example ékelődésszerű word
+always szopássz 156-135-1234-4-234-156	For example szopásszerű word
+always entitássz 15-1345-2345-24-2345-4-234-156	For example entitásszintű word
+always érésszá 16-1235-16-234-156-4	For example érésszámú word
+always kölcsönzéssz 13-12345-123-146-12345-1345-126-16-234-156	For example kölcsönzésszám word
+always hasszé 125-1-234-156-16	For example sertéshasszél word
+always ízléssz 34-126-123-16-234-156	For example ízlésszerű, ízlésszintje words
+always ötössz 12345-2345-12345-234-156	For example ötösszaltó, ötösszámú word
+always megállapodássz 134-15-1245-4-123-123-1-1234-135-145-4-234-156	For example megállapodásszegésére words
+always meggyőződéssz 134-15-1245-1456-12456-126-12456-145-16-234-156	For example meggyőződésszabadság word
+always zenésszín 126-15-1345-16-234-156-34-1345	For example zenésszínházi word
+always egressze 15-1245-1235-15-234-156-15	For example egresszem word
+always egresszó 15-1245-1235-15-234-156-246	For example egresszósz word
+begword egresszí 15-1245-1235-15-234-156-34	For example egresszív beginning words
+always egresszö 15-1245-1235-15-234-156-12345	For example egresszörp word
+always uborkássz 136-12-135-1235-13-4-234-156	For example uborkásszendvics word
+always sorsszöv 234-135-1235-234-156-12345-1236	For example sorsszövő word
+always ivássz 24-1236-4-234-156	For example ivásszünetet word
+always nyersszenny 1246-15-1235-234-156-15-1246-1246	For example nyersszennyvíz word
+always ivarzássz 24-1236-1-1235-126-4-234-156	For example ivarzásszinkronizálás word
+always festékessz 124-15-234-2345-16-13-15-234-156	For example festékesszőnyeg word
+always készítéssz 13-16-156-34-2345-16-234-156	For example filmkészítéssztrájk word
+always hússziv 125-346-234-156-24-1236	For example hússzivacs word
+always bádogossz 12-4-145-135-1245-135-234-156	For example bádogosszerkezetek word
+always jelzéssz 245-15-123-126-16-234-156	For example jelzésszámú word
+always együttessz 15-1456-12356-2345-2345-15-234-156	For example együttesszínművész word
+always praxissz 1234-1235-1-1346-24-234-156	For example praxisszám, praxisszerződés, praxisszoftverben words
+always hússzirm 125-346-234-156-24-1235-134	For example hússzirmain word
+always fenyvessz 124-15-1246-1236-15-234-156	For example fenyvesszálló, fenyvesszéli words
+always gyorsulássz 1456-135-1235-234-136-123-4-234-156	For example gyorsulásszenzor word
+always nyákossz 1246-4-13-135-234-156	For example nyákosszerű word
+always nyálkássz 1246-4-123-13-4-234-156	For example nyálkásszerű word
+always bontássz 12-135-145-2345-4-234-156	For example bontásszakmák, bontásszerű word
+always milliárdossz 134-24-123-123-24-4-1235-145-135-234-156	For example milliárdosszál word
+always ócskavassz 246-146-13-1-1236-1-234-156	For example ócskavassziget word
+always szellentéssz 156-15-123-123-15-1345-2345-16-234-156	For example szellentésszagú word
+always hasszobr 125-1-234-156-135-12-1235	For example hasszobrászat word
+always kanálissz 13-1-1345-4-123-24-234-156	For example kanálisszájú word
+always drogossz 145-1235-135-1245-135-234-156	For example drogosszemüveg word
+always terheléssz 2345-15-1235-125-15-123-16-234-156	For example terhelésszint word
 
 #ty, tty related exceptions
 #This exception part containing english words with need presenting original english braille rules
@@ -2068,6 +2186,15 @@ always bukkáliszs 12-136-13-13-4-123-24-234-345	For example bukkáliszsír word
 always szárazsam 156-4-1235-1-126-234-1-134	For example szárazsampon word
 always fürdészuh 124-12356-1235-145-16-234-126-136-125	For example fürdészuhanyzás word
 always imázszen 24-134-4-345-126-15-1345	For example imázszenét word
+always köntöszs 13-12345-1345-2345-12345-234-345	For example köntöszsinór word
+always ízskál 34-126-234-13-4-123	For example ízskála word
+always gézzsá 1245-16-126-345-4	For example gézsák word
+always ötöszs 12345-2345-12345-234-345	For example ötöszsűri word
+always gázzse 1245-4-126-345-15	For example gázzseb word
+always gőzzsem 1245-12456-126-345-15-134	For example gőzzsemle word
+always reformátuszs 1235-15-124-135-1235-134-4-2345-136-234-345	For example reformátuszsinat word
+always kerítészs 13-15-1235-34-2345-16-234-345	For example kerítészsonglőrt word
+always biológuszs 12-24-135-123-246-1245-136-234-345	For example biológuszseni word
 
 #Historical person names related exceptions
 always táncsics 2345-4-1345-146-24-146	Táncsics Mihály is a historical person for 1848. march 15 hungarian revolution


### PR DESCRIPTION
Hi Boys,

As it is usual, I added new forward and backward translation exceptions with hungarian language Braille tables, and created or modified required testcase entries the previous autogenerated dictionary file.
The review is very easy:
The first commit diff output is not large, only 393 lines, and affects only with hungarian language related exceptions, other languages is not affected.
The second commit not need detailed reviewing, because contains only the tests/braille-specs/hu-hu-g1_dictionary_special_consonants.yaml testcase file update.

My local test results:
1. All required Liblouis tests passed my local system into the tests directory, other languages is not affecting this update, regression errors will be not happens with other languages if the change is merged into the master branch. So, make check command ran right my local system.
2. The change not produce regression errors with hungarian large local text corpus database. The change passed the extended large hungarian text corpus word collection database forward and backward translation tests direction, with hu-hu-g1.ctb table related all 8099480 word forward and backward translations is happened right.
hu-hu-g2.ctb table related back-translation is not possible with this large word collection, because some abbreviations means two or three suffixes (for example in hu-hu-g2.ctb if a word ends with bl letters, the bl letter possible back-translating ból, ből suffixes, hz possible back-translating hoz, hez, höz sufffixes).

If possible and fits the time before september 4, please add this update the 3.27 milestone list, and because possible will be happens after september 4 screen reader version update (for example will be releasing new NVDA version), please approve this change the 3.27 release.

Thanks the good cooperation,

Attila