### PR TITLE
UEB: Ensure letter indicators are added to letters A-J following numbers in a capitalized passage

### DIFF
--- a/tables/en-ueb-g1.ctb
+++ b/tables/en-ueb-g1.ctb
@@ -51,7 +51,14 @@ numsign 3456  number sign, just a dots operand
 numericmodechars .,
 nocontractsign 56
 nonumsign 56
-numericnocontchars abcdefghij
+numericnocontchars abcdefghijABCDEFGHIJ
+
+# A capital ends numeric mode, so clean up extraneous letter indicators between a number
+# and a subsequent capital letter
+noback pass2 _$d[@6-56]$U @6                # handle "1234Card"
+noback pass2 _$d[@6-6-56]$U @6-6            # handle "1234CARD"
+noback pass2 _$d[@256-6-6-56]$U @256-6-6    # handle "1234.CARD"
+noback pass2 _$d[@256-6-56]$U @256-6        # handle "1234.Card"
 
 # Correct order of comma and numeric indicator
 match %a , %# 2-34569  force correct position of numeric indicator

--- a/tests/braille-specs/en-ueb-06-numeric_mode.yaml
+++ b/tests/braille-specs/en-ueb-06-numeric_mode.yaml
@@ -241,3 +241,14 @@ tests:
   - '"<;x1 #d">'
 - - (x,4)
   - '"<x1#d">'
+# from https://github.com/liblouis/liblouis/issues/1323
+- - ABC DEFG HIJ
+  - ",,,abc defg hij,'"
+- - ABC 456G HIJ
+  - ",,,abc #def;g hij,'"
+- - ABC 45FG HIJ
+  - ",,,abc #de;fg hij,'"
+- - ABC 4EFG HIJ
+  - ",,,abc #d;efg hij,'"
+- - AB123456G DWP CR
+  - ",,,ab#abcdef;g dwp cr,'"


### PR DESCRIPTION
Resolves #1323 

Fixes an issue when in a capitalized passage, a letter indicator is not inserted for a capital letter following a number (e.g. AB1234FG requires a letter indicator between 4 and F, but is not currently getting one).  This was caused because `numericnocontchars` is case sensitive (see also #631) and the UEB table only included lowercase letters.


