### PR TITLE
Added new forward and backward exceptions with hungarian subtables

### DIFF
--- a/tables/hu-backtranslate-word-corrections.cti
+++ b/tables/hu-backtranslate-word-corrections.cti
@@ -203,6 +203,16 @@ nofor correct "ÚCCSUK" "ÚCSCSUK"	For example CSÚCSCSUKÁRÓL word
 nofor correct "ronccsopo" "roncscsopo"	For example gumiabroncscsoport word
 nofor correct "Roncscsopo" "Roncscsopo"	For example Roncscsoport word
 nofor correct "RONCCSOPO" "RONCSCSOPO"	For example GUMIABRONCSCSOPORT word
+nofor correct "irgáccso" "irgácscso"	For example virgácscsokorral word
+nofor correct "IRGÁCCSO" "IRGÁCSCSO"	For example VIRGÁCSCSOKORRAL word
+nofor correct "apuccsosz" "apucscsosz"	For example papucscsoszogás word
+nofor correct "APUCCSOSZ" "APUCSCSOSZ"	For example PAPUCSCSOSZOGÁS word
+nofor correct "ulccsin" "ulcscsin"	For example kulcscsináló word
+nofor correct "ULCCSIN" "ULCSCSIN"	For example KULCSCSINÁLÓ word
+nofor correct "ganccsill" "gancscsill"	For example agancscsillár word
+nofor correct "GANCCSILL" "GANCSCSILL"	for example AGANCSCSILLÁR word
+nofor correct "aranccsop" "arancscsop"	For example parancscsoportosítás word
+nofor correct "ARANCCSOP" "ARANCSCSOP"	For example PARANCSCSOPORTOSÍTÁS word
 
 #ggy, gygy backtranslation rule corrections
 nofor correct "szalaggyak" *
@@ -408,6 +418,13 @@ nofor correct "ANYAGGYAN" *	For example ANYAGGYANÚ word
 nofor correct "néggyertyá" "négygyertyá"	For example négygyertyás word
 nofor correct "Néggyertyá" "Négygyertyá"	For example Négygyertyás word
 nofor correct "NÉGGYERTYÁ" "NÉGYGYERTYÁ"	For example NÉGYGYERTYÁS word
+nofor correct "léggyűjt" "légygyűjt"	For example légygyűjtemény word
+nofor correct "Léggyűjt" "Légygyűjt"	For example Légygyűjtemény word
+nofor correct "LÉGGYŰJT" "LÉGYGYŰJT"	For example LÉGYGYŰJTEMÉNY word
+nofor correct "nyaggyűj" *	For example anyaggyűjtögetést word
+nofor correct "NYAGGYŰJ" *	For example ANYAGGYŰJTÉS word
+nofor correct "veggyer" *	For example üveggyerek word
+nofor correct "VEGGYER" *	For example ÜVEGGYEREK word
 
 #nyny, nyny letters related backtranslate corrections
 nofor correct "rannyak" "ranynyak"	For example aranynyakláncának word
@@ -624,6 +641,20 @@ nofor correct "amlénnya" *	For example pamlénnyal word
 nofor correct "AMLÉNNYA" *	For example PAMLÉNNYAL word
 nofor correct "lménnyelv" "lménynyelv"	For example élménnynyelv word
 nofor correct "LMÉNNYELV" "LMÉNYNYELV"	For example ÉLMÉNYNYELV word
+nofor correct "igannyo" "iganynyo"	For example higanynyomokat word
+nofor correct "IGANNYO" "IGANYNYO"	For example HIGANYNYOMOKAT word
+nofor correct "idénnyaral" "idénynyaral"	For example idénynyaralók word
+nofor correct "Idénnyaral" "Idénynyaral"	For example Idénynyaralók word
+nofor correct "IDÉNNYARAL" "IDÉNYNYARAL"	For example IDÉNYNYARALÓK word
+nofor correct "lőnnyú" "lőnynyú"	For example előnynyújtás word
+nofor correct "LŐNNYÚ" "LŐNYNYÚ"	For example ELŐNYNYÚJTÁS word
+nofor correct "ínnyugt" "ínynyugt"	For example fogínynyugtató word
+nofor correct "Ínnyugt" "Ínynyugt"	For example Ínynyugtató word
+nofor correct "ÍNNYUGT" "ÍNYNYUGT"	For example FOGÍNYNYUGTATÓ word
+nofor correct "svánnyo" "sványnyo"	For example ásványnyomokban word
+nofor correct "SVÁNNYO" "SVÁNYNYO"	For example ÁSVÁNYNYOMOKBAN word
+nofor correct "génnyil" "génynyil"  For example igénynyilatkozatának word
+nofor correct "GÉNNYIL" "GÉNYNYIL"  For example IGÉNYNYILATKOZATÁNAK word
 
 #lyly letters related backtranslate corrections
 nofor correct "amelylyel" *
@@ -797,8 +828,8 @@ nofor correct "itnesszala" "itneszszala"	For example fitneszszalag word backtran
 nofor correct "ITNESSZALA" "ITNESZSZALA"	For example FITNESZSZALAG word
 nofor correct "itnessztá" "itneszsztá"	For example fitneszsztár word
 nofor correct "ITNESSZTÁ" "ITNESZSZTÁ"	For example FITNESZSZTÁR word
