### PR TITLE
Add metadata to Cantonese (Hong Kong) table

### DIFF
--- a/tables/zh-hk.ctb
+++ b/tables/zh-hk.ctb
@@ -1,3 +1,12 @@
+#-index-name: chinese, Cantonese, Hong Kong
+#-display-name: Chinese Hong Kong Cantonese Braille
+
+#+language: zh-HK
+#+type: literary
+#+dots: 6
+#+contraction: no
+#+direction: forward
+#
 # liblouis: Chinese Hong Kong Cantonese braille Translation Table
 #
 #  liblouis is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
As we are developing a product that uses LibLouis and I'm in a need to gather metadata of all tables into a form suitable for further processing (I chose JSON for that), I'm testing my little application (if there is any interest in that, I'll publish the link when it's done, it's public).  
When testing the output, I noticed at least one table without metadata (if this pull request is accepted and I notice more, I'm happy to post further pull requests).

## My Assumptions
* As I didn't see any reference to dots 7 or 8, I set dots mode to 6
* I have no idea about contractions here, but I assume it's uncontracted despite the CTB extension (correct me if I'm wrong)
* As every sign is preceded by `sign` and there is no back-translation mentioned, I assume the direction is `forward`.