### PR TITLE
liblouis/compileTranslationTable.c: present table filename with Duplicate emphasis class warning message in check_all_table.pl

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -3407,7 +3407,7 @@ doOpcode:
 			s[k++] = '\0';
 			for (i = 0; i < MAX_EMPH_CLASSES && (*table)->emphClassNames[i]; i++)
 				if (strcmp(s, (*table)->emphClassNames[i]) == 0) {
-					_lou_logMessage(LOU_LOG_WARN, "Duplicate emphasis class: %s", s);
+					compileWarning(file, "Duplicate emphasis class: %s", s);
 					warningCount++;
 					free(s);
 					return 1;


### PR DESCRIPTION
In liblouis/compileTranslationTable.c file needs do this small modification with issue #266 related.
Original version not presents table names with contains duplicated emphasis flags, for example bold, italic, underline, transnote, etc.
This is a partial fix, because table levels not fixed the duplicate definitions. So, this is only one step forward.

Attila