-nofor correct "itnesszolg" "itneszszolg"	For example fitneszszolgáltatás word backtranslation correction
-nofor correct "ITNESSZOLG" "ITNESZSZOLG"	For example FITNESZSZOLGÁLTATÁS word
+nofor correct "itnesszo" "itneszszo"	For example fitneszszobát, fitneszszolgáltatás word backtranslation correction
+nofor correct "ITNESSZO" "ITNESZSZO"	For example FITNESZSZOBÁT, FITNESZSZOLGÁLTATÁS word
 nofor correct "itnesszö" "itneszszö"	For example fitneszszövetség word
 nofor correct "ITNESSZÖ" "ITNESZSZÖ"	For example FITNESZSZÖVETSÉG word
 nofor correct "itnesszüne" "itneszszüne"	For example fitneszszünet word backtranslation correction
@@ -1651,8 +1682,10 @@ nofor correct "ÖSSZÍN" "ÖSZSZÍN"	For example LÖSZSZÍN word
 nofor correct "tússzer" "túszszer"	For example túszszerű word
 nofor correct "Tússzer" "Túszszer"	For example Túszszerű word
 nofor correct "TÚSSZER" "TÚSZSZER"	For example TÚSZSZERŰ word
-nofor correct "itnesszek" "itneszszek"	For example fitneszszektor word
-nofor correct "ITNESSZEK" "ITNESZSZEK"	For example FITNESZSZEKTOR word
+nofor correct "itnesszel" *	For example fitnesszel word
+nofor correct "ITNESSZEL" *	For example FITNESSZEL word
+nofor correct "itnessze" "itneszsze"	For example fitneszszektor, fitneszszemmel words
+nofor correct "ITNESSZE" "ITNESZSZE"	For example FITNESZSZEKTOR, FITNESZSZEMMEL words
 nofor correct "idásszakm" "idászszakm"	For example hidászszakma word
 nofor correct "IDÁSSZAKM" "IDÁSZSZAKM"	For example HIDÁSZSZAKMA WORD
 nofor correct "oksszáll" "okszszáll"	For example kokszszállítás word
@@ -1787,8 +1820,8 @@ nofor correct "ésszemecs" "észszemecs"	For example mészszemecskéket word
 nofor correct "ÉSSZEMECS" "ÉSZSZEMECS"	For example MÉSZSZEMECSKÉKET word
 nofor correct "énisszöve" "éniszszöve"	For example péniszszövethez word
 nofor correct "ÉNISSZÖVE" "ÉNISZSZÖVE"	For example PÉNISZSZÖVETHEZ word
-nofor correct "irkusszer" "irkuszszer"	For example cirkuszszerű word
-nofor correct "IRKUSSZER" "IRKUSZSZER"	For example CIRKUSZSZERŰ word
+nofor correct "irkussze" "irkuszsze"	For example cirkuszszekcióban, cirkuszszerű word
+nofor correct "IRKUSSZE" "IRKUSZSZE"	For example CIRKUSZSZEKCIÓBAN, CIRKUSZSZERŰ word
 nofor correct "vénnyilvá" "vénynyilvá"	For example vénynyilvántartás word
 nofor correct "Vénnyilvá" "Vénynyilvá"	For example Vénynyilvántartás word
 nofor correct "VÉNNYILVÁ" "VÉNYNYILVÁ"	For example VÉNYNYILVÁNTARTÁS word
@@ -2298,6 +2331,128 @@ nofor correct "ússzüne" "úszszüne"	For example túszszünet word
 nofor correct "ÚSSZÜNE" "ÚSZSZÜNE"	For example TÚSZSZÜNET word
 nofor correct "iszkossze" "iszkoszsze"	For example diszkoszszerű word
 nofor correct "ISZKOSSZE" "ISZKOSZSZE"	For example DISZKOSZSZERŰ word
