### PR TITLE
Another Malay Table Correction

### DIFF
--- a/tables/ms-my-g2.ctb
+++ b/tables/ms-my-g2.ctb
@@ -1387,7 +1387,7 @@ always estakan 15-234-2345-1-345
 always ewikan 15-2456-24-345
 
 # Letter F
-always faedah 124
+word faedah 124
 begword faedah 124-25
 midword faedah 25-124-25
 endword faedah 25-124

--- a/tables/ms-my-g2.ctb
+++ b/tables/ms-my-g2.ctb
@@ -38,14 +38,15 @@
 #  Maintained by Herbert Koh <kohherbert@hotmail.com>
 #
 
-repword - 123456 # put before en-ueb-g1.ctb so that it has precedence over hyphen - 36
-rependword - 25,123456
+repword - 123456a # put before en-ueb-g1.ctb so that it has precedence over hyphen - 36
+rependword - 25,123456a
 # omit caps indicator before repword indicator
-noback pass2 [@6@6]@123456 ?
-noback pass2 [@6]@123456 ?
+noback pass2 [@6@6]@123456a ?
+noback pass2 [@6]@123456a ?
+noback pass2 @123456a @123456
 
 # "kan" after repeat sign should become 345
-noback pass2 @123456-13-12456 @123456-345
+noback pass2 @123456a-13-12456 @123456-345
 
 include en-ueb-g1.ctb
 

--- a/tests/braille-specs/ms-my-g2.yaml
+++ b/tests/braille-specs/ms-my-g2.yaml
@@ -118,7 +118,6 @@ tests:
   # indicator)
   - - "Kita"
     - ",="
-    - xfail: caps indicator omitted before repword indicator
 
   # Contractions
   #

--- a/tests/braille-specs/ms-my-g2.yaml
+++ b/tests/braille-specs/ms-my-g2.yaml
@@ -2897,7 +2897,6 @@ tests:
     - "/4a" # does not contain a "d" because of the "di" contraction; see test below for back-translation of uncontracted "media"
   - - "find"
     - "f9d"
-    - xfail: {backward: "dots 124 (f) is back-translated to 'faedah'"}
 
   # dots 14 (c) should not be back-translated to "contoh" when part of a word
   - - "mencantas"


### PR DESCRIPTION
@bertfrees
Hi, sorry. I just realise this mistake when I test the table that you merge to the master from the previous pull request. The word faedah should be word, not always.
About the capital sign, it still can't be shown here.
I think you have add something to these 2 line but I forgot what you add there.
```
noback pass2 [@6@6]@123456 ?
noback pass2 [@6]@123456 ?
```
I think you add the letter "A" but I forgot the correct format. When I play around with that, the capital can be shown. May you help me to re-test that? Thanks.