### PR TITLE
Added some new forward and backward translation exceptions with hungarian subtable files

### DIFF
--- a/tables/hu-backtranslate-word-corrections.cti
+++ b/tables/hu-backtranslate-word-corrections.cti
@@ -192,6 +192,14 @@ nofor correct "akanccsatt" "akancscsatt"	For example bakancscsattogtatók word
 nofor correct "AKANCCSATT" "AKANCSCSATT"	For example BAKANCSCSATTOGTATÓK word
 nofor correct "ullanccsú" "ullancscsú"	For example kullancscsúcs word
 nofor correct "ULLANCCSÚ" "ULLANCSCSÚ"	For example KULLANCSCSÚCS word
+nofor correct "ümölccsem" "ümölcscsem"	For example gyümölcscsemete word
+nofor correct "ÜMÖLCCSEM" "ÜMÖLCSCSEM"	For example GYÜMÖLCSCSEMETE word
+nofor correct "úccsi" "úcscsi"	For example csúcscsip word
+nofor correct "ÚCCSI" "ÚCSCSI"	For example CSÚCSCSIP word
+nofor correct "ilinccser" "ilincscser"	For example kilincscserével word
+nofor correct "ILINCCSER" "ILINCSCSER"	For example KILINCSCSERÉVEL word
+nofor correct "úccsuk" "úcscsuk"	For example csúcscsukáról word
+nofor correct "ÚCCSUK" "ÚCSCSUK"	For example CSÚCSCSUKÁRÓL word
 
 #ggy, gygy backtranslation rule corrections
 nofor correct "szalaggyak" *
@@ -384,6 +392,16 @@ nofor correct "Léggyöke" *	For example Léggyökerű word
 nofor correct "LÉGGYÖKE" *	For example LÉGGYÖKERŰ word
 nofor correct "önggyűj" "öngygyűj"	For example gyöngygyűjtésre word
 nofor correct "ÖNGGYŰJ" "ÖNGYGYŰJ"	For example GYÖNGYGYŰJTÉSRE word
+nofor correct "veggyerme" *	For example üveggyermek word
+nofor correct "VEGGYERME" *	For example ÜVEGGYERMEK word
+nofor correct "eggyomrú" "egygyomrú"	For example egygyomrú word
+nofor correct "Eggyomrú" "Egygyomrú"	For example Egygyomrú word
+nofor correct "EGGYOMRÚ" "EGYGYOMRÚ"	For example EGYGYOMRÚ word
+nofor correct "irággyá" *	For example művirággyártó word
+nofor correct "IRÁGGYÁ" *	For example MŰVIRÁGGYÁRTÓ word
+nofor correct "anyaggyan" *	For example anyaggyanú word
+nofor correct "Anyaggyan" *	For example Anyaggyanú word
+nofor correct "ANYAGGYAN" *	For example ANYAGGYANÚ word
 
 #nyny, nyny letters related backtranslate corrections
 nofor correct "rannyak" "ranynyak"	For example aranynyakláncának word
@@ -560,8 +578,8 @@ nofor correct "aggyőr" "agygyőr"	For example nagygyőr word
 nofor correct "AGGYŐR" "AGYGYŐR"	For example NAGYGYŐR word
 nofor correct "oronnyitó" "oronynyitó"	For example toronynyitó word
 nofor correct "ORONNYITÓ" "ORONYNYITÓ"	For example TORONYNYITÓ word
-nofor correct "oronnyitá" "oronynyitá"  For example toronynyitás word
-nofor correct "ORONNYITÁ" "ORONYNYITÁ"  For example TORONYNYITÁS word
+nofor correct "oronnyitá" "oronynyitá"	For example toronynyitás word
+nofor correct "ORONNYITÁ" "ORONYNYITÁ"	For example TORONYNYITÁS word
 nofor correct "özlönnyil" "özlönynyil"	For example közlönynyilatkozat word
 nofor correct "ÖZLÖNNYIL" "ÖZLÖNYNYIL"	For example KÖZLÖNYNYILATKOZAT word
 nofor correct "edőnnyo" "edőnynyo"	For example redőnynyomógomb word