+nofor correct "ányásszül" "ányászszül"	For example bányászszülők word
+nofor correct "ÁNYÁSSZÜL" "ÁNYÁSZSZÜL"	For example BÁNYÁSZSZÜLŐK word
+nofor correct "álasszlo" "álaszszlo"	For example válaszszlogennel word
+nofor correct "ÁLASSZLO" "ÁLASZSZLO"	For example VÁLASZSZLOGENNEL word
+nofor correct "isiásszer" "isiászszer"	For example isiászszerű word
+nofor correct "Isiásszer" "Isiászszer"  For example Isiászszerű word
+nofor correct "ISIÁSSZER" "ISIÁSZSZER"	For example ISIÁSZSZERŰ word
+nofor correct "lusszenv" "luszszenv"	For example pluszszenvedést word
+nofor correct "LUSSZENV" "LUSZSZENV"	For example PLUSZSZENVEDÉST word
+nofor correct "lfogássz" *	For example felfogásszemlélet word
+nofor correct "LFOGÁSSZ" *	For example FELFOGÁSSZEMLÉLET word
+nofor correct "égésszenv" "égészszenv"	For example régészszenvedéllyel word
+nofor correct "ÉGÉSSZENV" "ÉGÉSZSZENV"	For example RÉGÉSZSZENVEDÉLLYEL word
+nofor correct "mésszállí" "mészszállí"	For example mészszállítmánnyal word
+nofor correct "Mésszállí" "Mészszállí"	For example mészszállítmány word
+nofor correct "MÉSSZÁLLÍ" "MÉSZSZÁLLÍ"	For example MÉSZSZÁLLÍTMÁNY word
+nofor correct "epesszer" "epeszszer"	For example repeszszerű word
+nofor correct "EPESSZER" "EPESZSZER"	For example REPESZSZERŰ word
+nofor correct "erasszig" "eraszszig"	For example teraszszigetelés word
+nofor correct "ERASSZIG" "ERASZSZIG"	For example TERASZSZIGETELÉS word
+nofor correct "úcsdísszet" "úcsdíszszet"	For example csúcsdíszszettet word
+nofor correct "ÚCSDÍSSZET" "ÚCSDÍSZSZET"	For example CSÚCSDÍSZSZETTET word
+nofor correct "aritásszen" "aritászszen"	For example karitászszentmise word
+nofor correct "ARITÁSSZE" "ARITÁSZSZE"	For example KARITÁSSZENTMISE word
+nofor correct "lusszala" "luszszala"	For example pluszszalag word
+nofor correct "LUSSZALA" "LUSZSZALA"	For example PLUSZSZALAG word
+nofor correct "akasszig" "akaszszig"	For example szakaszszigetelés word
+nofor correct "AKASSZIG" "AKASZSZIG"	For example SZAKASZSZIGETELÉS word
+nofor correct "ússzeké" "úszszeké"	For example húszszekérnyi word
+nofor correct "ÚSSZEKÉ" "ÚSZSZEKÉ"	For example HÚSZSZEKÉRNYI word
+nofor correct "itelezéssze" *	For example hitelezésszegény word
+nofor correct "ITELEZÉSSZE" *	For example HITELEZÉSSZEGÉNY word
+nofor correct "gyásszegélyű" "gyászszegélyű"	For example gyászszegélyű word
+nofor correct "Gyásszegélyű" "Gyászszegélyű"	For example Gyászszegélyű word
+nofor correct "GYÁSSZEGÉLYŰ" "GYÁSZSZEGÉLYŰ"	For example GYÁSZSZEGÉLYŰ word
+nofor correct "bortusszö" "bortuszszö"	For example abortuszszökevény word
+nofor correct "BORTUSSZÖ" "BORTUSZSZÖ"	For example ABORTUSZSZÖKEVÉNY word
+nofor correct "adogásszer" *	For example dadogásszerű word
+nofor correct "ADOGÁSSZER" *	For example DADOGÁSSZERŰ word
+nofor correct "itnessző" "itneszsző"	For example fitneszszőnyeg word
+nofor correct "ITNESSZŐ" "ITNESZSZŐ"	For example FITNESZSZŐNYEG word
+nofor correct "oksszák" "okszszák"	For example bokszszákot word
+nofor correct "OKSSZÁK" "OKSZSZÁK"	For example BOKSZSZÁKOT word
+nofor correct "orgásszto" "orgászszto"	For example horgászsztori word
+nofor correct "ORGÁSSZTO" "ORGÁSZSZTO"	For example HORGÁSZSZTORI word
+nofor correct "edésszer" *	For example átfedésszerűen word
+nofor correct "EDÉSSZER" *	For example ÁTFEDÉSSZERŰEN word
+nofor correct "össztye" "öszsztye"	For example löszsztyepp word
+nofor correct "ÖSSZTYE" "ÖSZSZTYE"	For example LÖSZSZTYEPP word
+nofor correct "ítosszé" "ítoszszé"	For example mítoszszédelgés word
+nofor correct "ÍTOSSZÉ" "ÍTOSZSZÉ"	For example MÍTOSZSZÉDELGÉS word
+nofor correct "ipogássze" *	For example csipogásszerű word
+nofor correct "IPOGÁSSZE" *	For example CSIPOGÁSSZERŰ word
+nofor correct "ísszu" "íszszu"	For example díszszurkolója word
+nofor correct "ÍSSZU" "ÍSZSZU"	For example DÍSZSZURKOLÓJA word
+nofor correct "tónussza" *	For example tónusszabályozás word
+nofor correct "Tónussza" *	For example Tónusszabályozás word
+nofor correct "TÓNUSSZA" *	For example TÓNUSSZABÁLYOZÁS word
+nofor correct "eresszell" "ereszszell"	For example ereszszellőző word
+nofor correct "Eresszell" "Ereszszell"	For example Ereszszellőző word
+nofor correct "ERESSZELL" "ERESZSZELL"	For example ERESZSZELLŐZŐ word
+nofor correct "enésszleng" "enészszleng"	For example zenészszlengben word
+nofor correct "ENÉSSZLENG" "ENÉSZSZLENG"	For example ZENÉSZSZLENGBEN word
+nofor correct "enisszem" "eniszszem"	For example teniszszempontból word
+nofor correct "ENISSZEM" "ENISZSZEM"	For example TENISZSZEMPONTBÓL word
+nofor correct "eniszkusszö" "eniszkuszszö"	For example meniszkuszszövet word
+nofor correct "ENISZKUSSZÖ" "ENISZKUSZSZÖ"	For example MENISZKUSZSZÖVET word
+nofor correct "apassze" "apaszsze"	For example ragtapaszszerű word
+nofor correct "APASSZE" "APASZSZE"	For example RAGTAPASZSZERŰ word
+nofor correct "imnusszto" "imnuszszto"	For example himnuszsztori word
+nofor correct "IMNUSSZTO" "IMNUSZSZTO"	For example HIMNUSZSZTORI word
+nofor correct "adásszékk" "adászszékk"	For example vadásszékkel word
+nofor correct "ADÁSSZÉKK" "ADÁSZSZÉKK"	For example VADÁSZSZÉKKEL word
+nofor correct "munkássz" *	For example munkásszázad word
+nofor correct "Munkássz" *	For example Munkásszázad word
+nofor correct "MUNKÁSSZ" *	For example MUNKÁSSZÁZAD word
+nofor correct "idásszáz" *	For example dzsidásszázad word
+nofor correct "IDÁSSZÁZ" *	For example DZSIDÁSSZÁZAD word
+nofor correct "uskásszáz" *	For example puskásszázad word
+nofor correct "USKÁSSZÁZ" *	For example PUSKÁSSZÁZAD word
+nofor correct "ásszáza" "ászszáza"	For example ászszázad word
+nofor correct "Ásszáza" "Ászszáza"	For example Ászszázad word
+nofor correct "ÁSSZÁZA" "ÁSZSZÁZA"	For example ÁSZSZÁZAD word
+nofor correct "átosszag" "átoszszag"	For example pátoszszagú word
+nofor correct "ÁTOSSZAG" "ÁTOSZSZAG"	For example PÁTOSZSZAGÚ word
+nofor correct "tússzáll" "túszszáll"	For example túszszállítás word
+nofor correct "Tússzáll" "Túszszáll"	For example Túszszállítás word
+nofor correct "TÚSSZÁLL" "TÚSZSZÁLL"	For example TÚSZSZÁLLÍTÁS word
+nofor correct "busszob" "buszszob"	For example buszszoba word
+nofor correct "Busszob" "Buszszob"	For example Buszszoba word
+nofor correct "BUSSZOB" "BUSZSZOB"	For example BUSZSZOBA word
+nofor correct "dásszárny" "dászszárny"	For example vadászszárnya word
+nofor correct "DÁSSZÁRNY" "DÁSZSZÁRNY"	For example VADÁSZSZÁRNYA word
+nofor correct "avasszer" "avaszszer"	For example tavaszszerű word
+nofor correct "AVASSZER" "AVASZSZER"	For example TAVASZSZERŰ word
+nofor correct "ányásszi" "ányászszi"	For example bányászszimulátor word
+nofor correct "ÁNYÁSSZI" "ÁNYÁSZSZI"	For example BÁNYÁSZSZIMULÁTOR word
+nofor correct "ússzava" "úszszava"	For example húszszavas word
+nofor correct "ÚSSZAVA" "ÚSZSZAVA"	For example HÚSZSZAVAS word
+nofor correct "ákássze" "ákászsze"	For example rákászszezon word
+nofor correct "ÁKÁSSZE" "ÁKÁSZSZE"	For example RÁKÁSZSZEZON word
+nofor correct "erítéssze" *	For example kerítésszegély word
+nofor correct "ERÍTÉSSZE" *	For example KERÍTÉSSZEGÉLY word
+nofor correct "resszök" "reszszök"	For example ereszszökevény word
+nofor correct "RESSZÖK" "RESZSZÖK"	For example ERESZSZÖKEVÉNY word
+nofor correct "lusszú" "luszszú"	For example pluszszúrás word
+nofor correct "LUSSZÚ" "LUSZSZÚ"	For example PLUSZSZÚRÁS word
+nofor correct "hányásszer" *	For example hányásszerű word
+nofor correct "Hányásszer" *	For example Hányásszerű word
+nofor correct "HÁNYÁSSZER" *	For example HÁNYÁSSZERŰ word
+nofor correct "ütyöréssze" *	For example fütyörésszen word
+nofor correct "ÜTYÖRÉSSZE" *	For example FÜTYÖRÉSSZEN word
+nofor correct "lusszilár" "luszszilár"	For example pluszszilárdsága word
+nofor correct "LUSSZILÁR" "LUSZSZILÁR"	For example PLUSZSZILÁRDSÁGGAL word
+nofor correct "ajusszárn" "ajuszszárn"	For example harcsabajuszszárnya word
+nofor correct "AJUSSZÁRN" "AJUSZSZÁRN"	For example HARCSABAJUSZSZÁRNYA word
+nofor correct "ertésszó" *	For example sertésszósz word
+nofor correct "ERTÉSSZÓ" *	For example SERTÉSSZÓSZ word
+nofor correct "oksszokny" "okszszokny"	For example bokszszoknyát word
+nofor correct "OKSSZOKNY" "OKSZSZOKNY"	For example BOKSZSZOKNYÁT word
+nofor correct "elkéssza" "elkészsza"	For example lelkészszakon word
+nofor correct "ELKÉSSZA" "ELKÉSZSZA"	For example LELKÉSZSZAKON word
 
 #zszs backtranslated word corrections
 nofor correct "törzszsel" "törzzsel"

