### PR TITLE
Update fuzz_translate_generic.c: Add missing include unistd.h

### DIFF
--- a/tests/fuzzing/fuzz_translate_generic.c
+++ b/tests/fuzzing/fuzz_translate_generic.c
@@ -27,6 +27,7 @@
 #include <internal.h>
 #include <liblouis.h>
 #include <assert.h>
+#include <unistd.h>
 
 #define LANGUAGE	"en"
 


### PR DESCRIPTION
To fix a clang-18 error:

```
make[1]: Leaving directory '/src/liblouis'
table_fuzzer.cc:19:16: warning: ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]
   19 |         char *table = "empty.ctb";
      |                       ^
1 warning generated.
fuzz_translate_generic.c:86:9: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   86 |         unlink(new_file);
      |         ^
fuzz_translate_generic.c:104:9: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  104 |         unlink(new_file);
      |         ^
fuzz_translate_generic.c:119:5: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  119 |     unlink(new_file);
      |     ^
3 errors generated.
ERROR:__main__:Building fuzzers failed.