@@ -588,6 +606,18 @@ nofor correct "árnnyír" "árnynyír"	For example szárnynyíráson word
 nofor correct "ÁRNNYÍR" "ÁRNYNYÍR"	For example SZÁRNYNYÍRÁSON word
 nofor correct "ersennyelv" "ersenynyelv"	For example versenynyelvben word
 nofor correct "ERSENNYELV" "ERSENYNYELV"	For example VERSENYNYELVBEN word
+nofor correct "árkánnyel" "árkánynyel"	For example sárkánynyelven word
+nofor correct "ÁRKÁNNYEL" "ÁRKÁNYNYEL"	For example SÁRKÁNYNYELVEN word
+nofor correct "sszonnyár" "sszonynyár"	For example asszonynyár word
+nofor correct "SSZONNYÁR" "SSZONYNYÁR"	For example ASSZONYNYÁR word
+nofor correct "áránnyár" "áránynyár"	For example báránynyárs word
+nofor correct "ÁRÁNNYÁR" "ÁRÁNYNYÁR"	For example BÁRÁNYNYÁRS word
+nofor correct "énnyomvo" "énynyomvo"	For example fénynyomvonal word
+nofor correct "ÉNNYOMVO" "ÉNYNYOMVO"	For example FÉNYNYOMVONAL word
+nofor correct "amlénnya" *	For example pamlénnyal word
+nofor correct "AMLÉNNYA" *	For example PAMLÉNNYAL word
+nofor correct "lménnyelv" "lménynyelv"	For example élménnynyelv word
+nofor correct "LMÉNNYELV" "LMÉNYNYELV"	For example ÉLMÉNYNYELV word
 
 #lyly letters related backtranslate corrections
 nofor correct "amelylyel" *
@@ -2152,6 +2182,112 @@ nofor correct "ransszóvi" "ranszszóvi"	For example transzszóvivője word
 nofor correct "RANSSZÓVI" "RANSZSZÓVI"	For example TRANSZSZÓVIVŐJE word
 nofor correct "ísszín" "íszszín"	For example díszszín word
 nofor correct "ÍSSZÍN" "ÍSZSZÍN"	For example DÍSZSZÍN word