--- a/tables/hu-exceptionwords.cti
+++ b/tables/hu-exceptionwords.cti
@@ -169,6 +169,9 @@ always arcstru 1-1235-14-234-2345-1235-136	For example arcstruktúra word
 always arcsál 1-1235-14-234-4-123	For example arcsál word
 always élcsor 16-123-14-234-135-1235	For example élcsor word
 always perccse 1234-15-1235-14-146-15	For example perccsepp word
+always hóláncspra 125-246-123-4-1345-14-234-1234-1235-1	For example hóláncspray word
+always kedvencsé 13-15-145-1236-15-1345-14-234-16	For example kedvencség word
+always orbánccs 135-1235-12-4-1345-14-146	For example orbánccsalád word
 
 #csz letters related exceptions
 always pöcszong 1234-12345-146-126-135-1345-1245	For example pöcszongorás word
@@ -187,6 +190,7 @@ always tekercsz 2345-15-13-15-1235-146-126	For example tekercszaja word
 always ferenccsá 124-15-1235-15-1345-14-146-4	For example ferenccsákja word
 always csúcszöl 146-346-146-126-12345-123	For example csúcszöld word
 always pöcszen 1234-12345-146-126-15-1345	For example pöcszenész word
+always csúcszuh 146-346-146-126-136-125	For example csúcszuhanás word
 
 #gy, ggy related exceptions
 #This exception section containing word parts and full words with need marking ggy letter pairs with single g and gy braille dot combination
