### PR TITLE
drop python<=3.7 support

### DIFF
--- a/tools/lou_maketable.d/make_suggestions.py
+++ b/tools/lou_maketable.d/make_suggestions.py
@@ -25,7 +25,7 @@ def update_counters(total, init=False):
     if not init:
         sys.stderr.write("\033[1A\033[K")
         sys.stderr.write("\033[1A\033[K")
-    sys.stderr.write(("%d words processed\n" % total))
+    sys.stderr.write("%d words processed\n" % total)
     sys.stderr.flush()
 
 def main():
@@ -79,7 +79,7 @@ def main():
                     for rule in suggest_rules:
                         println("%(opcode)s\t%(text)s\t%(braille)s" % rule)
                 else:
-                    println("# >>>\t%s\t%s" % (text, braille or ""))
+                    println("# >>>\t{}\t{}".format(text, braille or ""))
                     for comment in comments:
                         println("# | " + comment)
                     println("# |__")

--- a/tools/lou_maketable.d/submit_rows.py
+++ b/tools/lou_maketable.d/submit_rows.py
@@ -34,10 +34,10 @@ class Reader:
         if not row or row[0].startswith("#"):
             return next(self)
         if not len(row) == 3:
-            printerrln('expected 3 columns, got %s: %s' % (len(row),row))
+            printerrln('expected 3 columns, got {}: {}'.format(len(row),row))
             exit(1)
         if not row[0] == "":
-            printerrln("expected first column to be empty, got '%s'" % (row[0],))
+            printerrln("expected first column to be empty, got '{}'".format(row[0]))
             exit(1)
         maybe_chunked_text, braille = row[1:3]
         maybe_chunked_text = to_lowercase(maybe_chunked_text)
@@ -45,7 +45,7 @@ class Reader:
         braille = braille if braille != "" else None
         if braille != None:
             if '0' in to_dot_pattern(braille).split('-'):
-                printerrln('invalid braille: %s' % (braille,))
+                printerrln('invalid braille: {}'.format(braille))
                 exit(1)
         exit_if_not(not chunked_text or validate_chunks(chunked_text))
         return {'text': text,

--- a/tools/lou_maketable.d/submit_rules.py
+++ b/tools/lou_maketable.d/submit_rules.py
@@ -45,7 +45,7 @@ def main():
     for line in fileinput.FileInput(args.FILE, openhook=fileinput.hook_encoded("utf-8")):
         m = p.match(line)
         if not m:
-            printerrln("%s: rule is not valid" % (line,))
+            printerrln("{}: rule is not valid".format(line))
             exit(1)
         exit_if_not(m)
         add_or_delete, nocross, opcode, text, braille, _, _ = m.groups()
@@ -62,16 +62,16 @@ def main():
             rule = list(rule)
             if add_or_delete == '-':
                 if not rule:
-                    printerrln("%s%s %s %s: rule can not be deleted because not in %s" % (nocross,opcode,text,braille,args.CONTRACTION_TABLE))
+                    printerrln("{}{} {} {}: rule can not be deleted because not in {}".format(nocross,opcode,text,braille,args.CONTRACTION_TABLE))
                     exit(1)
             else:
                 if rule:
-                    printerrln("%s%s %s %s: rule can not be added because already in %s" % (nocross,opcode,text,braille,args.CONTRACTION_TABLE))
+                    printerrln("{}{} {} {}: rule can not be added because already in {}".format(nocross,opcode,text,braille,args.CONTRACTION_TABLE))
                     exit(1)
                 rule = {"opcode": opcode, "nocross": nocross, "text": text, "braille": braille, "comment": comment}
                 rules.append(rule)
     opcode_order = {"word": 1, "always": 2, "begword": 3, "endword": 4, "midword": 5, "begmidword": 6, "midendword": 7, "prfword": 8, "sufword": 9}
     for rule in sorted(rules, key=lambda rule: (rule["text"], rule["nocross"], opcode_order[rule["opcode"]])):
-        println(u"{nocross:<9}{opcode:<10} {text:<10} {braille:<30} {comment}".format(**rule))
+        println("{nocross:<9}{opcode:<10} {text:<10} {braille:<30} {comment}".format(**rule))
 
 if __name__ == "__main__": main()

--- a/tools/lou_maketable.d/utils.py
+++ b/tools/lou_maketable.d/utils.py
@@ -39,10 +39,10 @@ liblouis.toLowercase.argtypes = (c_wchar,)
 liblouis.toLowercase.restype = c_wchar
 
 def println(line=""):
-    sys.stdout.write(("%s\n" % line))
+    sys.stdout.write("%s\n" % line)
 
 def printerrln(line=""):
-    sys.stderr.write(("%s\n" % line))
+    sys.stderr.write("%s\n" % line)
 
 def validate_chunks(chunked_text):
     return re.search(r"^([^)(|]+|\([^)(|][^)(|]+\))(\|?([^)(|]+|\([^)(|][^)(|]+\)))*$", chunked_text) != None
@@ -170,7 +170,7 @@ def translate(text):
     return c_braille.value, c_rules[0:c_rules_len.value]
 
 def get_rule(c_rule_pointer):
-    c_rule_string = create_unicode_buffer(u"", 128)
+    c_rule_string = create_unicode_buffer("", 128)
     if not liblouis.printRule(cast(c_rule_pointer, c_void_p), c_rule_string):
         return None
     return tuple(c_rule_string.value.split("\t"))
@@ -189,7 +189,7 @@ def suggest_chunks(text, braille):
 def find_relevant_rules(text):
     c_text = create_unicode_buffer(text)
     max_rules = 16
-    c_rules = [u""] * max_rules + [None]
+    c_rules = [""] * max_rules + [None]
     for i in range(0, max_rules):
         c_rules[i] = create_unicode_buffer(c_rules[i], 128)
         c_rules[i] = cast(c_rules[i], c_wchar_p)


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.