### PR TITLE
Add display table definitions to many of the yaml tests

### DIFF
--- a/tests/yaml/attribute.yaml
+++ b/tests/yaml/attribute.yaml
@@ -1,7 +1,10 @@
 # attribute name can be a digit between 0 and 7, in which case it can
 # be used in a match expression (but not in a multipass expression)
-table: |
+display: |
+  display a 1
+  display b 12
   display A 17
+table: |
   sign a 1
   sign b 12
   attribute 5 b
@@ -18,7 +21,6 @@ tests:
 # emphmodechars, seqdelimiter, seqbeforechars, seqafterchars,
 # noletsign, noletsignbefore, noletsignafter
 table: |
-  display A 17
   sign a 1
   sign b 12
   attribute foo b
@@ -32,19 +34,16 @@ tests:
 # digit, punctuation, uppercase, lowercase, math, sign or litdigit
 # (and it will set that attribute, not a custom one)
 table: |
-  display A 17
   sign a 1
   sign b 12
   attribute letter b
   noback context _$l["a"] @17
 table: |
-  display A 17
   sign a 1
   sign b 12
   attribute letter b
   noback context _%letter["a"] @17
 table: |
-  display A 17
   sign a 1
   sign b 12
   attribute letter b
@@ -58,7 +57,6 @@ tests:
 # attribute is also set on the dot pattern (only relevant for
 # multipass rules)
 table: |
-  display A 17
   sign a 1
   sign b 12
   attribute foo b
@@ -72,7 +70,6 @@ tests:
 # but the name must be a word, and class and attribute may not be both
 # present in the same table
 table: |
-  display A 17
   sign a 1
   sign b 12
   class foo b

--- a/tests/yaml/back_cont_then_punc.yaml
+++ b/tests/yaml/back_cont_then_punc.yaml
@@ -1,6 +1,6 @@
 # Tests for #360: contractions followed by punctuation.
+display: tables/unicode.dis
 table: |
-  include tables/unicode.dis
   letter a 1
   letter b 12
   letter d 145

--- a/tests/yaml/before_begmidword.yaml
+++ b/tests/yaml/before_begmidword.yaml
@@ -9,9 +9,8 @@
 # rule should only trigger when 'lande' is before a 'u'. If one class
 # definition is removed as in the second test then the correct rules
 # are triggered.
-
+display: tables/unicode.dis
 table: |
-  include tables/unicode.dis
   include tables/de-chardefs6.cti
   attribute foo zz
   attribute a a
@@ -46,7 +45,6 @@ tests:
 # if we remove one of the class definitions then the correct rules
 # match
 table: |
-  include tables/unicode.dis
   include tables/de-chardefs6.cti
   attribute a a
   attribute b b
@@ -77,7 +75,6 @@ tests:
 # it looks like it doesn't matter which class definition we remove
 # match, as long as we remove one
 table: |
-  include tables/unicode.dis
   include tables/de-chardefs6.cti
   attribute foo zz
   attribute b b
@@ -110,7 +107,6 @@ tests:
 # `before u begmidword stärke` should not match at all. Again this
 # seems to depend on the number of classes defined
 table: |
-  include tables/unicode.dis
   include tables/de-chardefs6.cti
   attribute foo zz
   attribute a a
@@ -142,7 +138,6 @@ tests:
 
 # If we remove a class then the translation is correct
 table: |
-  include tables/unicode.dis
   include tables/de-chardefs6.cti
   attribute a a
   attribute b b

--- a/tests/yaml/begcaps_endcaps.yaml
+++ b/tests/yaml/begcaps_endcaps.yaml
@@ -1,5 +1,5 @@
+display: tables/nl-BE.dis
 table: |
-  include tables/nl-BE.dis
   include tables/braille-patterns.cti
   include tables/latinLetterDef6Dots.uti
   capsletter 46

--- a/tests/yaml/broken_equals_operand.yaml
+++ b/tests/yaml/broken_equals_operand.yaml
@@ -24,8 +24,8 @@
 # the = sign should be replaced internally by the corresponding dot
 # pattern at compile time.
 
+display: tables/unicode.dis
 table: |