@@ -298,7 +302,7 @@ partword hűség =	For example hűséggyűrűsök word related need this general
 partword maggyűj 134-1-1245-1456-23456-245	For example maggyűjtemény word
 partword népesség =	For example népességgyarapodás word related need this exception
 partword örökség =	For example örökséggyűjteményben word related need this exception
-begword szeggyá 156-15-1245-1456-4	For example szeggyár word
+always szeggyá 156-15-1245-1456-4	For example szeggyár word
 partword tisztséggy 2345-24-156-2345-234-16-1245-1456	For example tisztséggyűjtemény word
 begword szalaggyakor 156-1-123-1-1245-1456-1-13-135-1235	For example szalaggyakorlatát word
 partword szalaggyűj 156-1-123-1-1245-1456-23456-245	For example szalaggyűjteménye, hangszalaggyűjtemény, lyukszalaggyűjtemény words related need this general exception
@@ -481,6 +485,46 @@ always honvédséggy 125-135-1345-1236-16-145-234-16-1245-1456	For example honv�
 always legesleggyor 123-15-1245-15-234-123-15-1245-1456-135-1235	For example legesleggyorsabb word
 always göngyöleggy 1245-12345-1345-1456-12345-123-15-1245-1456	For example göngyöleggyártás word
 always löveggy 123-12345-1236-15-1245-1456	For example löveggyilkos word
+always hanggyer 125-1-1345-1245-1456-15-1235	For example hanggyertya word
+always döggyűj 145-12345-1245-1456-23456-245	For example döggyűjtemény word
+always joggyar 245-135-1245-1456-1-1235	For example joggyarapító, joggyarmatosító words
+always joggyőz 245-135-1245-1456-12456-126	For example joggyőzelem word
+always céggy 14-16-1245-1456	For example céggyártás, céggyűjtemény word
+always egyéniséggy 15-1456-16-1345-24-234-16-1245-1456	For example egyéniséggyilkos word
+always nedvességgy 1345-15-145-1236-15-234-234-16-1245-1456	For example nedvességgyöngy, nedvességgyűjtő words
+always pékséggy 1234-16-13-234-16-1245-1456	For example pékséggyógyulás word
+always kiborggy 13-24-12-135-1235-1245-1456	For example kiborggyártó, kiborggyár words
+always általánossággy 4-123-2345-1-123-4-1345-135-234-234-4-1245-1456	For example általánossággyűjtemény word
+always barátsággy 12-1-1235-4-2345-234-4-1245-1456	For example barátsággyűrűt word
+always bloggy 12-123-135-1245-1456	For example bloggyilkos, bloggyűjtemény, bloggyűjtő words
+always csomaggy 146-135-134-1-1245-1456	For example csomaggyár, csomaggyorsítótár, csomaggyűjtés words
+always döggyűj 145-12345-1245-1456-23456-245	For example döggyűjtemény word
+always gazdasággy 1245-1-126-145-1-234-4-1245-1456	For example gazdasággyilkos word
+always geggyű 1245-15-1245-1456-23456	For example geggyűjtemény word
+always haraggy 125-1-1235-1-1245-1456	For example haraggyűjtögetés word
+always ifjúsággy 24-124-245-346-234-4-1245-1456	For example ifjúsággyógyászati word
+always ággyil 4-1245-1456-24-123	For example ággyilkos, ifjúsággyilkos, szabadsággyilkos words
+always ggyár 1245-1456-4-1235	For example igassággyártás word
+always reggyűr 1235-15-1245-1456-23456-1235	For example kéreggyűrődés, méreggyűrű words
+always kisebbséggy 13-24-234-15-12-12-234-16-1245-1456	For example kisebséggyűlöletét word
+always ggyönyör 1245-1456-12345-1246-12345-1235	For example legesleggyönyörűbb word
+always lózunggy 123-246-126-136-1345-1245-1456	For example lózunggyűjtemény word
+always meddőséggy 134-15-145-145-12456-234-16-1245-1456	For example meddőséggyanús word
+always meggyözön 134-15-1456-1456-12345-126-12345-1345	For example meggyözön word
+always léggyőz 123-16-1245-1456-12456-126	For example léggyőzelmet word
+always nyereséggy 1246-15-1235-15-234-16-1245-1456	For example nyereséggyakorlatát word
+always pudinggy 1234-136-145-24-1345-1245-1456	For example pudinggyümölcs word
+always ággyógy 4-1245-1456-246-1456	For example sárgasággyógyítók, világgyógyszer words
+always segítséggy 234-15-1245-34-2345-234-16-1245-1456	For example segítséggyújtás word
+always serleggy 234-15-1235-123-15-1245-1456	For example serleggyűjtés word
+always zuggy 126-136-1245-1456	For example szájzuggyulladás, zuggyógyszer words
+always szalaggy 156-1-123-1-1245-1456	For example szalaggyulladás, szalaggyengeség words
+always taggyű 2345-1-1245-1456-2345	For example taggyűlési word
+always ügyészséggy 12356-1456-16-156-234-16-1245-1456	For example ügyészséggyújtogató word
+always hatékonysággy 125-1-2345-16-13-135-1246-234-4-1245-1456	For example hatékonysággyilkos word
+always maggyú 134-1-1245-1456-346	For example vasmaggyújtó word
+always barátsággy 12-1-1235-4-2345-234-4-1245-1456	For example barátsággyűrű, barátsággyilkos word
+always orvossággy 135-1235-1236-135-234-234-4-1245-1456	For example orvossággyűjtő word
 
 #ny, nny related exceptions
 #Following exception parts need marking nny letter pairs with single n and nny braille dot combinations