+nofor correct "lusszos" *	For example slusszos word
+nofor correct "LUSSZOS" *	For example SLUSSZOS word
+nofor correct "ozmosszak" "ozmoszszak"	For example kozmoszszakasz word
+nofor correct "OZMOSSZAK" "OZMOSZSZAK"	For example KOZMOSZSZAKASZ word
+nofor correct "umusszemcs" "umuszszemcs"	For example humuszszemcsék word
+nofor correct "UMUSSZEMCS" "UMUSZSZEMCS"	For example HUMUSZSZEMCSÉKET word
+nofor correct "éhésszék" "éhészszék"	For example méhészszékház word
+nofor correct "ÉHÉSSZÉK" "ÉHÉSZSZÉK"	For example MÉHÉSZSZÉKHÁZ word
+nofor correct "ókusszom" *	For example mókusszomszéd word
+nofor correct "ÓKUSSZOM" *	For example MÓKUSSZOMSZÉD word
+nofor correct "ítésszék" "ítészszék"	For example ítészszékbe word
+nofor correct "Ítésszék" "Ítészszék"	For example Ítészszékbe word
+nofor correct "ÍTÉSSZÉK" "ÍTÉSZSZÉK"	For example ÍTÉSZSZÉKBE word
+nofor correct "endésszolg" "endészszolg"	For example rendészszolgálat word
+nofor correct "ENDÉSSZOLG" "ENDÉSZSZOLG"	For example RENDÉSZSZOLGÁLAT word
+nofor correct "ínéssza" "ínészsza"	For example színészszamár word
+nofor correct "ÍNÉSSZA" "ÍNÉSZSZA"	For example SZÍNÉSZSZAMÁR word
+nofor correct "ílusszav" *	For example stílusszavazáson word
+nofor correct "ÍLUSSZAV" *	For example STÍLUSSZAVAZÁSON word
+nofor correct "odrásszenv" "odrászszenv"	For example fodrászszenvedély word
+nofor correct "ODRÁSSZENV" "ODRÁSZSZENV"	For example FODRÁSZSZENVEDÉLY word
+nofor correct "ányásszöv" "ányászszöv"	For example bányászszövetség word
+nofor correct "ÁNYÁSSZÖV" "ÁNYÁSZSZÖV"	For example BÁNYÁSZSZÖVETSÉG word
+nofor correct "vadássztráj" "vadászsztráj"	For example vadászsztrájk word
+nofor correct "Vadássztráj" "Vadászsztráj"	For example Vadászsztrájk word
+nofor correct "VADÁSSZTRÁJ" "VADÁSZSZTRÁJ"	For example VADÁSZSZTRÁJK word
+nofor correct "aránusszer" "aránuszszer"	For example varánuszszerű word
+nofor correct "ARÁNUSSZER" "ARÁNUSZSZER"	For example VARÁNUSZSZERŰ word
+nofor correct "ipogásszez" *	For example szipogásszezonban word
+nofor correct "IPOGÁSSZEZ" *	For example SZIPOGÁSSZEZONBAN word
+nofor correct "ínésszül" "ínészszül"	For example színészszülők word
+nofor correct "ÍNÉSSZÜL" "ÍNÉSZSZÜL"	For example SZÍNÉSZSZÜLŐK word
+nofor correct "ellépésszóló" *	For example fellépésszóló word
+nofor correct "ELLÉPÉSSZÓLÓ" *	For example FELLÉPÉSSZÓLÓ word
+nofor correct "iakónusszolg" *	For example diakónuszszolgálat word
+nofor correct "IAKÓNUSSZOLG" *	For example DIAKÓNUSSZOLGÁLAT word
+nofor correct "ókusszedé" "ókuszszedé"	For example kókuszszedés word
+nofor correct "ÓKUSSZEDÉ" "ÓKUSZSZEDÉ"	For example KÓKUSZSZEDÉS word
+nofor correct "ínésszínhá" "ínészszínhá"	For example színészszínház word
+nofor correct "ÍNÉSSZÍNHÁ" "ÍNÉSZSZÍNHÁ"	For example SZÍNÉSZSZÍNHÁZ word
+nofor correct "ősszínű" "őszszínű"	For example őszszínű word
+nofor correct "Ősszínű" "Őszszínű"	For example Hőszszínű word
+nofor correct "ŐSSZÍNŰ" "ŐSZSZÍNŰ"	For example ŐSZSZÍNŰ word
+nofor correct "itnesszer" "itneszszer"	For example fitneszszerető word
+nofor correct "ITNESSZER" "ITNESZSZER"	For example FITNESZSZERETŐ word
+nofor correct "álasszindr" "álaszszindr"    For example válaszszindrómának word
+nofor correct "ÁLASSZINDR" "ÁLASZSZINDR"    For example VÁLASZSZINDRÓMÁNAK word
+nofor correct "iasszál" "iaszszál"  For example viaszszálból word
+nofor correct "IASSZÁL" "IASZSZÁL"  For example VIASZSZÁLBAN word
+nofor correct "fasszépsé" "faszszépsé"
+nofor correct "Fasszépsé" "Faszszépsé"
+nofor correct "FASSZÉPSÉ" "FASZSZÉPSÉ"
+nofor correct "ijjogásszer" *	For example vijjogásszerű word
+nofor correct "IJJOGÁSSZER" *	For example VIJJOGÁSSZERŰ word
+nofor correct "pítésszó" *	For example leépítésszóval word
+nofor correct "PÍTÉSSZÓ" *	For example LEÉPÍTÉSSZÓVAL word
+nofor correct "arvasszel" *	For example szarvasszelet word
+nofor correct "ARVASSZEL" *	For example SZARVASSZELET word
+nofor correct "álasszám" "álaszszám"	For example válaszszám word
+nofor correct "ÁLASSZÁM" "ÁLASZSZÁM"	For example VÁLASZSZÁM word
+nofor correct "lkusszekto" "lkuszszekto"	For example alkuszszektor word
+nofor correct "LKUSSZEKTO" "LKUSZSZEKTO"	For example ALKUSZSZEKTOR word
+nofor correct "ázadásszí" *	For example lázadásszítás word
+nofor correct "ÁZADÁSSZÍ" *	For example LÁZADÁSSZÍTÁS word
+nofor correct "encegésszer" *	For example hencegésszerű word
+nofor correct "ENCEGÉSSZER" *	For example HENCEGÉSSZERŰ word
+nofor correct "gyásszent" "gyászszent"	For example gyászszentmise word
+nofor correct "Gyásszent" "Gyászszent"	For example Gyászszentmise word
+nofor correct "GYÁSSZENT" "GYÁSZSZENT"	For example GYÁSZSZENTMISE word
+nofor correct "ereplésszer" *	For example kereplésszerű word
+nofor correct "EREPLÉSSZER" *	For example KEREPLÉSSZERŰ word
+nofor correct "orásszöv" "orászszöv"	For example borászszövetség word
+nofor correct "ORÁSSZÖV" "ORÁSZSZÖV"	For example BORÁSZSZÖVETSÉG word
+nofor correct "szövésszak" *	For example szövésszakkör word
+nofor correct "Szövéssza" *	For example Szövésszakkör word
+nofor correct "SZÖVÉSSZA" *	For example SZÖVÉSSZAKKÖR word
+nofor correct "iabétesszö" "iabéteszszö"	For example diabéteszszövetség word
+nofor correct "IABÉTESSZÖ" "IABÉTESZSZÖ"	For example DIABÉTESZSZÖVETSÉG word
+nofor correct "oksszün" "okszszün"	For example bokszszünet word
+nofor correct "OKSSZÜN" "OKSZSZÜN"	For example BOKSZSZÜNET word
+nofor correct "obrásszer" "obrászszer"	For example szobrászszerszám word
+nofor correct "OBRÁSSZER" "OBRÁSZSZER"	For example SZOBRÁSZSZERSZÁM word
+nofor correct "fókusszám" "fókuszszám"	For example fókuszszámítással word
+nofor correct "Fókusszám" "Fókuszszám"	For example Fókuszszámítással word
+nofor correct "FÓKUSSZÁM" "FÓKUSZSZÁM"	For example FÓKUSZSZÁMÍTÁSSAL word
+nofor correct "szesszak" "szeszszak"	For example szeszszakértő word
+nofor correct "Szesszak" "Szeszszak"	For example Szeszszakértő word
+nofor correct "SZESSZAK" "SZESZSZAK"	For example SZESZSZAKÉRTŐ word
+nofor correct "örésszer" *	For example csőtörésszerűen word
+nofor correct "ÖRÉSSZER" *	For example CSŐTÖRÉSSZERŰEN word
+nofor correct "eknősszí" *	For example teknősszínű word
+nofor correct "EKNŐSSZÍ" *	For example TEKNŐSSZÍNŰ word
+nofor correct "ultussze" "ultuszsze"	For example kultuszszemély word
+nofor correct "ULTUSSZE" "ULTUSZSZE"	For example KULTUSZSZEMÉLY word
+nofor correct "ányásszok" "ányászszok"	For example bányászszokások word
+nofor correct "ÁNYÁSSZOK" "ÁNYÁSZSZOK"	For example BÁNYÁSZSZOKÁSOK word
+nofor correct "űvésszül" "űvészszül"	For example művészszülők word
+nofor correct "ŰVÉSSZÜL" "ŰVÉSZSZÜL"	For example MŰVÉSZSZÜLŐK word
+nofor correct "kertésszez" "kertészszez"	For example kertészszezon word
+nofor correct "Kertésszez" "Kertészszez"	For example Kertészszezon word
+nofor correct "KERTÉSSZEZ" "KERTÉSZSZEZ"	For example KERTÉSZSZEZON word
+nofor correct "ísszóró" "íszszóró"	For example díszszórókút word
+nofor correct "ÍSSZÓRÓ" "ÍSZSZÓRÓ"	For example DÍSZSZÓRÓKÚTJÁNÁL word
+nofor correct "résszivárog" "részszivárog"	For example résszivárogtatásokkal word
+nofor correct "Résszivárog" "Részszivárog"	For example Részszivárogtatás word
+nofor correct "RÉSSZIVÁROG" "RÉSZSZIVÁROG"	For example RÉSZSZIVÁROGTATÁS word
 
 #zszs backtranslated word corrections
 nofor correct "törzszsel" "törzzsel"

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -165,6 +165,10 @@ always piacsemp 1234-24-1-146-15-134-1234	For example piacsempészésen word
 always perccsász 1234-15-1235-14-146-4-156	For example perccsászárok word
 always arcsimo 1-1235-14-234-24-134-135	For example arcsimogató word
 always arcsimí 1-1235-14-234-24-134-34	For example arcsimító word
