### PR TITLE
Remove loweredDigits6dots from Spanish Character Definitions

### DIFF
--- a/tables/es-chardefs.cti
+++ b/tables/es-chardefs.cti
@@ -68,7 +68,6 @@ math        \x002B        235                 +                   PLUS SIGN
 punctuation \x002C        2                   ,                   COMMA
 punctuation \x002D        36                  -                   HYPHEN-MINUS
 punctuation \x002E        3                   .                   FULL STOP
-include loweredDigits6Dots.uti
 punctuation \x003A        25                  :                   COLON
 punctuation \x003B        23                  ;                   SEMICOLON
 math        \x003C        246                 <                   LESS-THAN SIGN

--- a/tests/braille-specs/es-g2.yaml
+++ b/tests/braille-specs/es-g2.yaml
@@ -1,4 +1,5 @@
 # Copyright © 2018 Juan Pablo Bello
+# Copyright © 2024 Bert Frees
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -592,3 +593,12 @@ tests:
   - - es su ¿bikini?
     - ⠫ ⠜ ⠢⠐⠃⠊⠅⠊⠝⠊⠐⠢
     - xfail: unresolved multipass situation
+
+table:
+  language: es
+  grade: 1
+flags: {testmode: bothDirections}
+tests:
+  # back-translation of punctuation
+  - - ":"
+    - ⠒ # should not back-translate to "3"


### PR DESCRIPTION
Iván argote Pérez wrote on the mailing list:

> Hello, would you please consider taking ths file to replace the one for Spanish? the line lowdigit has been removed as it did cause punctuation being represented as numbers, as it is in computer English Braille. It is quite complicated for me to open a github ticket, but it won't make any othor side effect change as Spanish table does not have grade 2, thank and best regards.

So I opened a pull request with his changes. I think it sounds reasonable. 