-  include tables/unicode.dis
   punctuation ; 56
   include tables/latinLetterDef6Dots.uti
   lowercase ó 56-135

--- a/tests/yaml/capsnocont.yaml
+++ b/tests/yaml/capsnocont.yaml
@@ -1,5 +1,5 @@
+display: tables/unicode-without-blank.dis
 table: |
-  include tables/unicode-without-blank.dis
   # excerpts from no-no-g1.ctb:
   include tables/spaces.uti
   include tables/latinLetterDef6Dots.uti

--- a/tests/yaml/computer_braille.yaml
+++ b/tests/yaml/computer_braille.yaml
@@ -1,7 +1,6 @@
 # Test various methods of triggering computer braille
-
+display: tables/unicode-without-blank.dis
 table: |
-  include tables/unicode-without-blank.dis
   include tables/spaces.uti
   punctuation . 3
   include tables/latinLetterDef6Dots.uti
@@ -48,7 +47,6 @@ tests:
 # - it takes the first character definition rule rather than the last
 # - it fails on characters outside of the range \x0020-\x007E
 table: |
-  include tables/unicode-without-blank.dis
   space \s 0
   letter a 1-1
   letter a 1

--- a/tests/yaml/example_test.yaml
+++ b/tests/yaml/example_test.yaml
@@ -1,6 +1,7 @@
 # lines starting with '#' are comments
 # first define which tables will be used for your tests
-table: [tables/unicode-without-blank.dis, tables/en-ueb-g1.ctb]
+display: tables/unicode-without-blank.dis
+table: tables/en-ueb-g1.ctb
 
 # then optionally define flags such as testmode. If no flags are
 # defined forward translation is assumed

--- a/tests/yaml/precedence.yaml
+++ b/tests/yaml/precedence.yaml
@@ -4,19 +4,21 @@
 # ---------------------------------------------
 
 # last undefined rule wins
-table: |
+display: |
   display 1 1
   display 2 2
+table: |
   undefined 1
   undefined 2
 tests:
   - [x, 2]
 
 # the first character definition rule wins
-table: |
+display: |
   display 1 1
   display 2 2
   display 3 3
+table: |
   sign P 1
   sign P 2
   sign P 3
@@ -33,10 +35,11 @@ tests:
       cursorPos: [0,0]
 
 # ... also if a context rule with * in the action part is matched
-table: |
+display: |
   display 1 1
   display 2 2
   display 3 3
+table: |
   sign P 1
   sign P 2
   sign P 3
@@ -47,8 +50,8 @@ tests:
     - "1"
 
 # the first character definition rule wins
+display: tables/unicode-without-blank.dis
 table: |
-  include tables/unicode-without-blank.dis
   include tables/spaces.uti
   lowercase a 1
   uppercase A 1
@@ -81,8 +84,8 @@ tests:
 # if "X" is defined as "uppercase X ...", the first "uppercase X" wins
 # if "X" is defined as "base uppercase X x", the first definition of "x" wins
 # (original issue: https://github.com/liblouis/liblouis/issues/384)
+display: tables/unicode-without-blank.dis
 table: |
-  include tables/unicode-without-blank.dis
   include tables/spaces.uti
   lowercase a 1
   base uppercase A a
@@ -110,8 +113,8 @@ tests:
   - - Aa Bb Cc Dd Ee Ff Gg Hh
     - ⠠⠁⠁ ⠠⠃⠃ ⠠⠉⠉ ⠠⠙⠙ ⠠⠑⠑ ⠠⠋⠋ ⠠⠛⠛ ⠠⠓⠓
 # same but without capsletter
+display: tables/unicode-without-blank.dis
 table: |
-  include tables/unicode-without-blank.dis
   include tables/spaces.uti
   lowercase a 1
   base uppercase A a
@@ -141,6 +144,7 @@ tests:
 # for printing escape sequences for undefined characters, only
 # character definitions that map to a single dot are used and the
 # first definition wins. display rules are ignored.
+display: tables/unicode-without-blank.dis
 table: |
   include tables/unicode-without-blank.dis
   digit 0 356


### PR DESCRIPTION
Quite a few of the yaml tests in `tests/yaml` do not use display table definitions. Add display table definitions to many of them. This helps with portability with louis-rs.