### PR TITLE
Add back translation for Belarusian and Ukrainian literary braille

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 liblouis NEWS -- history of user-visible changes.  	-*- org -*-
 
+* Noteworthy changes in release 3.29.0 (2024-03-04)
+
+** Braille table improvements
+- Added support for back translation to the Belarusian and Ukrainian literary
+  Braille tables (bel.utb and uk.utb respectively) thanks to Andrey Yakuboy.
+
 * Noteworthy changes in release 3.28.0 (2023-12-04)
 This release manages to bring as many new features, table improvements
 and bug fixes as we haven't seen in a long time. There are a number of

--- a/tables/bel.utb
+++ b/tables/bel.utb
@@ -5,9 +5,9 @@
 #+type: literary
 #+dots: 6
 #+contraction: no
-#+direction: forward
+#+direction: both
 
-#  Copyright (C) 2021 Andrey Yakuboy <braille@yakuboy.ru>
+#  Copyright (C) 2021, 2024 Andrey Yakuboy <braille@yakuboy.ru>
 #
 #  This file is part of liblouis.
 #
@@ -30,18 +30,32 @@
 #-maintainer: Andrey Yakuboy
 
 # The Belarusian alphabet has 2 letters that are not in the Russian
-# alphabet, namely І and Ў. Like in ru-litbrl.ctb, the
-# following definitions have dot 9 set to make them distinguishable
-# from the Latin letters.
+# alphabet, namely І and Ў.
 
-lowercase \x0456 134569  SMALL CYRILLIC LETTER I    і  # conflicts with definition in ru-litbrl.ctb
-lowercase \x045e 3469    CYRILLIC LETTER SHORT U    ў
+lowercase \x0456 13456  SMALL CYRILLIC LETTER I    і  # conflicts with definition in ru-litbrl.ctb
+lowercase \x045e 346    CYRILLIC LETTER SHORT U    ў
 
 # base rule for Ў (the base rule for І is already in ru-litbrl.ctb)
 base uppercase \x040e \x045e  CYRILLIC LETTER SHORT U    Ўў
+
+# Add dot 9 to additional Cyrillic characters, as in ru-litbrl.ctb
+
+noback always \x0456 134569
+noback always \x045e 3469
+
+noback always \x0406 134569
+noback always \x040e 3469
 
 include ru-litbrl.ctb
 
 # Extend classes defined in ru-litbrl.ctb
 attribute uppercyrillic \x040e
 attribute lowercyrillic \x045e
+
+# Back translation of additional letters
+
+nofor context #4=1@13456 "\x0406"#4=0
+nofor context #4=1@346 "\x040e"#4=0
+
+nofor context #4=2@13456 "\x0406"
+nofor context #4=2@346 "\x040e"

--- a/tables/ru-litbrl.ctb
+++ b/tables/ru-litbrl.ctb
@@ -450,7 +450,7 @@ noback	math	\x2217	35	# asterisk operator
 math	\x00b0	46-356
 noback	math	\x2103	46-356-46-14
 noback	math	\x2109	46-356-46-124
-math	\x221e	12456	# infinity
+noback	math	\x221e	12456	# infinity
 noback	math	\x222b	2346	# integral
 noback	math	\x222c	2346-2346	# double integral
 noback	math	\x222d	2346-2346-2346	# triple integral

--- a/tables/uk.utb
+++ b/tables/uk.utb
@@ -3,7 +3,7 @@
 
 #+language: uk
 #+type: literary
-#+direction: forward
+#+direction: both
 
 # -----------------
 # TODO: Please add a reference to official documentation about
@@ -13,10 +13,12 @@
 
 #-copyright: Bert Frees
 #-copyright: EAC "Lemur"
+#-copyright: Andrey Yakuboy
 #-license: LGPLv2.1
 
 #  Copyright (C) 2017 EAC "Lemur" <www.trosti.com.ua>
 #  Copyright (C) 2018 Bert Frees <bertfrees@gmail.com>
+#  Copyright (C) 2024 Andrey Yakuboy <braille@yakuboy.ru>
 #
 #  This file is part of liblouis.
 #
@@ -41,17 +43,27 @@
 # -----------------
 
 # The Ukrainian alphabet has 4 letters that are not in the Russian
-# alphabet, namely Є, І, Ї and Ґ. Like in ru-litbrl.ctb, the
-# following definitions have dot 9 set to make them distinguishable
-# from the Latin letters.
+# alphabet, namely Є, І, Ї and Ґ.
 
-lowercase \x0454 3459    CYRILLIC LETTER IE   є  # conflicts with definition in# ru-litbrl.ctb
-lowercase \x0456 134569  CYRILLIC LETTER I    і  # conflicts with definition in# ru-litbrl.ctb
-lowercase \x0457 14569   CYRILLIC LETTER II   ї  # conflicts with definition in# ru-litbrl.ctb
-lowercase \x0491 124569  CYRILLIC LETTER GE   ґ
+lowercase \x0454 345    CYRILLIC LETTER IE   є  # conflicts with definition in# ru-litbrl.ctb
+lowercase \x0456 13456  CYRILLIC LETTER I    і  # conflicts with definition in# ru-litbrl.ctb
+lowercase \x0457 1456   CYRILLIC LETTER II   ї  # conflicts with definition in# ru-litbrl.ctb
+lowercase \x0491 12456  CYRILLIC LETTER GE   ґ
 
 # base rule for Ґ (the base rules for Є, І and Ї are already in ru-litbrl.ctb)
 base uppercase \x0490 \x0491  CYRILLIC LETTER GE   Ґґ
