### PR TITLE
Experiment with using m4 as a macro language

### DIFF
--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -432,6 +432,12 @@ $(fuzzing_yml): $(srcdir)/Makefile.am
 
 all-local: $(fuzzing_yml)
 
+# tables that use macros need to be expanded
+BUILT_SOURCES = nl-NL-g0.utb
+CLEANFILES = nl-NL-g0.utb
+nl-NL-g0.utb: nl-NL-g0.utb.in Makefile
+	m4 $< > $@
+
 tablesdir = $(datadir)/liblouis/tables
 tables_DATA = $(table_files)
 EXTRA_DIST = $(table_files)

--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -288,6 +288,7 @@ table_files = \
 	nl-BE.dis \
 	nl-chardefs.uti \
 	nl-comp8.utb \
+	nl-NL-g0.utb.in \
 	nl-NL-g0.utb \
 	nl-print.dis \
 	nl-unicode.dis \

--- a/tables/nl-NL-g0.utb.in
+++ b/tables/nl-NL-g0.utb.in
@@ -1,0 +1,367 @@
+#
+#  Copyright (C) 2010, 2011 by DocArch <http://www.docarch.be>
+#  Copyright (C) 2014-2015, 2019 by Bert Frees
+#  Copyright (C) 2014 by CBB <http://www.cbb.nl>
+#  Copyright (C) 2015, 2016, 2018 by Dedicon <http://www.dedicon.nl>
+#  Copyright (C) 2024 by Davy Kager
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# -------------------------------------------------------------------------------
+#
+#  Dutch Braille as used in the Netherlands
+#
+#     Created by Bert Frees <bertfrees@gmail.com>
+#     Modified by Henri Apperloo <h.apperloo@cbb.nl>
+#     Modified by Davy Kager <DavyKager@dedicon.nl>
+#
+#     See also: « Braillestandaard voor algemeen gebruik in het Nederlandse taalgebied,
+#                Van toepassing vanaf 19 april 2018 »
+#              (Braille Autoriteit, 2018)
+#               [http://liblouis.io/braille-specs/dutch][1]
+#          and: « World Braille Usage (3rd edition) »
+#               [http://liblouis.io/braille-specs/world-braille-usage-third-edition.pdf][2]
+#
+# ----------------------------------------------------------------------------------------------
+
+# Define some m4 macros to simpify writing the table
+define(`_foreignuplow',`
+noback lowercase $1 $3b
+nofor  lowercase $1 $3
+base uppercase $2 $1
+attribute foreign $2$1
+')
+# The following line changes the quotes used by m4. It should prevent
+# any accidental changes to the normal text in the table
+changequote(`{{{', `}}}')
+
+# include a display table by default to avoid errors if the user would not include a display table
+include nl-print.dis
+
+include nl-chardefs.uti
+include braille-patterns.cti
+
+hyphen    \x002D  36
+
+# §3.1 Het cijferteken [1]
+
+midnum    \x002C  2    # COMMA
+midnum    \x002E  256  # FULL STOP
+
+# §1.55 Paragraafteken [1]
+
+begword \x00A7   346-0
+midword \x00A7 0-346-0
+endword \x00A7 0-346
+
+# §2.18 Procent- en promilleteken [1]
+
+endnum  \x0025 0-123456
+endnum  \x2030 0-123456-123456
+
+# §3.2 De basisrekentekens (spatieregel) [1]
+
+# isgelijkteken =
+begword \x003D   2356-0
+midword \x003D 0-2356-0
+endword \x003D 0-2356
+
+# plusteken +
+begword \x002B   235a-0
+endnum  \x002B 5-235a
+
+# deelteken ÷
+begword \x00F7   256-0
+midword \x00F7 0-256-0
+endword \x00F7 0-256
+
+# maalteken ×
+begword \x00D7   236-0
+midword \x00D7 0-236-0
+endword \x00D7 0-236
+
+# §2.17 Muntsymbolen/valutatekens [1]
+# Als de munteenheid na het getal wordt geplaatst, dan wordt ze bij voorkeur voluit geschreven
+noback correct ["€"]$s.!$d "euro"
+noback correct ["$"]$s.!$d "dollar"
+noback correct ["£"]$s.!$d "pond"
+noback correct ["¥"]$s.!$d "yen"
+noback correct ["€"]$s.~   "euro"
+noback correct ["$"]$s.~   "dollar"
+noback correct ["£"]$s.~   "pond"
+noback correct ["¥"]$s.~   "yen"
+noback correct ["€"]!$ds   "euro"
+noback correct ["$"]!$ds   "dollar"
+noback correct ["£"]!$ds   "pond"
+noback correct ["¥"]!$ds   "yen"
+noback correct ["€"]~      "euro"
+noback correct ["$"]~      "dollar"
+noback correct ["£"]~      "pond"
+noback correct ["¥"]~      "yen"
+
+# Geplaatst vóór het getal wordt de munteenheid door haar beginletter weergegeven, zonder spatie tussen letter en cijfer
+
+# §1.5 euroteken € (zonder spatie vóór het getal) [1]
+noback joinnum \x20AC 15a
+
+# §1.4 dollarteken $ (zonder spatie vóór het getal) [1]
+noback joinnum \x0024 145a
+
+# §1.16 pondteken £ (zonder spatie vóór het getal) [1]
+noback joinnum \x00A3 1234a
+
+# §1.24 yenteken ¥ (zonder spatie vóór het getal) [1]
+noback joinnum \x00A5 13456a
+
+# §1.34 verticale streep | (spatie voor en na) [1]
+
+begword \x007C   1456-0
+midword \x007C 0-1456-0
+endword \x007C 0-1456
+
+# §3.6 Graad-, minuut- en secondeteken [1]
+noback context $d["''"] @4-35a-35a
+noback context $d["'"] @4-35a
+
+# Roman page numbers
+replace  \\_
+
+# §2.11 Herstelteken [1]
+
+# For numbers that are immediately followed by a letter a-j, a sign must be
+# inserted for terminating the number.
+
+# Using these rules instead of the multipass rules makes a lot of tests fail:
+# nocontractsign 6
+# numericnocontchars abcdefghij
+
+attribute digitletter abcdefghijABCDEFGHIJ    # 1st class = $w
+noback context     $d[]%digitletter       @6a
+noback context     $d","[]%digitletter    @6a
+noback context     $d"."[]%digitletter    @6a
+noback context     $d":"[]%digitletter    @6a
+# Multiple dots 6 are collapsed into a single dot 6.
+noback pass2       [@6a]@6a                 ?
+# A dot 6 is not needed when the number is already cancelled by a capital, emphasis or foreign language sign
+noback pass3       $d[@6a]@45              ?
+noback pass3       $d[@6a]@46              ?
+noback pass3       $d[@6a]@456             ?
+noback pass3       $d[@6a]@56              ?
+
+# §2.20 Sleutelteken tweede betekenis [1]
+
+# §2.3 Ampersandteken [1]
+
+# When an AMPERSAND appears within a word (e.g. an initialism like AT&T) it must be
+# preceded by a "second meaning" sign because its first meaning is LETTER C WITH
+# CEDILLA (ç).
+
+# When a PLUS SIGN appears within a word (e.g. 30+'er) it must be preceded by a
+# "second meaning" sign because its first meaning is EXCLAMATION MARK.
+
+attribute    plusamp                     +&     # 2nd class = $x
+attribute    noplusamp                   .'‘’   # 3rd class = $y
+noback pass4    %noplusamp[]%plusamp        @5
+noback pass4    $l[]%plusamp                @5
+noback pass4    [@235a]%plusamp             @235a-5
+noback pass4    [@12346a]%plusamp           @12346-5
+noback pass4    [@12346a]                   @12346
+
+numsign  3456
+
+# §1.58 Drukwijzigingsteken [1]
+emphclass italic
+emphclass underline
+emphclass bold
+
+lenemphphrase italic 4
+begemphword italic 456
+endemphword italic 6
+begemphphrase italic 456-456
+endemphphrase italic before 456
+emphletter italic 456
+
+lenemphphrase bold 4
+begemphword bold 456
+endemphword bold 6
+begemphphrase bold 456-456
+endemphphrase bold before 456
+emphletter bold 456
+
+lenemphphrase underline 4
+begemphword underline 456
+endemphword underline 6
+begemphphrase underline 456-456
+endemphphrase underline before 456
+emphletter underline 456
+
+# §2.12 Hoofdletters [1]
+
+# Certain characters can appear within an uppercase string without cancelling
+# the uppercase "state". These characters are + (PLUS SIGN), & (AMPERSAND),
+# . (FULL STOP), ' (APOSTROPHE), ‘ (LEFT SINGLE QUOTATION MARK)
+# and ’ (RIGHT SINGLE QUOTATION MARK).
+capsmodechars +&.'‘’
+# The same goes for the emphasis "state".
+emphmodechars italic +&.'‘’
+emphmodechars bold +&.'‘’
+emphmodechars underline +&.'‘’
+
+# These are the characters for which emphasis is not indicated
+noemphchars italic \s'()
+noemphchars bold \s'()
+noemphchars underline \s'()
+
+# treat apostrophe in 't as a letter
+letter \xe000 3
+noback correct ["'"]"t"$s "\xe000"
+
+lencapsphrase 4
+begcapsword 45
+endcapsword 6
+begcapsphrase 45-45
+endcapsphrase before 45
+capsletter 46
+
+# Left and right curly brackets
+
+punctuation \x007B        12356               {                   LEFT CURLY BRACKET
+punctuation \x007D        23456               }                   RIGHT CURLY BRACKET
+
+# 2.2. Alfabetwisselingsteken
+
+modeletter foreign 56
+begmodeword foreign 56
+begmodephrase foreign 56-56
+endmodephrase foreign before 56
+lenmodephrase foreign 4
+
+# Note that we don't use the "base" opcode to define foreign letters
+# because we don't want non-foreign characters to cancel foreign mode.
+
+# Foreign letters Ã, Õ (Portuguese), Å, Æ, Ø (Norwegian/Danish/Finnish), Ì (Italian)
+
+lowercase       \x00E3 1                  ã                  LATIN SMALL LETTER A WITH TILDE
+lowercase       \x00E5 1                  å                  LATIN SMALL LETTER A WITH RING ABOVE
+lowercase       \x00E6 1-15-15            æ                  LATIN SMALL LETTER AE
+lowercase       \x00EC 24                 ì                  LATIN SMALL LETTER I WITH GRAVE
+lowercase       \x00F5 135                õ                  LATIN SMALL LETTER O WITH TILDE
+lowercase       \x00F8 246                ø                  LATIN SMALL LETTER O WITH STROKE
+
+base uppercase  \x00C3 \x00E3            Ãã                  LATIN CAPITAL LETTER A WITH TILDE - LATIN SMALL LETTER A WITH TILDE
+base uppercase  \x00C5 \x00E5            Åå                  LATIN CAPITAL LETTER A WITH RING ABOVE - LATIN SMALL LETTER A WITH RING ABOVE
+base uppercase  \x00C6 \x00E6            Ææ                  LATIN CAPITAL LETTER AE - LATIN SMALL LETTER AE
+base uppercase  \x00CC \x00EC            Ìì                  LATIN CAPITAL LETTER I WITH GRAVE - LATIN SMALL LETTER I WITH GRAVE
+base uppercase  \x00D5 \x00F5            Õõ                  LATIN CAPITAL LETTER O WITH TILDE - LATIN SMALL LETTER O WITH TILDE
+base uppercase  \x00D8 \x00F8            Øø                  LATIN CAPITAL LETTER O WITH STROKE - LATIN SMALL LETTER O WITH STROKE
+
+attribute foreign ÃãÅåÆæÌìÕõØø
+
+# Greek letters
+
+noback lowercase α 1b          GREEK LETTER ALPHA
+nofor  lowercase α 1           GREEK LETTER ALPHA
+noback lowercase ά 1c          GREEK LETTER ALPHA WITH TONOS
+nofor  lowercase ά 1           GREEK LETTER ALPHA WITH TONOS
+noback lowercase β 12b         GREEK LETTER BETA
+nofor  lowercase β 12          GREEK LETTER BETA
+noback lowercase γ 1245b       GREEK LETTER GAMMA
+nofor  lowercase γ 1245        GREEK LETTER GAMMA
+noback lowercase δ 145b        GREEK LETTER DELTA
+nofor  lowercase δ 145         GREEK LETTER DELTA
+noback lowercase ε 15b         GREEK LETTER EPSILON
+nofor  lowercase ε 15          GREEK LETTER EPSILON
+noback lowercase ζ 1356b       GREEK LETTER ZETA
+nofor  lowercase ζ 1356        GREEK LETTER ZETA
+noback lowercase ι 24b         GREEK LETTER IOTA
+nofor  lowercase ι 24          GREEK LETTER IOTA
+noback lowercase ί 24c         GREEK LETTER IOTA WITH TONOS
+nofor  lowercase ί 24          GREEK LETTER IOTA WITH TONOS
+noback lowercase κ 13b         GREEK LETTER KAPPA
+nofor  lowercase κ 13          GREEK LETTER KAPPA
+noback lowercase λ 123b        GREEK LETTER LAMDA
+nofor  lowercase λ 123         GREEK LETTER LAMDA
+noback lowercase μ 134b        GREEK LETTER MU
+nofor  lowercase μ 134         GREEK LETTER MU
+noback lowercase ν 1345b       GREEK LETTER NU
+nofor  lowercase ν 1345        GREEK LETTER NU
+noback lowercase ξ 1346b       GREEK LETTER XI
+nofor  lowercase ξ 1346        GREEK LETTER XI
+noback lowercase ο 135b        GREEK LETTER OMICRON
+nofor  lowercase ο 135         GREEK LETTER OMICRON
+noback lowercase π 1234b       GREEK LETTER PI
+nofor  lowercase π 1234        GREEK LETTER PI
+noback lowercase ρ 1235b       GREEK LETTER RHO
+nofor  lowercase ρ 1235        GREEK LETTER RHO
+noback lowercase σ 234b        GREEK LETTER SIGMA
+nofor  lowercase σ 234         GREEK LETTER SIGMA
+noback lowercase ς 234c        GREEK LETTER FINAL SIGMA
+nofor  lowercase ς 234         GREEK LETTER FINAL SIGMA
+noback lowercase τ 2345b       GREEK LETTER TAU
+nofor  lowercase τ 2345        GREEK LETTER TAU
+noback lowercase υ 136b        GREEK LETTER UPSILON
+nofor  lowercase υ 136         GREEK LETTER UPSILON
+noback lowercase φ 124b        GREEK LETTER PHI
+nofor  lowercase φ 124         GREEK LETTER PHI
+noback lowercase ϕ 124c        GREEK PHI SYMBOL
+nofor  lowercase ϕ 124         GREEK PHI SYMBOL
+noback lowercase ψ 13456b      GREEK LETTER PSI
+nofor  lowercase ψ 13456       GREEK LETTER PSI
+noback lowercase ω 2456b       GREEK LETTER OMEGA
+nofor  lowercase ω 2456        GREEK LETTER OMEGA
+noback lowercase η 156b        GREEK LETTER ETA
+nofor  lowercase η 156         GREEK LETTER ETA
+noback lowercase θ 1456b       GREEK LETTER THETA
+nofor  lowercase θ 1456        GREEK LETTER THETA
+noback lowercase χ 12346b      GREEK LETTER CHI
+nofor  lowercase χ 12346       GREEK LETTER CHI
+
+base uppercase Α α
+base uppercase Ά ά
+base uppercase Β β
+base uppercase Γ γ
+base uppercase Δ δ
+base uppercase Ε ε
+base uppercase Ζ ζ
+base uppercase Ι ι
+base uppercase Ί ί
+base uppercase Κ κ
+base uppercase Λ λ
+base uppercase Μ μ
+base uppercase Ν ν
+base uppercase Ξ ξ
+base uppercase Ο ο
+base uppercase Π π
+base uppercase Ρ ρ
+base uppercase Σ σ
+base uppercase Τ τ
+base uppercase Υ υ
+base uppercase Φ φ
+base uppercase Ψ ψ
+base uppercase Ω ω
+base uppercase Η η
+base uppercase Θ θ
+base uppercase Χ χ
+
+attribute foreign ΑαΆάΒβΓγΔδΕεΖζΙιΊίΚκΛλΜμΝνΞξΟοΠπΡρΣσςΤτΥυΦφϕΨψΩωΗηΘθΧχ
+
+# Other alphabets
+
+attribute foreign Ññ # ñ defined in nl-chardefs.uti
+
+_foreignuplow(ł,Ł,126)
+_foreignuplow(ź,Ź,2346)


