### PR TITLE
norwegian: added test for mixed capital and small letters

### DIFF
--- a/tests/braille-specs/no_harness.yaml
+++ b/tests/braille-specs/no_harness.yaml
@@ -254,6 +254,11 @@ tests:
     - DTBook NBfU
     - ⠠⠙⠠⠞⠠⠃⠕⠕⠅ ⠠⠝⠠⠃⠋⠠⠥
     - {xfail: true}
+  # when acronyms are mixed capitals and small letters, the capital sign should be present in front of each capital letter
+  -
+    - KrFU
+    - ⠠⠅⠗⠠⠋⠠⠥
+    - {xfail: true}
   -
     - MHz kHz
     - ⠠⠍⠠⠓⠵ ⠅⠠⠓⠵


### PR DESCRIPTION
When acronyms are mixed capitals and small letters the capital sign should be present in front of each capital like this:
KrFU: ⠠⠅⠗⠠⠋⠠⠥

Not like this:
⠠⠅⠗⠠⠠⠋⠥

This pull request adds a test for this.