@@ -643,6 +687,11 @@ always londonny 123-135-1345-145-135-1345-1246	For example londonnyi word
 always fotonny 124-135-2345-135-1345-1246	Fotonnyaláb word
 always fűtésszezonny 124-23456-2345-16-234-156-15-126-135-1345-1246	For example fűtésszezonnyi word
 always patronny 1234-1-2345-1235-135-1345-1246	For example patronnyi word
+always banánny 12-1-1345-4-1345-1246	For example banánnyi, banánnyársak word
+always nikotinny 1345-24-13-135-2345-24-1345-1246	For example nikotinnyalókák word
+always kanonny 13-1-1345-135-1345-1246	For example kanonnyi word
+always ikonny 24-13-135-1345-1246	For example ikonnyomkodás word
+always nejlonny 1345-15-245-123-135-1345-1246	For example nejlonnyilas word
 
 #ly related exceptions
 #This exception parts need marking ly letters with two single l and y letter combination
@@ -656,6 +705,7 @@ partword grizzly =	For example grizzlymedvék beginning word exception, or apagr
 word grizly =	For example grizly single word
 word grizzly =	For example grizzly single word exception
 begword lyukaszász 456-136-13-1-234-126-4-156	For example lyukaszászló-adományozással word
+always iparoszá 24-1234-1-1235-135-234-126-4	For example iparoszászló word
 
 #sz letter pair related exceptions
 #This exception list containing words or word parts need using single s and z letter dot combinations
@@ -727,6 +777,7 @@ always földrengész 124-12345-123-145-1235-15-1345-1245-16-234-126	For example 
 always számítógépeszen 156-4-134-34-2345-246-1245-16-1234-15-234-126-15-1345	For example számítógépeszene word
 always gyömöszöld 1456-12345-134-12345-156-12345-123-145	For example belegyömöszöld word
 always tudászón 2345-136-145-4-234-126-246-1345	For example tudászóna word
+always verszárl 1236-15-1235-234-126-4-1235-123	For example verszárlat word
 
 #szs related exceptions
 #This exception list containing some words with need using single s and zs braille dots
@@ -810,11 +861,23 @@ always stíluszen 234-2345-34-123-136-234-126-15-1345	For example stíluszenész
 always fejlesztészá 124-15-245-123-15-156-2345-16-234-126-4	For example fejlesztészáró word
 always húszabál 125-346-234-126-1-12-4-123	For example húszabálók word
 always verszene 1236-15-1235-234-126-15-1345-15	For example verszene word
-always pulzuszón 1234-136-123-126-136-234-126-246-1345	For example pulzuszónában word
+always pulzusz 1234-136-123-126-136-234-126	For example pulzuszónában word
 always verszará 1236-15-1235-234-126-1-1235-4	For example verszarándoklat word
 always töltész 2345-12345-123-2345-16-234-126	For example töltészápor word
 always adászárá 1-145-4-234-126-4-1235-4	For example adászárás word
 always kiadászá 13-24-1-145-4-234-126-4	For example kiadászárolás word