### PR DESCRIPTION
As we all know I'm a bit afraid of adding the macro feature to liblouis. So far I managed to keep it under the rug by making it a compile time feature that was disabled by default. But the imminent merge of #1557 left me with a sleepless night.

So I sat down and experimented with a standard off-the-shelf macro preprocessor. I had the choice between the C-Preprocessor or [M4](https://www.gnu.org/software/m4/m4.html). The [wikipedia page on the C Preprocessor](https://en.wikipedia.org/wiki/C_preprocessor#Other_uses) says that M4 is a "general macro processor" and as such way more powerful than the C Preprocessor. So I went with M4.

As an experiment I took the `nl-NL-g0.utb` table and implemented the `foreignuplow` macro. It turns out to be super simple:
``` m4
define(`_foreignuplow',`
noback lowercase $1 $3b
nofor  lowercase $1 $3
base uppercase $2 $1
attribute foreign $2$1
')
```
Invocation is simply
``` m4
_foreignuplow(ł,Ł,126)
_foreignuplow(ź,Ź,2346)
```
Add above to the table and save it in say `nl-NL-g0.utb.in`.

Then you'll have to hook it up in the `Makefile.am` to run `nl-NL-g0.utb.in` through `m4` to generate `nl-NL-g0.utb`.

I have to say this solution really appeals to me. We are using a real, powerful and battle-tested macro processor as opposed to use a half-decent homegrown one. It gives us all the power of m4 to play with without having to implement anything or write any documentation.

Also (and that is of course my hidden agenda) it keeps the parsing of liblouis tables extremely simple, as it was before