+always arcstru 1-1235-14-234-2345-1235-136	For example arcstruktúra word
+always arcsál 1-1235-14-234-4-123	For example arcsál word
+always élcsor 16-123-14-234-135-1235	For example élcsor word
+always perccse 1234-15-1235-14-146-15	For example perccsepp word
 
 #csz letters related exceptions
 always pöcszong 1234-12345-146-126-135-1345-1245	For example pöcszongorás word
@@ -472,6 +476,10 @@ always nemzetiséggy 1345-15-134-126-15-2345-24-234-16-1245-1456	For example nem
 always nézettséggy 1345-16-126-15-2345-2345-234-16-1245-1456	For example nézettséggyár word
 always bátorsággy 12-4-2345-135-1235-234-4-1245-1456	For example bátorsággyűjtés word
 always legénységgy 123-15-1245-16-1246-234-16-1245-1456	For example legénységgyilkos word
+always honvédséggy 125-135-1345-1236-16-145-234-16-1245-1456	For example honvédséggyakorlat word
+always legesleggyor 123-15-1245-15-234-123-15-1245-1456-135-1235	For example legesleggyorsabb word
+always göngyöleggy 1245-12345-1345-1456-12345-123-15-1245-1456	For example göngyöleggyártás word
+always löveggy 123-12345-1236-15-1245-1456	For example löveggyilkos word
 
 #ny, nny related exceptions
 #Following exception parts need marking nny letter pairs with single n and nny braille dot combinations
