### PR TITLE
Report an error if a character cannot be handled in 16 bit unicode

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1390,7 +1390,10 @@ parseChars(const FileInfo *file, CharsString *result, CharsString *token) {
 			result->length = lastOutSize;
 			return 1;
 		}
-		if (CHARSIZE == 2 && utf32 > 0xffff) utf32 = 0xffff;
+		if (CHARSIZE == 2 && utf32 > 0xffff) {
+		  compileError(file, "liblouis has not been compiled for 32-bit Unicode");
+		  return 1;
+		}
 		result->chars[out++] = (widechar)utf32;
 	}
 	result->length = out;


### PR DESCRIPTION
and liblouis has not been compiled for 32bit Unicode

Fixes #564

The problem is that our test suite has no way to filter out problems that are just because a table is not fit for ucs2. So CI fails because `tables/ja-kantenji.utb` fails to compile now with ucs2 liblouis