### PR TITLE
Fix the display table for Lao braille yaml tests

### DIFF
--- a/tests/braille-specs/lo.yaml
+++ b/tests/braille-specs/lo.yaml
@@ -32,7 +32,32 @@
 # ----------------------------------------------------------------------------------------------
 
 display: |
-  include latinLetterDef6Dots.uti
+  display a 1
+  display b 12
+  display c 14
+  display d 145
+  display e 15
+  display f 124
+  display g 1245
+  display h 125
+  display i 24
+  display j 245
+  display k 13
+  display l 123
+  display m 134
+  display n 1345
+  display o 135
+  display p 1234
+  display q 12345
+  display r 1235
+  display s 234
+  display t 2345
+  display u 136
+  display v 1236
+  display w 2456
+  display x 1346
+  display y 13456
+  display z 1356
   include unicode.dis
 table:
   locale: lo


### PR DESCRIPTION
The yaml tests for Lao braille use a plain table (`latinLetterDef6Dots.uti`) in the display table. This is very fishy and naturally fails in louis-rs.

So I converted the yaml test to use a "normal" display table using only display opcodes.