@@ -630,6 +638,7 @@ always édennyal 16-145-15-1345-1246-1-123	For example édennyalábokra word
 always szalonnyil 156-1-123-135-1345-1246-24-123	For example szalonnyilas word
 endword alonnyi 1-123-135-1345-1246-24	For example fodrásszalonnyi word
 always szégyenny 156-16-1456-15-1345-1246	For example szégyennyakörv word
+always londonny 123-135-1345-145-135-1345-1246	For example londonnyi word
 
 #ly related exceptions
 #This exception parts need marking ly letters with two single l and y letter combination
@@ -712,6 +721,8 @@ always vaszy 1236-1-156-13456
 always üvegnyílászár 12356-1236-15-1245-1246-34-123-4-234-126-4-1235	For example üvegnyílászárókra word
 always földrengész 124-12345-123-145-1235-15-1345-1245-16-234-126	For example földrengészónák word
 always számítógépeszen 156-4-134-34-2345-246-1245-16-1234-15-234-126-15-1345	For example számítógépeszene word
+always gyömöszöld 1456-12345-134-12345-156-12345-123-145	For example belegyömöszöld word
+always tudászón 2345-136-145-4-234-126-246-1345	For example tudászóna word
 
 #szs related exceptions
 #This exception list containing some words with need using single s and zs braille dots
