### PR TITLE
Ascii braille 246 should be left square bracket, not left curly bracket

### DIFF
--- a/tables/text_nabcc.dis
+++ b/tables/text_nabcc.dis
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # liblouis  comes with ABSOLUTELY NO WARRANTY.
 
-# This is a description of the default text translation table used by BRLTTY.  
+# This is a description of the default text translation table used by BRLTTY.
 # It's based on the North American Braille Computer Code, but defines the full
 # Latin1 (ISO-8859-1) character set.
 
@@ -42,7 +42,7 @@
 # This table is synchronized with Text/en-nabcc.ttb table from the BRLTTY
 # project, except the re-added no-break space mapping.
 
-# The space and the 26 lowercase letters (a-z) are the same as in literary 
+# The space and the 26 lowercase letters (a-z) are the same as in literary
 # braille:
 
 #        Hex   Dots       Dec Char Description
@@ -74,7 +74,7 @@ display \x0078 1346     # 120 x    LATIN SMALL LETTER X
 display \x0079 13456    # 121 y    LATIN SMALL LETTER Y
 display \x007a 1356     # 122 z    LATIN SMALL LETTER Z
 
-# The 26 uppercase letters A-Z) are the same as their lowercase counterparts 
+# The 26 uppercase letters A-Z) are the same as their lowercase counterparts
 # except that dot7 is added:
 
 #        Hex   Dots       Dec Char Description
@@ -131,15 +131,15 @@ display \x002f 34       #  47 /    SOLIDUS
 display \x0028 12356    #  40 (    LEFT PARENTHESIS
 display \x0029 23456    #  41 )    RIGHT PARENTHESIS
 
-# With all of these major considerations having been taken into account, 
-# convenient representations were still available, and are used, for some of 
+# With all of these major considerations having been taken into account,
+# convenient representations were still available, and are used, for some of
 # the remaining characters:
 
 #        Hex   Dots       Dec Char Description
 display \x0026 12346    #  38 &    AMPERSAND
 display \x0023 3456     #  35 #    NUMBER SIGN
 
-# The remaining characters are what they are. Dot 7 isn't used either within 
+# The remaining characters are what they are. Dot 7 isn't used either within
 # the number block (32-63) or, with the exception of the DEL control character
 # (127), within the lowercase block (96-127). With the exception of the
 # underscore (95), dot 7 is used for every character within the uppercase block
@@ -158,10 +158,10 @@ display \x0027 3        #  39 '    APOSTROPHE
 display \x0060 4        #  96 `    GRAVE ACCENT
 display \x005e 457      #  94 ^    CIRCUMFLEX ACCENT
 display \x007e 45       # 126 ~    TILDE
-display \x005b 2467     #  91 [    LEFT SQUARE BRACKET
-display \x005d 124567   #  93 ]    RIGHT SQUARE BRACKET
-display \x007b 246      # 123 {    LEFT CURLY BRACKET
-display \x007d 12456    # 125 }    RIGHT CURLY BRACKET
+display \x005b 246      #  91 [    LEFT SQUARE BRACKET
+display \x005d 12456    #  93 ]    RIGHT SQUARE BRACKET
+display \x007b 2467     # 123 {    LEFT CURLY BRACKET
+display \x007d 124567   # 125 }    RIGHT CURLY BRACKET
 display \x003d 123456   #  61 =    EQUALS SIGN
 display \x003c 126      #  60 <    LESS-THAN SIGN
 display \x003e 345      #  62 >    GREATER-THAN SIGN

--- a/tables/yi.utb
+++ b/tables/yi.utb
@@ -148,6 +148,7 @@ endcapsword 6-3
 include litdigits6Dots.uti
 
 # display/passthrough for unicode braille
+include text_nabcc.dis
 include braille-patterns.cti
 
 # include the hebrew braille table

--- a/tests/braille-specs/yi.yaml
+++ b/tests/braille-specs/yi.yaml
@@ -21,6 +21,7 @@ table:
   grade: 1
   dots: 6
   __assert-match: yi.utb
+
 tests:
   - # Vos makht a yid - uses tsvey-vovn, komets-alef, pasekh-alef, and khirik-yud
     - װאָס מאַכט אַ ייִד
@@ -70,3 +71,20 @@ tests:
   - # mistome - contains the letter tof
     - מסתּמא
     - ⠍⠎⠳⠍⠁
+
+
+
+display: text_nabcc.dis
+
+# Test for uncontracted braille
+table:
+  language: yi
+  type: literary
+  grade: 1
+  dots: 6
+  __assert-match: yi.utb
+
+tests:
+  - # ikh gey mit aykh in gevet oyf vifl ir vilt
+    - איך גײ מיט אײַך אין געװעט אױף װיפֿל איר װילט
+    - aj* g5 mjt a0* ajn gevet a[f vjfl ajr vjlt


### PR DESCRIPTION
I'm a Yiddish teacher, and I have a blind student in my class who reads braille. We recently added a Yiddish table to LibLouis (thank you!). I figured out how to use the table to make a .brf file for my student to read, and now my student is happily learning and reading Yiddish on his braille computer. Everything is fabulous. 

Then, we tried to convert a second Yiddish book into braille using our new LibLouis table. 

I used this [new incantation](https://github.com/liblouis/liblouis/issues/1575) that I learned from @egli for transforming a Yiddish book into braille: 
```
 lou_translate --forward text_nabcc.dis,yi.utb < path/to/file.txt > path/to/file.brf
 ```
And that was great, because I got our book from unicode Yiddish to ascii braille in one step.

However, it had a slightly unexpected result: 

the character which I had defined in my table as dots 246 came out from text_nabcc.dis as a left curly bracket. When I sent the ascii braille file to my student to load up in his braille reader, left curly bracket was displayed as a blank space character. I checked the other ascii braille book I had made (where I used unicode.dis to generate unicode braille and then I used a different process to convert it to ascii braille), and that process had given me left square bracket for dots 246. When I did a find-and-replace on the left curly bracket to replace it with left square bracket, that got the 246 dots to render for my student.

Does that mean there's an error in text_nabcc.dis? Or might that mean that there's a slightly different ascii braille system that's being used on the decoding side in the proprietary firmware that powers my student's braille reader device? 

Or is it something else?  From my cursory google searches, ASCII braille seems like it is case-insensitive (so like, lower-case a is the same as upper-case A). The way to type left curly bracket is to hit shift plus left-square-bracket. So maybe some "let's be case-insensitive" code somewhere is converting left-square bracket to left curly bracket, and then some other "let's be case-sensitive" code (or running that in a "brackets don't have uppercase" environment) is failing to do the reverse. 

I googled it, and left square bracket seems to be commonly used in ascii braille for 246. however, in the ascii braille charts i found from googling, I could only find images. I have found no actual text that confirms this conjecture, but the images seem to agree with my student's braille computer that left square bracket is 246.

I wrote a spec expecting to get `[` instead of `{` for the character that makes dot 246, and made a change to the text_nabcc.dis file to get it to pass.  but those changes caused other tests to fail. If I'm right that it's a typo in the display table, then it's hard for me to know whether or not I should be trusting these tests that my change would break something, or whether that means there's also an error in the tests and I should change those, too. would changing the ascii braille for 246 to use `[` instead of `{` be a breaking change, or would it make the software work better? I can't tell. 

So I'm tentatively making this pull request, but in its current state, there are four failing test files. I'm hoping you can help me figure out what is going on here, and if this change makes sense and is worth changing these tests' output over.

