### PR TITLE
Fail if the size param to memcpy is negative

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -478,8 +478,10 @@ swapReplace(int start, int end, const TranslationTableHeader *table,
 			int d = output->length + l;
 			if (d > output->maxlength) return 0;
 			while (--d >= output->length) posMapping[d] = p;
-			memcpy(&output->chars[output->length], &replacements[k + 1],
-					l * sizeof(*output->chars));
+			// if length is negative fail
+			int length = l * sizeof(*output->chars);
+			if (length < 0) return 0;
+			memcpy(&output->chars[output->length], &replacements[k + 1], length);
 			output->length += l;
 		}
 	}


### PR DESCRIPTION
Make sure the size param for `memcpy` is not negative.

This should fix https://oss-fuzz.com/testcase-detail/6608976274653184 also mentioned in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60723

For inspiration I looked at https://github.com/inikep/lizard/commit/02491c71c2e6fd5c10997404df2f18d0fc7afadb