+always döntészuh 145-12345-1345-2345-16-234-126-136-125	For example döntészuhatag word
+always csapászó 146-1-1234-4-234-126-246	For example csapászónának word
+always páncéloszt 1234-4-1345-14-16-123-135-156-2345	For example páncélosztály, 
+always dartszsen 145-1-1235-2345-234-345-15-1345	For example dartszseni word
+always szaklat 234-126-1-13-123-1-2345		For example kortárszaklatás, víruszaklatás words
+always szsen 234-345-15-1345	For example kortárszseni, orvoszseni words
+always járász 245-4-1235-4-234-126	For example járászavar word
+always ízspek 34-126-234-1234-15-13	For example ízspektrum word
+always frízsá 124-1235-34-126-234-4	For example frízsáv word
+always sztriptízsh 156-2345-1235-24-1234-2345-34-126-234-125	For example sztriptízshow word
+always vaszk 1236-1-156-13	For example Vaszkóné word
+begword adászón 1-145-4-234-126-246-1345	For example adászóna word
 
 #ssz related exceptions
 #Following exception words and word parts need writing one s and one sz braille letter
@@ -2019,7 +2082,7 @@ begword társzen 2345-4-1235-234-126-15-1345	For example társzenekar word
 always hősszin 125-12456-234-156-24-1345	For example szuperhősszindróma word
 always hősszto 125-12456-234-156-2345-135	For example szuperhősszindróma word
 always vonószá 1236-135-1345-246-156-4	For example vonószárára word
-always lehúzássz 123-15-1235-346-126-4-234-156	For example lehúzásszagú word
+always húzássz 125-346-126-4-234-156	For example lehúzásszagú word
 always jelentész 245-15-123-15-1345-2345-16-234-126	For example jelentészaj, jelentészavarás word
 always billenéssz 12-24-123-123-15-1345-16-234-156	For example billenésszabályozás word
 always keléssz 13-15-123-16-234-156	For example kelésszám word
@@ -2135,6 +2198,57 @@ always rigmussz 1235-24-1245-134-136-234-156	For example rigmusszöveg word
 always cipőssz 14-24-1234-12456-234-156	For example cipősszekrény word
 always hússzenny 125-346-234-156-15-1246-1246	For example hússzennyezés word
 always uszítássz 136-156-34-2345-4-234-156	For example uszításszerű, uszításszabadság word
+always bőgéssz 12-12456-1245-16-234-156	For example bőgésszezon word
+always hajlítássz 125-1-245-123-34-2345-4-234-156	For example hajlításszámot word
+always válogatássz 1236-4-123-135-1245-1-2345-4-234-156	For example válogatásszámban word
+always felfogássz 124-15-123-124-135-1245-4-234-156	For example felfogásszemlélet word
+always affektussz 1-124-124-15-13-2345-136-234-156	For example affektusszabályozás word
+always szerepléssz 156-15-1235-15-1234-123-16-234-156	For example szereplésszámot word
+always díszítéssz 145-34-156-34-2345-16-234-156	For example díszítésszavazás word
+always asszisztenssz 1-156-156-24-156-2345-15-1345-234-156	For example asszisztensszámot word
+always gyűjtéssz 1456-23456-245-2345-16-234-156	For example gyűjtésszerű, gyűjtésszemét words
+always pelussz 1234-15-123-136-234-156	For example pelussztrájk word
+always sodrássz 234-135-145-1235-4-234-156	For example sodrásszerű word
+always szőrössző 156-12456-1235-12345-234-156-12456	For example szőrösszőnyeg word
+always koefficienssz 13-135-15-124-124-24-14-24-15-1345-234-156	For example koefficiensszámítás word
+always hitelezéssz 125-24-2345-15-123-15-126-16-234-156	For example hitelezésszegény word
+always búcsúzássz 12-346-1246-346-126-4-234-156	For example búcsúzásszaga word
+always felszólalássz 124-15-123-156-246-123-1-123-4-234-156	For example felszólalásszámmal word
+always reagálássz 1235-15-1-1245-4-123-4-234-156	For example reagálásszint word
+always klasszissz 13-123-1-156-156-24-234-156	For example klasszisszint word
+always aszkézissz 1-156-13-16-126-24-234-156	For example aszkézisszintű word
+always megszűnéssz 134-15-1245-156-23456-1345-16-234-156	For example megszűnésszám word
+always árkussz 4-1235-13-136-234-156	For example árkusszám word
+always fizetéssz 124-24-126-15-2345-16-234-156	For example fizetésszám, fizetésszerű words
+always értesítéssz 16-1235-2345-15-234-34-2345-16-234-156	For example értesítésszöveg word
+always elektromossz 15-123-15-13-2345-1235-135-134-135-234-156	For example elektromosszemét word
+always cigizéssz 14-24-1245-24-126-16-234-156	For example cigizésszámláló word
+always társzene 2345-4-1235-234-126-15-1345-15  For example kortárszene word
+always fedéssz 124-15-145-16-234-156	For example átfedésszerűen word
+always totalitássz 2345-135-2345-1-123-24-2345-4-234-156	For example totalitásszemlélet word
+always mulasztássz 134-136-123-1-156-2345-4-234-156	For example mulasztásszagú word
+always riogatássz 1235-24-135-1245-1-2345-4-234-156	For example riogatásszámba word
+always tekintéssz 2345-15-13-24-1345-2345-16-234-156	For example megtekintésszintű word
+always tónussz 2345-246-1345-136-234-156	For example féltónusszintje, izomtónusszintje, tónusszabályozás words
+always fűszeressz 124-23456-156-15-1235-15-234-156	For example fűszeresszelence word
+always kémikussz 13-16-134-24-13-136-234-156	For example kémikusszett word
+always cenzussz 14-15-1345-126-136-234-156	For example cenzusszerkezet word
+always várássz 1236-4-1235-4-234-156	For example elvárásszerű, elvárásszintnek word
+always foglalkozássz 124-135-1245-123-1-123-13-135-126-4-234-156	For example foglalkozásszerkezet, foglalkozásszám word
+always alakítássz 1-123-1-13-34-2345-4-234-156	For example alakításszámba word
+always követeléssz 13-12345-1236-15-2345-15-123-16-234-156	For example követelésszám word
+always ragyogássz 1235-1-1456-135-1245-4-234-156	For example ragyogásszerű word
+always pusztítássz 1234-136-156-2345-34-2345-4-234-156	For example pusztításszekvenciákkal word
+always vonulássz 1236-135-1345-136-123-4-234-156	For example vonulásszabályok word
+always dartssz 145-1-1235-2345-234-156	For example dartsszakosztály, dartsszövetség word
+always marássz 134-1-1235-4-234-156	For example marásszünet word
+always pillangóssz 1234-24-123-123-1-1345-1245-246-234-156	For example pillangósszéna word
+always lakossz 123-1-13-135-234-156	For example lakosszám word
+always mozgatássz 134-135-126-1245-1-2345-4-234-156	For example mozgatásszáma word
+always törőkossz 2345-12345-1235-12456-13-135-234-156	For example faltörőkosszerű word
+always vánkossz 1236-4-1345-13-135-234-156	For example vánkosszerű word
+always pörgéssz 1234-12345-1235-1245-16-234-156	For example pörgésszinten word
+always látomássz 123-4-2345-135-134-4-234-156	For example látomásszekvencia, látomásszerű words
 
 #ty, tty related exceptions
 #This exception part containing english words with need presenting original english braille rules