@@ -734,7 +745,6 @@ partword bukás =	For example bukásszámba word
 partword település =	For example települészónájára word
 partword utasítás =	For example törzsutasításszavakkal, utasításszavakkal related words need this exception
 partword turizmussz 2345-136-1235-24-126-134-136-234-156	For example turizmusszektor, turizmusszerű words
-begword adászár 1-145-4-234-126-4-1235	For example adászárásig word
 begword enyves 15-1246-1236-15-234	For example enyveszsinór word related need this exception
 partword kortárs =	For example kortárszenei word related need this general exception
 always tervezészs 2345-15-1235-1236-15-126-16-234-345	For example tervezészsebpénz word
@@ -792,6 +802,15 @@ always fétiszen 124-16-2345-24-234-126-15-1345	For example fétiszenekar word
 always kolbászoszt 13-135-123-12-4-156-135-156-2345	For example kolbászosztogató word
 always tőkésszi 2345-12456-13-16-234-156-24	For example Tőkéssziget, tőkésszigeti, Tőkésszigetről words
 always mókusza 134-246-13-136-234-126-1	For example mókuszaj word
+always stíluszen 234-2345-34-123-136-234-126-15-1345	For example stíluszenésznek word
+always fejlesztészá 124-15-245-123-15-156-2345-16-234-126-4	For example fejlesztészáró word
+always húszabál 125-346-234-126-1-12-4-123	For example húszabálók word
+always verszene 1236-15-1235-234-126-15-1345-15	For example verszene word
+always pulzuszón 1234-136-123-126-136-234-126-246-1345	For example pulzuszónában word
+always verszará 1236-15-1235-234-126-1-1235-4	For example verszarándoklat word
+always töltész 2345-12345-123-2345-16-234-126	For example töltészápor word
+always adászárá 1-145-4-234-126-4-1235-4	For example adászárás word
+always kiadászá 13-24-1-145-4-234-126-4	For example kiadászárolás word
 
 #ssz related exceptions
 #Following exception words and word parts need writing one s and one sz braille letter
@@ -2055,6 +2074,59 @@ always büntetéssz 12-12356-1345-2345-15-2345-16-234-156	For example büntetés
 always fotográfussz 124-135-2345-135-1245-1235-4-124-136-234-156	For example fotográfusszakma word
 always navigációssz 1345-1-1236-24-1245-4-14-24-246-234-156	For example navigációsszoftver word
 always borsszür 12-135-1235-234-156-12356-1235	For example borsszüret word
