### PR TITLE
Further last-minute UEB improvements

### DIFF
--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -548,8 +548,10 @@ sign \x21b5 56-1256-256-146 ↵   Rules of UEB, page 21
 sign \x21c0 56-1256-4-1235 ⇀
 sign \x21c1 56-1256-6-1235 ⇁
 sign \x21cc 45-456-2356 ⇌   equilibrium arrow (harpoons)
-sign \x21d2 56-1256-2356-2356 ⇒
-
+sign \x21d0 56-1256-2356-246 ⇐
+sign \x21d1 56-1256-2356-346 ⇑
+sign \x21d2 56-1256-2356-135 ⇒
+sign \x21d3 56-1256-2356-146 ⇓
 
 #   Unicode:  Mathematical Operators
 

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -840,7 +840,7 @@ sufword arccosine 345-14-14-135-234-35-15
 # con   10.6.1   10.6.2   10.6.3   10.6.4
 empmatchafter match %[^_~]%<* con [Cc]![Hh] 25
 empmatchafter match %[^_~]%<* con [Ee][Ss][Tt] 25
-empmatchafter match %[^_~]%<* con s%a 25  [Cc][Oo][Nn][Ss]  "mod cons" 10.6.4
+empmatchafter match %[^_~]%<* con [Ss]%a 25  [Cc][Oo][Nn][Ss]  "mod cons" 10.6.4
 empmatchafter match %[^_~]%<* con [ABDFGHIJLMNOPQRTUVWXYZabdfghijlmnopqrtuvwxyz] 25
 sufword conakry 14-135-1345-1-13-1235-13456
 sufword conan  14-135-1345-1-1345
@@ -858,7 +858,7 @@ word dishy 145-24-146-13456
 word diss 145-24-234-234
 empmatchafter match %[^_~]%<* dis [Cc]![Ss'’] 256
 empmatchafter match %[^_~]%<* dis [Hh][Ee]![DSVdsv] 256
-empmatchafter match %[^_~]%<* dis [Hh]![BCCEFGHIKLMNPRTWbcdefghiklmnprtw'’] 256
+empmatchafter match %[^_~]%<* dis [Hh]![BCDEFGHIKLMNPRTWbcdefghiklmnprtw'’] 256
 empmatchafter match %[^_~]%<* dis [Pp]![Ii] 256
 empmatchafter match %[^_~]%<* dis [ABDEFGIJLMNOQRSTUVWXYZabdefgijlmnoqrstuvwxyz] 256
 

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -660,6 +660,7 @@ match %[^_]|%[^_~]%<*[([{] be %[^_]|[)}\\]]%>*%[^_~] 23
 word enough's 26-3-234
 word enough’s 26-3-234
 match %[^_~]([\\([{]*|[\\([{]+%<*) enough (%>*[\\)\\]}]+|[\\)\\]}]*)%[^_~] 26
+nofor lowword enough 26
 always enough 26-1256-126
 
 # his


### PR DESCRIPTION
3 last-minute commits for minor improvements to UEB table.
(apologies that GIT thinks there are far more changes)

1. Fix back translation of dots 26 - when standing alone; should be the word enough.
2. Fix assignment for the right double arrow and added left, up, and down double arrows.
3. Fix typos in a couple of rules.
4. This will fix words beginning CONS- and DISHD- when written uppercase.
Many thanks again.

