### PR TITLE
Added Norbert Márkus to the AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -194,6 +194,7 @@ TABLE AND TEST CONTRIBUTORS
   Neil Soiffer <NeilS@dessci.com>
   Nicolas Pitre <nico@cam.org>
   Nicolai Svendsen <chojiro1990@gmail.com>
+  Norbert Márkus 
   Oleh Shpai <shpak1704@gmail.com>
   Patrick Zajda
   Paul Rambags <paulrambags@dedicon.nl>


### PR DESCRIPTION
Hi Boys,

I have a suggestion that I have been thinking about for a long time:
Since February, Norbert has made very significant improvements to the file of the Liblouis math sub-table, in addition, in the case of the Hungarian language, he developed the Braille display of Greek letters all by himself the proper hungarian subtable (the subtable I already documented he with contributor), and brought the Nemeth Braille tables to the level of the Liblouisutdml project as much as possible. So, in Liblouisutdml level Norbert doed entire the nemeth.ctb and proper edit tables actualization related tasks (co-author), I provide only the technical support to Norbert have possibility only concentrate the table development.

If this is possible, I would like to suggest that you include Norbert in the Liblouis AUTHORS file among the table and test contributors, I think he deserves this honor.
Since Norbert is my colleague, and I know that he does not want to place his e-mail address in the AUTHORS file for the time being, I placed his name in the form of Norbert Márkus in my additional proposal in accordance with the English standard.
I don't know under what criteria someone can currently be included in the AUTHORS file, is there currently some set of rules that must be met in order to add someone to the list of official contributors.
I know for example if a people developing a full new table, usual landing right the AUTHORS file the proper place (with happened now for example the fillippino table author related), this is absolute right. But don't no what the situation with subtable related contributions level.

I hope you will accept my amendment proposal. If so, push this small change to the main branch.

Thank you in advance if you accept my suggestion positively, and sorry if my english not always right. :-):-)

Attila