+always szexuálissz 156-15-1346-136-4-123-24-234-156
+always évesszal 16-1236-15-234-156-1-123	For example évesszaldó word
+always óvodássz 246-1236-135-145-4-234-156	For example óvodásszökése word
+always tárgyalássz 2345-4-1235-1456-1-123-4-234-156	For example tárgyalásszimulációk word
+always melóssz 134-15-123-246-234-156	For example melósszállító word
+always melegítéssz 134-15-123-15-1245-34-2345-16-234-156	For example bemelegítésszagúan word
+always statikussz 234-2345-1-2345-24-13-136-234-156	For example statikusszakértő word
+always tömörítéssz 2345-12345-134-12345-1235-34-2345-16-234-156	For example tömörítésszabályozás word
+always elkeseredéssz 15-123-13-15-234-15-1235-15-145-16-234-156	For example elkeseredésszagot word
+always gyermektársszak 1456-15-1235-134-15-13-2345-4-1235-234-156-1-13	For example gyermektársszakmák word
+always optikussz 135-1234-2345-24-13-136-234-156	For example optikusszaküzletben word
+always elmélkedéssz 15-123-134-16-123-13-15-145-16-234-156	For example elmélkedésszerű word
+always aromássz 1-1235-135-134-4-234-156	For example aromásszénhidrogén word
+always füstölgéssz 124-12356-234-2345-12345-123-1245-16-234-156	For example füstölgésszerű word
+always elkövetéssz 15-123-13-12345-1236-15-2345-16-234-156	For example elkövetésszerű, elkövetésszemle word
+always tömítéssz 2345-12345-134-34-2345-16-234-156	For example tömítésszettek word
+always megadássz 134-15-1245-1-145-4-234-156	For example megadásszakértő word
+always digitálisszöv 145-24-1245-24-2345-4-123-24-234-156-12345-1236	For example digitálisszöveg word
+always hasszűkít 125-1-234-156-23456-13-34-2345	For example hasszűkítés word
+always csillapítássz 146-24-123-123-1-1234-34-2345-4-234-156	For example csillapításszabályozás word
+always értelmesszer 16-1235-2345-15-123-134-15-234-156-15-1235	For example értelmesszerű word
+always szipogássz 156-24-1234-135-1245-4-234-156	For example szipogásszezon word
+always keramikussz 13-15-1235-1-134-24-13-136-234-156	For example keramikusszakma word
+always kritikussz 13-1235-24-2345-24-13-136-234-156	For example kritikusszövetség word
+always vajákossz 1236-1-245-4-13-135-234-156	For example vajákosszer word
+always származássz 156-4-1235-134-1-126-4-234-156	For example származásszórás word
+always leépítéssz 123-15-16-1234-34-2345-16-234-156	For example leépítésszóval word
+always kvalitásszin 13-1236-1-123-24-2345-4-234-156-24-1345	For example kvalitásszintű word
+always humanitáriussz 125-136-134-1-1345-24-2345-4-1235-24-136-234-156	For example humanitáriusszervezet word
+always átveréssz 4-2345-1236-15-1235-16-234-156	For example átveréssztorit word
+always filmessztr 124-24-123-134-15-234-156-2345-1235	For example filmessztrájk word
+always kopássz 13-135-1234-4-234-156	For example kopásszint word
+always szennyezéssz 156-15-1246-1246-15-126-16-234-156	For example szennyezésszint word
+always lázadássz 123-4-126-1-145-4-234-156	For example lázadásszítás word
+always hencegéssz 125-15-1345-14-15-1245-16-234-156	For example hencegésszerű word
+always kerepléssz 13-15-1235-15-1234-123-16-234-156	For example kereplésszerű word
+always teológussz 2345-15-135-123-246-1245-136-234-156	For example teológusszakának word
+always támogatássz 2345-4-134-135-1245-1-2345-4-234-156	For example támogatásszűkítésről word
+always tudományossz 2345-136-145-135-134-4-1246-135-234-156	For example tudományosszakember word
+always zeneszerzéssz 126-15-1345-15-156-15-1235-126-16-234-156	For example zeneszerzésszakon word
+always lesszám 123-15-234-156-4-134	For example lesszám, lesszámhoz words
+always lábassz 123-4-12-1-234-156	For example lábasszínház word
+always tejessz 2345-15-245-15-234-156	For example tejesszék word
+always törlesztéssz 2345-12345-1235-123-15-156-2345-16-234-156	For example törlesztésszüneteltetés word
+always üvegessz 12356-1236-15-1245-15-234-156	For example üvegesszakma word
+always helyettessz 125-15-456-15-2345-2345-15-234-156	For example helyettesszent word
+always megbízássz 134-15-1245-12-34-126-4-234-156	For example megbízásszám word
+always szimfonikuszen 156-24-134-124-135-1345-24-13-136-234-126-15-1345	For example szimfonikuszene word
+always törésszer 2345-12345-1235-16-234-156-15-1235	For example törésszerű word
+always fogamzássz 124-135-1245-1-134-126-4-234-156	For example fogamzásszabályozási word
+always hússzilár 125-346-234-156-24-123-4-1235	For example hússzilárdsága word
+always kockászá 13-135-14-13-4-234-126-4	For example kockászászló word
+always elvtárssz 15-123-1236-2345-4-1235-234-156	For example elvtársszemély word
 
 #ty, tty related exceptions
 #This exception part containing english words with need presenting original english braille rules
