### PR TITLE
Treat language and region metadata fields in table as language ranges

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -38,7 +38,8 @@
 
 typedef struct List {
 	void *head;
-	void (*free)(void *);
+	void (*free)(void *);  // free head
+	void *(*dup)(void *);  // dup head
 	struct List *tail;
 } List;
 
@@ -58,12 +59,14 @@ list_conj(List *list, void *x, int (*cmp)(void *, void *), void *(*dup)(void *),
 		list = malloc(sizeof(List));
 		list->head = dup ? dup(x) : x;
 		list->free = free;
+		list->dup = dup;
 		list->tail = NULL;
 		return list;
 	} else if (!cmp) {
 		List *l = malloc(sizeof(List));
 		l->head = dup ? dup(x) : x;
 		l->free = free;
+		l->dup = dup;
 		l->tail = list;
 		return l;
 	} else {
@@ -84,6 +87,7 @@ list_conj(List *list, void *x, int (*cmp)(void *, void *), void *(*dup)(void *),
 		List *l3 = malloc(sizeof(List));
 		l3->head = dup ? dup(x) : x;
 		l3->free = free;
+		l3->dup = dup;
 		l3->tail = l1;
 		if (!l2)
 			list = l3;
@@ -103,6 +107,20 @@ list_free(List *list) {
 		list_free(list->tail);
 		free(list);
 	}
+}
+
+/**
+ * Duplicate an instance of type List.
+ */
+static List *
+list_dup(List *list) {
+	if (!list || !list->dup) return list;
+	List *d = malloc(sizeof(List));
+	d->head = list->dup(list->head);
+	d->free = list->free;
+	d->dup = list->dup;
+	d->tail = list_dup(list->tail);
+	return d;
 }
 
 /**
@@ -150,7 +168,9 @@ list_toArray(List *list, void *(*dup)(void *)) {
 
 typedef struct {
 	char *key;
-	char *val;
+	void *val;
+	void (*free)(void *);  // free val
+	void *(*dup)(void *);  // dup val
 } Feature;
 
 typedef struct {
@@ -170,15 +190,17 @@ typedef struct {
 
 /**
  * Create an instance of type Feature.
- * The `key' and `val' strings are duplicated. Leaving out the `val'
- * argument results in a value of "yes".
+ *
+ * The `key' string is duplicated. What happens with `val' is
+ * determined by the `dup' and `free' arguments.
  */
 static Feature
-feature_new(const char *key, const char *val) {
-	static const char *YES = "yes";
+feat_new(const char *key, void *val, void *(*dup)(void *), void (*free)(void *)) {
 	Feature f;
 	f.key = strdup(key);
-	f.val = strdup(val ? val : YES);
+	f.val = dup ? dup(val) : val;
+	f.dup = dup;
+	f.free = free;
 	return f;
 }
 
@@ -186,12 +208,101 @@ feature_new(const char *key, const char *val) {
  * Free an instance of type Feature
  */
 static void
-feature_free(Feature *f) {
+feat_free(Feature *f) {
 	if (f) {
 		free(f->key);
-		free(f->val);
+		if (f->free) f->free(f->val);
 		free(f);
 	}
+}
+
+/**
+ * Duplicate an instance of type Feature.
+ */
+static Feature *
+feat_dup(Feature *f) {
+	if (!f) return NULL;
+	Feature *d = malloc(sizeof(Feature));
+	d->key = strdup(f->key);
+	d->val = f->dup ? f->dup(f->val) : f->val;
+	d->free = f->free;
+	d->dup = f->dup;
+	return d;
+}
+
+/* =========================== LANGUAGE TAGS ============================== */
+
+/**
+ * Return true if the tag we're parsing is a language tag (language, region or
+ * locale).
+ */
+static int
+isLanguageTag(const char *key, int len) {
+	return strncasecmp("language", key, len) == 0 ||
+			strncasecmp("region", key, len) == 0 || strncasecmp("locale", key, len) == 0;
+}
+
+static int
+isAlpha(char c) {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+static int
+isAlphaNum(char c) {
+	return (c >= '0' && c <= '9') || isAlpha(c);
+}
+
+/**
+ * Parse language tag into a list of subtags.
+ */
+static List *
+parseLanguageTag(const char *val) {
+	List *list = NULL;
+	List **tail = &list;
+	static char subtag[9];
+	if (!*val) return NULL;
+	if (val[0] == '*') {
+		if (val[1] && val[1] != '-') return NULL;
+		*subtag = '\0';
+		strncat(subtag, val, 1);
+		*tail = list_conj(NULL, subtag, NULL, (void *(*)(void *))strdup, free);
+		tail = &(*tail)->tail;
+		if (!val[1]) return list;
+		val = &val[2];
+	}
+	while (1) {
+		int len = 0;
+		for (; len <= 8; len++)
+			if (!val[len] || !isAlphaNum(val[len]) || (!list && !isAlpha(val[len])))
+				break;
+		if (len < 1 || len > 8) return NULL;
+		if (val[len] && val[len] != '-') return NULL;
+		*subtag = '\0';
+		strncat(subtag, val, len);
+		*tail = list_conj(NULL, subtag, NULL, (void *(*)(void *))strdup, free);
+		tail = &(*tail)->tail;
+		if (!val[len]) return list;
+		val = &val[len + 1];
+	}
+	return NULL;
+}
+
+/**
+ * Serialize language tag.
+ *
+ * The returned string must be freed by the caller.
+ */
+static char *
+serializeLanguageTag(const List *tag) {
+	int len = 0;
+	const List *l;
+	for (l = tag; l; l = l->tail) len = len + 1 + strlen(l->head);
+	char *s = malloc(len * sizeof(char));
+	for (l = tag; l; l = l->tail) {
+		if (l != tag) s = strcat(s, "-");
+		s = strcat(s, l->head);
+	}
+	return s;
 }
 
 /* ======================================================================== */
@@ -210,8 +321,58 @@ cmpKeys(Feature *f1, Feature *f2) {
 static int
 cmpFeatures(Feature *f1, Feature *f2) {
 	int r = strcasecmp(f1->key, f2->key);
-	if (r == 0) r = strcasecmp(f1->val, f2->val);
-	return r;
+	if (r != 0) return r;
+	if (isLanguageTag(f1->key, MAXSTRING)) {
+		List *l1 = f1->val;
+		List *l2 = f2->val;
+		while (l1 && l2) {
+			r = strcasecmp(l1->head, l2->head);
+			if (r != 0) return r;
+			l1 = l1->tail;
+			l2 = l2->tail;
+		}
+		return l1 ? 1 : l2 ? -1 : 0;
+	} else
+		return strcasecmp(f1->val, f2->val);
+}
+
+/**
+ * Return a positive number if the given language tag matches the language range,
+ * 0 otherwise.
+ *
+ * In case of a perfect match, return 10. Otherwise, for each extra subtag that
+ * has no exact match in the range, subtract two.
+ *
+ * See also <https://datatracker.ietf.org/doc/html/rfc4647#section-3.3.2>
+ */
+static int
+matchLanguageTags(const List *tag, const List *range) {
+	static const int POS_MATCH = 10;
+	static const int EXTRA = -2;
+	int q = POS_MATCH;
+	if (*((char *)range->head) == '*')
+		q += EXTRA;
+	else if (strcasecmp(tag->head, range->head) != 0)
+		return 0;
+	range = range->tail;
+	tag = tag->tail;
+	while (range) {
+		if (!tag) return 0;
+		if (strcasecmp(tag->head, range->head) == 0) {
+			range = range->tail;
+			tag = tag->tail;
+			continue;
+		} else if (strlen(tag->head) == 1)
+			return 0;
+		else
+			q += EXTRA;
+		tag = tag->tail;
+	}
+	while (tag) {
+		q += EXTRA;
+		tag = tag->tail;
+	}
+	return q;
 }
 
 /**
@@ -275,32 +436,40 @@ matchFeatureLists(const List *query, const List *tableFeatures, int fuzzy) {
 				while (l && cmpKeys(l->head, l2->head) == 0) l = l->tail;
 				l2 = l;
 			} else {
-				int pos = 0;
 				const List *l = l2;
-				while (1) {
-					if (!pos) {
-						char *v = ((Feature *)l->head)->val;
-						char *v1 = ((Feature *)l1->head)->val;
-						if (strcasecmp(v1, v) == 0)
-							pos = 1;
-						else {
-							char *k = ((Feature *)l->head)->key;
-							if (strcasecmp(k, "unicode-range") == 0) {
+				char *k = ((Feature *)l->head)->key;
+				int best = negMatch;
+				if (isLanguageTag(k, MAXSTRING)) {
+					while (1) {
+						// special handling of language tags: tags in the
+						// table are intepreted as language ranges
+						List *v = ((Feature *)l->head)->val;
+						List *v1 = ((Feature *)l1->head)->val;
+						int q = matchLanguageTags(v1, v);
+						if (q > 0 && q > best) best = q;
+						l = l->tail;
+						if (!l || cmpKeys(l->head, l2->head) != 0) break;
+					}
+				} else {
+					while (1) {
+						if (best < 0) {
+							char *v = ((Feature *)l->head)->val;
+							char *v1 = ((Feature *)l1->head)->val;
+							if (strcasecmp(v1, v) == 0)
+								best = posMatch;
+							else if (strcasecmp(k, "unicode-range") == 0) {
 								// special handling of unicode-range: ucs2 in
 								// table also matches ucs4 in query
 								if (strcasecmp(v1, "ucs4") == 0 &&
 										strcasecmp(v, "ucs2") == 0)
-									pos = 1;
+									best = posMatch;
 							}
 						}
+						l = l->tail;
+						if (!l || cmpKeys(l->head, l2->head) != 0) break;
 					}
-					l = l->tail;
-					if (!l || cmpKeys(l->head, l2->head) != 0) break;
 				}
-				if (pos)
-					quotient += posMatch;
-				else
-					quotient += negMatch;
+				quotient += best;
 				l1 = l1->tail;
 				l2 = l;
 			}
@@ -314,8 +483,7 @@ matchFeatureLists(const List *query, const List *tableFeatures, int fuzzy) {
  */
 static int
 isValidChar(char c) {
-	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-			c == '-' || c == '.' || c == '_';
+	return isAlphaNum(c) || c == '-' || c == '.' || c == '_';
 }
 
 /**
@@ -353,30 +521,52 @@ parseQuery(const char *query) {
 				char *k = malloc(keySize + 1);
 				k[keySize] = '\0';
 				memcpy(k, key, keySize);
-				if (strcasecmp(k, "locale") == 0) {
-					// locale is shorthand for language + region
-					FeatureWithImportance f1 = { feature_new("language", v), 0 };
-					FeatureWithImportance f2 = { feature_new("region", v), 0 };
-					_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'",
-							f1.feature.key, f1.feature.val);
-					_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'",
-							f2.feature.key, f2.feature.val);
-					features =
-							list_conj(list_conj(features,
-											  memcpy(malloc(sizeof(f1)), &f1, sizeof(f1)),
-											  NULL, NULL, (void (*)(void *))feature_free),
-									memcpy(malloc(sizeof(f2)), &f2, sizeof(f2)), NULL,
-									NULL, (void (*)(void *))feature_free);
+				if (isLanguageTag(k, keySize)) {
+					if (!v) goto compile_error;
+					List *tag = parseLanguageTag(v);
+					if (!tag) {
+						_lou_logMessage(LOU_LOG_ERROR, "Not a valid language tag: %s", v);
+						list_free(features);
+						return NULL;
+					}
+					if (strcasecmp(k, "locale") == 0) {
+						// locale is shorthand for language + region
+						FeatureWithImportance f1 = { feat_new("language", tag, NULL,
+															 (void (*)(void *))list_free),
+							0 };
+						FeatureWithImportance f2 = { feat_new("region", list_dup(tag),
+															 NULL,
+															 (void (*)(void *))list_free),
+							0 };
+						_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'",
+								f1.feature.key, v);
+						_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'",
+								f2.feature.key, v);
+						features = list_conj(features,
+								memcpy(malloc(sizeof(f1)), &f1, sizeof(f1)), NULL, NULL,
+								(void (*)(void *))feat_free);
+						features = list_conj(features,
+								memcpy(malloc(sizeof(f2)), &f2, sizeof(f2)), NULL, NULL,
+								(void (*)(void *))feat_free);
+					} else {
+						FeatureWithImportance f = {
+							feat_new(k, tag, NULL, (void (*)(void *))list_free), 0
+						};
+						_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'", k, v);
+						features = list_conj(features,
+								memcpy(malloc(sizeof(f)), &f, sizeof(f)), NULL, NULL,
+								(void (*)(void *))feat_free);
+					}
 				} else {
-					FeatureWithImportance f = { feature_new(k, v), 0 };
-					_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'",
-							f.feature.key, f.feature.val);
+					if (!v) v = "yes";
+					FeatureWithImportance f = { feat_new(k, v, (void *(*)(void *))strdup,
+														(void (*)(void *))free),
+						0 };
+					_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'", k, v);
 					features =
 							list_conj(features, memcpy(malloc(sizeof(f)), &f, sizeof(f)),
-									NULL, NULL, (void (*)(void *))feature_free);
-					if (strcasecmp(k, "unicode-range") == 0) {
-						unicodeRange = 1;
-					}
+									NULL, NULL, (void (*)(void *))feat_free);
+					if (strcasecmp(k, "unicode-range") == 0) unicodeRange = 1;
 				}
 				free(k);
 				free(v);
@@ -413,11 +603,14 @@ parseQuery(const char *query) {
 		static char value[5] = "";
 		if (!*value) sprintf(value, "ucs%d", CHARSIZE);
 		FeatureWithImportance *f = memcpy(malloc(sizeof(FeatureWithImportance)),
-				(&(FeatureWithImportance){ feature_new("unicode-range", value), -1 }),
+				(&(FeatureWithImportance){
+						feat_new("unicode-range", value, (void *(*)(void *))strdup,
+								(void (*)(void *))free),
+						-1 }),
 				sizeof(FeatureWithImportance));
 		_lou_logMessage(LOU_LOG_DEBUG, "Table has feature '%s:%s'", f->feature.key,
 				f->feature.val);
-		features = list_conj(features, f, NULL, NULL, (void (*)(void *))feature_free);
+		features = list_conj(features, f, NULL, NULL, (void (*)(void *))feat_free);
 	}
 	// attach importance to features
 	{
@@ -511,6 +704,8 @@ analyzeTable(const char *table, int activeOnly) {
 							keySize++;
 							info.linepos++;
 						}
+						char *k = widestrToStr(key, keySize);
+						int isLangTag = isLanguageTag(k, keySize);
 						if (info.linepos < info.linelen &&
 								info.line[info.linepos] == ':') {
 							info.linepos++;
@@ -519,7 +714,9 @@ analyzeTable(const char *table, int activeOnly) {
 								info.linepos++;
 							if (info.linepos < info.linelen &&
 									(!active ||
-											isValidChar((char)info.line[info.linepos]))) {
+											isValidChar((char)info.line[info.linepos]) ||
+											(isLangTag &&
+													'*' == info.line[info.linepos]))) {
 								val = &info.line[info.linepos];
 								valSize = 1;
 								info.linepos++;
@@ -556,50 +753,76 @@ analyzeTable(const char *table, int activeOnly) {
 								if (j > 0 && v[j - 1] == ' ') j--;
 								v[j] = '\0';
 							}
-							char *k = widestrToStr(key, keySize);
-							if (strcasecmp(k, "locale") == 0) {
-								FeatureWithLineNumber *f1 =
-										memcpy(malloc(sizeof(FeatureWithLineNumber)),
-												(&(FeatureWithLineNumber){
-														feature_new("language", v),
-														info.lineNumber }),
-												sizeof(FeatureWithLineNumber));
-								FeatureWithLineNumber *f2 =
-										memcpy(malloc(sizeof(FeatureWithLineNumber)),
-												(&(FeatureWithLineNumber){
-														feature_new("region", v),
-														info.lineNumber }),
-												sizeof(FeatureWithLineNumber));
-								_lou_logMessage(LOU_LOG_DEBUG,
-										"Table has feature '%s:%s'", f1->feature.key,
-										f1->feature.val);
-								_lou_logMessage(LOU_LOG_DEBUG,
-										"Table has feature '%s:%s'", f2->feature.key,
-										f2->feature.val);
-								features = list_conj(
-										features = list_conj(features, f1, NULL, NULL,
-												(void (*)(void *))feature_free),
-										f2, NULL, NULL, (void (*)(void *))feature_free);
-								if (!language) language = f1;
-								if (!region) region = f2;
+							if (isLangTag) {
+								if (!v) goto compile_error;
+								List *tag = parseLanguageTag(v);
+								if (!tag) {
+									_lou_logMessage(LOU_LOG_ERROR,
+											"Not a valid language tag: %s (line %d)", v,
+											info.lineNumber);
+									list_free(features);
+									return NULL;
+								}
+								if (strcasecmp(k, "locale") == 0) {
+									FeatureWithLineNumber *f1 = memcpy(
+											malloc(sizeof(FeatureWithLineNumber)),
+											(&(FeatureWithLineNumber){
+													feat_new("language", tag, NULL,
+															(void (*)(void *))list_free),
+													info.lineNumber }),
+											sizeof(FeatureWithLineNumber));
+									FeatureWithLineNumber *f2 = memcpy(
+											malloc(sizeof(FeatureWithLineNumber)),
+											(&(FeatureWithLineNumber){
+													feat_new("region", list_dup(tag),
+															NULL,
+															(void (*)(void *))list_free),
+													info.lineNumber }),
+											sizeof(FeatureWithLineNumber));
+									_lou_logMessage(LOU_LOG_DEBUG,
+											"Table has feature '%s:%s'", f1->feature.key,
+											v);
+									_lou_logMessage(LOU_LOG_DEBUG,
+											"Table has feature '%s:%s'", f2->feature.key,
+											v);
+									features = list_conj(features, f1, NULL, NULL,
+											(void (*)(void *))feat_free);
+									features = list_conj(features, f2, NULL, NULL,
+											(void (*)(void *))feat_free);
+									if (!language) language = f1;
+									if (!region) region = f2;
+								} else {
+									FeatureWithLineNumber *f = memcpy(
+											malloc(sizeof(FeatureWithLineNumber)),
+											(&(FeatureWithLineNumber){
+													feat_new(k, tag, NULL,
+															(void (*)(void *))list_free),
+													info.lineNumber }),
+											sizeof(FeatureWithLineNumber));
+									_lou_logMessage(LOU_LOG_DEBUG,
+											"Table has feature '%s:%s'", k, v);
+									features = list_conj(features, f, NULL, NULL,
+											(void (*)(void *))feat_free);
+									if (strcasecmp(k, "language") == 0) {
+										if (!language) language = f;
+									} else if (strcasecmp(k, "region") == 0) {
+										if (!region) region = f;
+									}
+								}
 							} else {
+								if (!v) v = "yes";
 								FeatureWithLineNumber *f = memcpy(
 										malloc(sizeof(FeatureWithLineNumber)),
 										(&(FeatureWithLineNumber){
-												feature_new(k, v), info.lineNumber }),
+												feat_new(k, v, (void *(*)(void *))strdup,
+														(void (*)(void *))free),
+												info.lineNumber }),
 										sizeof(FeatureWithLineNumber));
-								_lou_logMessage(LOU_LOG_DEBUG,
-										"Table has feature '%s:%s'", f->feature.key,
-										f->feature.val);
+								_lou_logMessage(
+										LOU_LOG_DEBUG, "Table has feature '%s:%s'", k, v);
 								features = list_conj(features, f, NULL, NULL,
-										(void (*)(void *))feature_free);
-								if (strcasecmp(k, "language") == 0) {
-									if (!language) language = f;
-								} else if (strcasecmp(k, "region") == 0) {
-									if (!region) region = f;
-								} else if (strcasecmp(k, "unicode-range") == 0) {
-									unicodeRange = 1;
-								}
+										(void (*)(void *))feat_free);
+								if (strcasecmp(k, "unicode-range") == 0) unicodeRange = 1;
 							}
 							free(k);
 							free(v);
@@ -616,22 +839,28 @@ analyzeTable(const char *table, int activeOnly) {
 		if (!region && language) {
 			region = memcpy(malloc(sizeof(FeatureWithLineNumber)),
 					(&(FeatureWithLineNumber){
-							feature_new("region", language->feature.val), -1 }),
+							feat_new("region", language->feature.val,
+									language->feature.dup, language->feature.free),
+							-1 }),
 					sizeof(FeatureWithLineNumber));
-			_lou_logMessage(LOU_LOG_DEBUG, "Table has feature '%s:%s'",
-					region->feature.key, region->feature.val);
-			features = list_conj(
-					features, region, NULL, NULL, (void (*)(void *))feature_free);
+			char *v = serializeLanguageTag(region->feature.val);
+			_lou_logMessage(
+					LOU_LOG_DEBUG, "Table has feature '%s:%s'", region->feature.key, v);
+			free(v);
+			features =
+					list_conj(features, region, NULL, NULL, (void (*)(void *))feat_free);
 		}
 		if (features && !unicodeRange) {
 			// by default we assume unicode-range: ucs2
 			FeatureWithLineNumber *f = memcpy(malloc(sizeof(FeatureWithLineNumber)),
 					(&(FeatureWithLineNumber){
-							feature_new("unicode-range", "ucs2"), -1 }),
+							feat_new("unicode-range", "ucs2", (void *(*)(void *))strdup,
+									(void (*)(void *))free),
+							-1 }),
 					sizeof(FeatureWithLineNumber));
 			_lou_logMessage(LOU_LOG_DEBUG, "Table has feature '%s:%s'", f->feature.key,
 					f->feature.val);
-			features = list_conj(features, f, NULL, NULL, (void (*)(void *))feature_free);
+			features = list_conj(features, f, NULL, NULL, (void (*)(void *))feat_free);
 		}
 	} else
 		_lou_logMessage(LOU_LOG_ERROR, "Cannot open table '%s'", info.fileName);
@@ -837,7 +1066,10 @@ lou_getTableInfo(const char *table, const char *key) {
 		int cmp = strcasecmp(f->feature.key, key);
 		if (cmp == 0) {
 			if (lineNumber < 0 || lineNumber > f->lineNumber) {
-				value = strdup(f->feature.val);
+				if (isLanguageTag(key, MAXSTRING))
+					value = serializeLanguageTag(f->feature.val);
+				else
+					value = strdup(f->feature.val);
 				lineNumber = f->lineNumber;
 			}
 		} else if (cmp > 0) {

--- a/tables/he-IL.utb
+++ b/tables/he-IL.utb
@@ -25,7 +25,7 @@
 #+language: he
 #+language: ar
 #+language: en
-#+region:mul-IL
+#+region: *-IL
 #+type: literary
 #+dots: 6
 #+contraction: no


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/html/rfc4647#section-3.3.2

This will make selecting a braille table for your language more automatic, if the language is a dialect that has no dedicated table.