@@ -2304,6 +2418,18 @@ always imázszón 24-134-4-345-126-246-1345	For example imázszóna word
 always komikuszs 13-135-134-24-13-136-234-345	For example komikuszseni word
 always gázsort 1245-4-126-234-135-1235-2345	For example könnygázsortűz word
 begword gázsáv 1245-4-126-234-4-1236	For example gázsávokkal word
+always előadászen 15-123-12456-1-145-4-234-126-15-1345	For example előadászenei word
+always mellkaszúz 134-15-123-123-13-1-234-126-346-126	For example mellkaszúzódás word
+always társzsű 2345-4-1235-234-345-23456	For example társzsűri word
+always vágászó 1236-4-1245-4-234-126-246	For example vágászónával word
+always nyomászuh 1246-135-134-4-234-126-136-125	For example vérnyomászuhanás word
+always verszeng 1236-15-1235-234-126-15-1345-1245	For example verszengő word
+always szarvaszu 156-1-1235-1236-1-234-126-136  For example rénszarvaszuzmó word
+always populáriszen 1234-135-1234-136-123-4-1235-24-234-126-15-1345	For example populáriszene word
+always asszázsz 1-156-156-4-345-126	For example passzázszavar word
+always laktóz 123-1-13-2345-246-126	For example laktózsav word
+always borzst 12-135-1235-126-234-2345	For example borzstratégia word
+always verszené 1236-15-1235-234-126-15-1345-16	For example verszenével word
 
 #Historical person names related exceptions
 always táncsics 2345-4-1345-146-24-146	Táncsics Mihály is a historical person for 1848. march 15 hungarian revolution


### PR DESCRIPTION
Hi guys,

As usual, I made updates and new exceptions for tables/hu-exceptionwords.cti and tables/hu-backtranslate-word-corrections.cti files, and added new test subjects to the Hungarian word database test file.
The first commit contains the list of exceptions, the second commit contains the entries of the test cases. The second commit does not need to be reviewed, the commit contains Hungarian language-specific test cases.
The first commit is not big, approx. 428 lines.
The second commit is long, it contains the test case file modifications, approx. 1528 lines, it is not necessary to subject this to review. :-):-)
The make check command ran successfully on my machine.
The large Hungarian grade1 corpus test did not show any errors, the entire grade1 word database was correctly translated to and fro.
This pull request does not cause regression errors related to other languages, as the change only affects the Hungarian table files.
If possible, add this pull request to the 3.29.0 Liblouis milestone list, and I ask that the change be pushed to the main Liblouis branch before the release, as the subtable files contain more important changes.
Since I am currently working on the Turkish non-literary Braille board, the Turkish grade1 board and the grade2 board, I am now putting the Hungarian board files in a frozen state due to the closeness of the release date, in that case I will only make changes to the Hungarian board files as usual starting today, if it can't wait until the release of the next 3.30 Liblouis version.

Thank you in advance for your cooperation and I wish you a good 3.29.0 Liblouis release.

Attila