+
+# Add dot 9 to additional Cyrillic characters, as in ru-litbrl.ctb
+
+noback always \x0454 3459
+noback always \x0456 134569
+noback always \x0457 14569
+noback always \x0491 124569
+
+noback always \x0404 3459
+noback always \x0406 134569
+noback always \x0407 14569
+noback always \x0490 124569
 
 # Ukrainian braille is largely the same as Russian braille
 include ru-litbrl.ctb
@@ -59,3 +71,15 @@ include ru-litbrl.ctb
 # Extend classes defined in ru-litbrl.ctb
 attribute uppercyrillic \x0490
 attribute lowercyrillic \x0491
+
+# Back translation of additional letters
+
+nofor context #4=1@345 "\x0404"#4=0
+nofor context #4=1@13456 "\x0406"#4=0
+nofor context #4=1@1456 "\x0407"#4=0
+nofor context #4=1@12456 "\x0490"#4=0
+
+nofor context #4=2@345 "\x0404"
+nofor context #4=2@13456 "\x0406"
+nofor context #4=2@1456 "\x0407"
+nofor context #4=2@12456 "\x0490"

--- a/tests/braille-specs/bel.yaml
+++ b/tests/braille-specs/bel.yaml
@@ -3,7 +3,7 @@
 # Initial version of this test was adapted from ru.yaml
 #
 # Copyright © 2018 by Sergiy Moskalets <www.trosti.com.ua>
-# Copyright © 2020-2021 by Andrey Yakuboy <braille@yakuboy.ru>
+# Copyright © 2020-2021, 2024 by Andrey Yakuboy <braille@yakuboy.ru>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,8 +19,8 @@ table:
   __assert-match: bel.utb
   contraction: no
   dots: 6
-tests:
 
+tests:
   - - У Іўі худы жвавы чорт у зялёнай камізэльцы пабег пад’есці фаршу з юшкай.
     - ⠥ ⠽⠬⠽ ⠓⠥⠙⠮ ⠚⠺⠁⠺⠮ ⠟⠕⠗⠞ ⠥ ⠵⠫⠇⠡⠝⠁⠯ ⠅⠁⠍⠽⠵⠪⠇⠾⠉⠮ ⠏⠁⠃⠑⠛ ⠏⠁⠙⠄⠑⠎⠉⠽ ⠋⠁⠗⠱⠥ ⠵ ⠳⠱⠅⠁⠯⠲
   - - 123,5+46=169,5
@@ -40,6 +40,12 @@ tests:
   - ['\x000a', '\x0020']
   - ['\x000c', '\x0020']
   - ['\x000d', '\x0020']
+
+flags: {testmode: backward}
+
+tests:
+  - - ⠘⠥ ⠘⠽⠬⠽ ⠓⠥⠙⠮ ⠚⠺⠁⠺⠮ ⠟⠕⠗⠞ ⠥ ⠵⠫⠇⠡⠝⠁⠯ ⠅⠁⠍⠽⠵⠪⠇⠾⠉⠮ ⠏⠁⠃⠑⠛ ⠏⠁⠙⠄⠑⠎⠉⠽ ⠋⠁⠗⠱⠥ ⠵ ⠳⠱⠅⠁⠯⠲
+    - У Іўі худы жвавы чорт у зялёнай камізэльцы пабег пад'есці фаршу з юшкай.
 
 # computer braille
 display: |

--- a/tests/braille-specs/uk.yaml
+++ b/tests/braille-specs/uk.yaml
@@ -3,7 +3,7 @@
 # Initial version of this test was adapted from ru.yaml
 #
 # Copyright © 2018 by Sergiy Moskalets <www.trosti.com.ua>
-# Copyright © 2020, 2022 by Andrey Yakuboy <braille@yakuboy.ru>
+# Copyright © 2020, 2022, 2024 by Andrey Yakuboy <braille@yakuboy.ru>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -41,6 +41,12 @@ tests:
   - - Єє Іі Її Ґґ
     - ⠘⠜⠜ ⠘⠽⠽ ⠘⠹⠹ ⠘⠻⠻
     - xfail: option to indicate capitals does not exist yet
+
+flags: {testmode: backward}
+
+tests:
+  - - ⠘⠺⠕⠝⠁ ⠍⠗⠽⠜ ⠏⠗⠕ ⠵⠽⠺⠄⠫⠇⠑ ⠇⠊⠎⠞⠫ ⠝⠁ ⠻⠁⠝⠅⠥⠂⠁⠇⠑ ⠹⠹ ⠍⠗⠽⠹ ⠝⠑ ⠵⠃⠥⠺⠁⠳⠞⠾⠎⠫⠲
+    - Вона мріє про зів'яле листя на ґанку, але її мрії не збуваються.
 
 # computer braille
 display: |


### PR DESCRIPTION
Hi! Haven't contributed to Liblouis for a while, got some free time! :-)

This commit adds back translation support for Ukrainian and Belarusian literary braille: additional letters that are not in the Russian alphabet can now be translated back.

I'll add a news entry a bit later!