@@ -2217,6 +2289,13 @@ always reformátuszs 1235-15-124-135-1235-134-4-2345-136-234-345	For example ref
 always kerítészs 13-15-1235-34-2345-16-234-345	For example kerítészsonglőrt word
 always biológuszs 12-24-135-123-246-1245-136-234-345	For example biológuszseni word
 always mézsűr 134-16-126-234-23456-1235 For example mézsűrűségen word
+always informatikuszs 24-1345-124-135-1235-134-1-2345-24-13-136-234-345	For example informatikuszseninek word
+always vitézser 1236-24-2345-16-126-234-15-1235	For example vitézsereg word
+always közzsarg 13-12345-126-345-1-1235-1245	For example közzsargon word
+always imázszón 24-134-4-345-126-246-1345	For example imázszóna word
+always komikuszs 13-135-134-24-13-136-234-345	For example komikuszseni word
+always gázsort 1245-4-126-234-135-1235-2345	For example könnygázsortűz word
+begword gázsáv 1245-4-126-234-4-1236	For example gázsávokkal word
 
 #Historical person names related exceptions
 always táncsics 2345-4-1345-146-24-146	Táncsics Mihály is a historical person for 1848. march 15 hungarian revolution

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -186,6 +186,7 @@ always kulcszón 13-136-123-146-126-246-1345	For example kulcszóna word
 always tekercsz 2345-15-13-15-1235-146-126	For example tekercszaja word
 always ferenccsá 124-15-1235-15-1345-14-146-4	For example ferenccsákja word
 always csúcszöl 146-346-146-126-12345-123	For example csúcszöld word
+always pöcszen 1234-12345-146-126-15-1345	For example pöcszenész word
 
 #gy, ggy related exceptions
 #This exception section containing word parts and full words with need marking ggy letter pairs with single g and gy braille dot combination


### PR DESCRIPTION
Hi Boys,

As it is usual between releases to releases, I added many new forward and backward translation exceptions with hungarian subtable files related (affected subtable files is tables/hu-exceptionwords.cti and tables/hu-backtranslate-word-corrections.cti file).

Review is easy, the first commit is not very large (only 328 lines), the first commit affects only with only hungarian subtable files.
The second commit contains new added and verifyed exceptions related testcase entries.
This new testcase entries I manual readed in my Braille-display before added the affected test dictionary file.
You not need reviewing the second commit (you dont will be wanting this), because the second commit patch is bigger, 828 lines. :-):-)
This commit affects only the hungarian language test case file, other languages test case files are not affected.

Usual test results:
General make -j8 check command into the tests directory: 200 tests passed, 1 test xfailed (equals the result with after the 3.27.0 release publication).
Make distwin command result my local machine: passed
Large hungarian Braille grade 1 local test yaml corpus test: 8819405 tests passed.
Will be have regression risks: no, because other languages braille quality are not affected.

My hungarian word collector program collected this new words when I extending the corpus database from news portal articles, hungarian books, etc.
I always see what new words are landed the database and filtering the new words with important braille rules related.

If this is possible, please add the 3.28.0 milestone this pull request, and merge this two commits into the master branch.

Attila