### PR TITLE
liblouis/compileTranslationTable.c: Change this warning to an error: "Invalid attribute name: must be a digit between 0 and 7 or a word containing only letters"

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1127,7 +1127,7 @@ addCharacterClass(const FileInfo *file, const widechar *name, int length,
 				// don't abort because in some cases (before/after rules)
 				// this will work fine, but it will not work in multipass
 				// expressions
-				compileWarning(file,
+				compileError(file,
 						"Invalid attribute name: must be a digit between "
 						"0 and 7 or a word containing only letters");
 			}


### PR DESCRIPTION
Hy Boys,

Previous, if basename opcode wrong defined, only presents following warning message:
"Invalid attribute name: must be a digit between 0 and 7 or a word containing only letters"
The message type changed now from warning to error message.
After this PR is merged, Fixes #1133 
@bertfrees revieved the original issue with this now committed diff output and asked me to open a PR this fix related. :-):-)

Attila