### PR TITLE
Update UEB tests file to clarify that the UEB tests are not limited to rulebook examples

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -106,7 +106,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/en-GB-g2.yaml			  \
 	braille-specs/en-gb-g1_harness.yaml		  \
 	braille-specs/en-nabcc.yaml			  \
-	braille-specs/en-ueb-rueb.yaml	  		  \
+	braille-specs/en-ueb.yaml	  		  \
 	braille-specs/en-ueb-g1_backward.yaml		  \
 	braille-specs/en-ueb-g1_harness.yaml		  \
 	braille-specs/en-ueb-g2-dictionary_harness.yaml	  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -39,7 +39,7 @@ EXTRA_DIST =					\
 	en-GB-g2.yaml				\
 	en-gb-g1_harness.yaml			\
 	en-nabcc.yaml				\
-	en-ueb-rueb.yaml			\
+	en-ueb.yaml				\
 	en-ueb-g1_backward.yaml			\
 	en-ueb-g1_harness.yaml			\
 	en-ueb-g2-dictionary_harness.yaml	\

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -1,5 +1,9 @@
-# Examples from "The Rules of Unified English Braille"
-# <http://liblouis.io/braille-specs/english/#unified-english-braille-ueb>
+# Tests relating to the Unified English Braille Code. Initially this was comprised of the examples
+# published in "The Rules of Unified English Braille" (2013 edition), and the file follows the
+# structure of the UEB rulebook. However, additional tests and examples (not necessarily in the
+# rulebook) have also been added where required.
+#
+# Reference: <http://liblouis.io/braille-specs/english/#unified-english-braille-ueb>
 
 display: text_nabcc.dis
 table:


### PR DESCRIPTION
As suggested in the discussion at PR #1491, to avoid creating many different test files in response to individual issues, UEB table-related tests will be stored in a single YAML file. Historically this file contained only examples from the UEB rulebook, but this clarifies that the examples are not limited to that source.

(Submitted as a separate PR for clarity as the change has nothing to do with that PR.)