### PR TITLE
liblouis/compileTranslationTable.c: check_all_tables.pl.log presents table name and issued warning numbers

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4924,7 +4924,7 @@ compileTable(const char *tableList, const char *displayTableList,
 /* Clean up after compiling files */
 cleanup:
 	free_tablefiles(tableFiles);
-	if (warningCount) _lou_logMessage(LOU_LOG_WARN, "%d warnings issued", warningCount);
+	if (warningCount) _lou_logMessage(LOU_LOG_WARN, "%s: %d warnings issued", tableList, warningCount);
 	if (!errorCount) {
 		if (translationTable) setDefaults(*translationTable);
 		return 1;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4924,7 +4924,8 @@ compileTable(const char *tableList, const char *displayTableList,
 /* Clean up after compiling files */
 cleanup:
 	free_tablefiles(tableFiles);
-	if (warningCount) _lou_logMessage(LOU_LOG_WARN, "%s: %d warnings issued", tableList, warningCount);
+	if (warningCount)
+		_lou_logMessage(LOU_LOG_WARN, "%s: %d warnings issued", tableList, warningCount);
 	if (!errorCount) {
 		if (translationTable) setDefaults(*translationTable);
 		return 1;


### PR DESCRIPTION
Hy Boys,

In issue #266 @bertfrees asked a code modification with liblouis/compileTranslationTable.c file to tests/check_all_tables.pl.log file what tables how many warning message are presents.

The resulted check_all_table.pl.log file is more elegant now, see an example log:
```
/usr/src/liblouis/tables/en-us-emphasis.uti:27: warning: Duplicate emphasis class: italic
/usr/src/liblouis/tables/en-us-emphasis.uti:28: warning: Duplicate emphasis class: underline
/usr/src/liblouis/tables/en-us-emphasis.uti:29: warning: Duplicate emphasis class: bold
/usr/src/liblouis/tables/ko-2006-g2.ctb: 6 warnings issued
/usr/src/liblouis/tables/en-us-emphasis.uti:27: warning: Duplicate emphasis class: italic
/usr/src/liblouis/tables/en-us-emphasis.uti:28: warning: Duplicate emphasis class: underline
/usr/src/liblouis/tables/en-us-emphasis.uti:29: warning: Duplicate emphasis class: bold
/usr/src/liblouis/tables/ko-g2.ctb: 6 warnings issued
/usr/src/liblouis/tables/en-ueb-g1.ctb:81: warning: Duplicate emphasis class: italic
/usr/src/liblouis/tables/en-ueb-g1.ctb:82: warning: Duplicate emphasis class: underline
/usr/src/liblouis/tables/en-ueb-g1.ctb:83: warning: Duplicate emphasis class: bold
/usr/src/liblouis/tables/en-ueb-g1.ctb:84: warning: Duplicate emphasis class: script
/usr/src/liblouis/tables/en-ueb-g1.ctb:85: warning: Duplicate emphasis class: transnote
/usr/src/liblouis/tables/en-ueb-g1.ctb:86: warning: Duplicate emphasis class: trans1
/usr/src/liblouis/tables/en-ueb-g1.ctb:87: warning: Duplicate emphasis class: trans2
/usr/src/liblouis/tables/en-ueb-g1.ctb:88: warning: Duplicate emphasis class: trans3
/usr/src/liblouis/tables/en-ueb-g1.ctb:89: warning: Duplicate emphasis class: trans4
/usr/src/liblouis/tables/en-ueb-g1.ctb:90: warning: Duplicate emphasis class: trans5
/usr/src/liblouis/tables/zhcn-cbs.ctb: 20 warnings issued
PASS check_all_tables.pl (exit status: 0)
```

The original code line only presents the issued warnings numbers, but not presents the affected table names the log file.

Attila