### PR TITLE
[fix](lou_checkyaml): fix some memory issues in checkyaml

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1406,12 +1406,14 @@ _lou_extParseChars(const char *inString, widechar *outString) {
 	   For this function, the functional nature should be maintained,
 	   i.e. the same input -> the same behavior.
 	   Therefore, `errorCount` should not be externally influenced. */
+	int oldErrorCount = errorCount;
 	errorCount = 0;
 	parseChars(NULL, &result, &wideIn);
 	if (errorCount) {
 		errorCount = 0;
 		return 0;
 	}
+	errorCount = oldErrorCount;
 	for (k = 0; k < result.length; k++) outString[k] = result.chars[k];
 	return result.length;
 }

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1403,7 +1403,6 @@ _lou_extParseChars(const char *inString, widechar *outString) {
 	for (k = 0; inString[k] && k < MAXSTRING - 1; k++) wideIn.chars[k] = inString[k];
 	wideIn.chars[k] = 0;
 	wideIn.length = k;
-	/* Fix issue #1535. */
 	if (!parseChars(NULL, &result, &wideIn)) return 0;
 	for (k = 0; k < result.length; k++) outString[k] = result.chars[k];
 	return result.length;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1403,8 +1403,8 @@ _lou_extParseChars(const char *inString, widechar *outString) {
 	wideIn.chars[k] = 0;
 	wideIn.length = k;
 	/* Fix issue #1535.
-	   For this function, the functional nature should be maintained, 
-	   i.e. the same input -> the same behavior. 
+	   For this function, the functional nature should be maintained,
+	   i.e. the same input -> the same behavior.
 	   Therefore, `errorCount` should not be externally influenced. */
 	errorCount = 0;
 	parseChars(NULL, &result, &wideIn);

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4568,7 +4568,7 @@ compileString(const char *inString, TranslationTableHeader **table,
 	file.lineNumber = 1;
 	file.status = 0;
 	file.linepos = 0;
-	for (k = 0; inString[k]; k++) file.line[k] = inString[k];
+	for (k = 0; k < MAXSTRING - 1 && inString[k]; k++) file.line[k] = inString[k];
 	file.line[k] = 0;
 	file.linelen = k;
 	if (table && *table && (*table)->finalized) {

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -625,6 +625,7 @@ putDots(const FileInfo *file, widechar d, TranslationTableHeader **table, int ru
 
 static CharDotsMapping *
 getDotsForChar(widechar c, const DisplayTableHeader *table) {
+	if (table == NULL) return NULL;
 	CharDotsMapping *cdPtr;
 	const TranslationTableOffset bucket = table->charToDots[_lou_charHash(c)];
 	TranslationTableOffset offset = bucket;
@@ -638,6 +639,7 @@ getDotsForChar(widechar c, const DisplayTableHeader *table) {
 
 static CharDotsMapping *
 getCharForDots(widechar d, const DisplayTableHeader *table) {
+	if (table == NULL) return NULL;
 	CharDotsMapping *cdPtr;
 	const TranslationTableOffset bucket = table->dotsToChar[_lou_charHash(d)];
 	TranslationTableOffset offset = bucket;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1402,6 +1402,11 @@ _lou_extParseChars(const char *inString, widechar *outString) {
 	for (k = 0; inString[k] && k < MAXSTRING - 1; k++) wideIn.chars[k] = inString[k];
 	wideIn.chars[k] = 0;
 	wideIn.length = k;
+	/* Fix issue #1535.
+	   For this function, the functional nature should be maintained, 
+	   i.e. the same input -> the same behavior. 
+	   Therefore, `errorCount` should not be externally influenced. */
+	errorCount = 0;
 	parseChars(NULL, &result, &wideIn);
 	if (errorCount) {
 		errorCount = 0;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5066,7 +5066,7 @@ _lou_getTable(const char *tableList, const char *displayTableList,
 		const TranslationTableHeader **translationTable,
 		const DisplayTableHeader **displayTable) {
 	TranslationTableHeader *newTable;
-	DisplayTableHeader *newDisplayTable;
+	DisplayTableHeader *newDisplayTable = NULL;
 	getTable(tableList, displayTableList, &newTable, &newDisplayTable);
 	if (newTable)
 		if (!finalizeTable(newTable)) newTable = NULL;

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -266,9 +266,9 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		}
-		
+
 		currentPass--;
-		// If not goodTrans, we need to break out of the loop directly, 
+		// If not goodTrans, we need to break out of the loop directly,
 		// as realInlen might be an uninitialized value in this case.
 		if (!goodTrans) break;
 

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -266,6 +266,12 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 					appliedRules, &appliedRulesCount, maxAppliedRules);
 			break;
 		}
+		
+		currentPass--;
+		// If not goodTrans, we need to break out of the loop directly, 
+		// as realInlen might be an uninitialized value in this case.
+		if (!goodTrans) break;
+
 		passPosMapping[realInlen] = output.length;
 		if (passPosMapping == posMapping) {
 			passPosMapping = posMapping2;
@@ -299,8 +305,7 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 				}
 			}
 		}
-		currentPass--;
-		if (currentPass >= lastPass && goodTrans) {
+		if (currentPass >= lastPass) {
 			releaseStringBuffer(input.bufferIndex);
 			input = (InString){ .chars = output.chars,
 				.length = output.length,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -755,7 +755,7 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 		*passCharDots = 1;
 	while (*passIC < transRule->dotslen) {
 		int itsTrue = 1;  // whether we have a match or not
-		// check if `pos` is within the input string, 
+		// check if `pos` is within the input string,
 		// maybe a unsigned type would be better to omit negative values
 		if (pos > input->length || pos < 0) return 0;
 		switch ((*passInstructions)[*passIC]) {
@@ -2924,11 +2924,12 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 		if (!in_word && wordBuffer[i] & WORD_CHAR) {
 			in_word = 1;
 			last_word_start = i;
-		} else /* check if at end of word */
+		} else { /* check if at end of word */
 			if (in_word && !(wordBuffer[i] & WORD_CHAR)) {
 				in_word = 0;
 				last_word_end = i;
 			}
+		}
 
 		/* check for symbol or word indicator */
 		if (!in_emph_word &&
@@ -2950,7 +2951,7 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 				} else
 					goto end_passage;
 			}
-		} else /* check for word end indicator or word end */
+		} else { /* check for word end indicator or word end */
 			if ((in_emph_word &&
 						(buffer[i].word & class->value &&
 								buffer[i].end & class->value)) ||
@@ -2961,6 +2962,7 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 					last_pass_word_end = i;
 				}
 			}
+		}
 
 		/* check if possibly at beginning of passage */
 		if (!in_pass && (in_emph_word || last_emph_symbol == i)) {
@@ -2972,7 +2974,7 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 				last_pass_word_end = -1;
 				pass_word_cnt = 1;
 			}
-		} else /* check if at end of passage */
+		} else { /* check if at end of passage */
 			if (in_pass) {
 				if (in_word && !(in_emph_word || last_emph_symbol == i)) {
 				end_passage:
@@ -3000,6 +3002,7 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 					}
 				}
 			}
+		}
 	}
 }
 

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -755,7 +755,9 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 		*passCharDots = 1;
 	while (*passIC < transRule->dotslen) {
 		int itsTrue = 1;  // whether we have a match or not
-		if (pos > input->length) return 0;
+		// check if `pos` is within the input string, 
+		// maybe a unsigned type would be better to omit negative values
+		if (pos > input->length || pos < 0) return 0;
 		switch ((*passInstructions)[*passIC]) {
 		case pass_first:
 			if (pos != 0) itsTrue = 0;
@@ -882,7 +884,8 @@ passDoTest(const TranslationTableHeader *table, int pos, const InString *input,
 				startReplace = startMatch;
 				endReplace = endMatch;
 			}
-			if (startReplace < startMatch)
+			// Check whetehr endReplace != -1 while startReplace! = -1
+			if (startReplace < startMatch || endReplace == -1)
 				return 0;
 			else {
 				*match = (PassRuleMatch){ .startMatch = startMatch,
@@ -3877,7 +3880,7 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 					if (!putCharacter(input->chars[pos], table, pos, input, output,
 								posMapping, cursorPosition, cursorStatus, mode))
 						goto failure;
-					pos++;
+					if (++pos >= input->length) break;
 				}
 			}
 			break;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -607,7 +607,7 @@ doPassSearch(const TranslationTableHeader *table, const InString *input,
 		*searchPos = pos;
 		while (*searchIC < transRule->dotslen) {
 			int itsTrue = 1;  // whether we have a match or not
-			if (*searchPos > input->length) return 0;
+			if (*searchPos >= input->length) return 0;
 			switch (passInstructions[*searchIC]) {
 			case pass_lookback:
 				*searchPos -= passInstructions[*searchIC + 1];

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -262,7 +262,7 @@ check_base(const char *tableList, const char *input, const char *expected,
 		int error_printed = 0;
 		// The expected_inputPos array may be shorter than the actual input length.
 		for (i = 0; i < outlen || i < expectedlen; i++) {
-			if (i < outlen && i < expectedlen && expected_inputPos[i] == inputPos[i]) 
+			if (i < outlen && i < expectedlen && expected_inputPos[i] == inputPos[i])
 				continue;
 			retval = 1;
 			if (in.diagnostics) {

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -134,7 +134,9 @@ check_base(const char *tableList, const char *input, const char *expected,
 	int *outputPos = NULL;
 	int cursorPos = 0;
 	inbuf = malloc(sizeof(widechar) * inlen);
-	outbuf = malloc(sizeof(widechar) * outlen);
+	// + 1 : reserved for the '\0' terminator of C-format string argument used in
+	// `print_widechars`
+	outbuf = malloc(sizeof(widechar) * (outlen + 1));
 	expectedbuf = malloc(sizeof(widechar) * expectedlen);
 	if (in.typeform != NULL) {
 		typeformbuf = malloc(outlen * sizeof(formtype));
@@ -190,7 +192,9 @@ check_base(const char *tableList, const char *input, const char *expected,
 			// Hm, something is not quite right. Try again with a larger outbuf
 			free(outbuf);
 			outlen = inlen * outlen_multiplier * (k + 1);
-			outbuf = malloc(sizeof(widechar) * outlen);
+			// + 1 : reserved for the '\0' terminator of C-format string argument used in
+			// `print_widechars`
+			outbuf = malloc(sizeof(widechar) * (outlen + 1));
 			if (expected_inputPos) {
 				free(inputPos);
 				inputPos = malloc(sizeof(int) * outlen);

--- a/tools/brl_checks.c
+++ b/tools/brl_checks.c
@@ -256,16 +256,25 @@ check_base(const char *tableList, const char *input, const char *expected,
 	}
 	if (expected_inputPos) {
 		int error_printed = 0;
-		for (i = 0; i < outlen; i++) {
-			if (expected_inputPos[i] != inputPos[i]) {
-				retval = 1;
-				if (in.diagnostics) {
-					if (!error_printed) {  // Print only once
-						fprintf(stderr, "Input position failure:\n");
-						error_printed = 1;
-					}
+		// The expected_inputPos array may be shorter than the actual input length.
+		for (i = 0; i < outlen || i < expectedlen; i++) {
+			if (i < outlen && i < expectedlen && expected_inputPos[i] == inputPos[i]) 
+				continue;
+			retval = 1;
+			if (in.diagnostics) {
+				if (!error_printed) {  // Print only once
+					fprintf(stderr, "Input position failure:\n");
+					error_printed = 1;
+				}
+				if (i < outlen && i < expectedlen) {
 					fprintf(stderr, "Expected %d, received %d in index %d\n",
 							expected_inputPos[i], inputPos[i], i);
+				} else if (i < expectedlen) {
+					fprintf(stderr, "Expected %d, received nothing in index %d\n",
+							expected_inputPos[i], i);
+				} else {
+					fprintf(stderr, "Expected nothing, received %d in index %d\n",
+							inputPos[i], i);
 				}
 			}
 		}

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -308,7 +308,7 @@ read_table(yaml_event_t *start_event, yaml_parser_t *parser, const char *display
 	emph_classes = lou_getEmphClasses(v->name);	 // get declared emphasis classes
 	if (emph_classes == NULL) {
 		error_at_line(EXIT_FAILURE, 0, file_name, start_event->start_mark.line + 1,
-				"No declared emphasis classes found in table %s", v->name);
+				"Failed to fetch the emphasis classes list in table %s", v->name);
 	}
 	table_name = strdup((char *)v->name);
 	if (!display_table) {

--- a/tools/lou_checkyaml.c
+++ b/tools/lou_checkyaml.c
@@ -306,6 +306,10 @@ read_table(yaml_event_t *start_event, yaml_parser_t *parser, const char *display
 				"Table %s not valid", v->name);
 	free(emph_classes);
 	emph_classes = lou_getEmphClasses(v->name);	 // get declared emphasis classes
+	if (emph_classes == NULL) {
+		error_at_line(EXIT_FAILURE, 0, file_name, start_event->start_mark.line + 1,
+				"No declared emphasis classes found in table %s", v->name);
+	}
 	table_name = strdup((char *)v->name);
 	if (!display_table) {
 		if (v->content) {


### PR DESCRIPTION
I have created the relevant issues #1530 , #1531 , #1532 , #1533 , #1534 , #1535 , #1536 , #1537 , #1538 , #1539

According to the PoC of those issues, I made initial fixes to these issues. 

Note that in addition to adding some check guards, I tried to make some more core fixes, which modified the original semantics and may break the normal program logic.

The core fixes are listed as follows:
- 00bbd1bfd9ba841e1dd2cef62e455ff030aaa29d : Fix #1532; Make sure `match.endMarch >= 0 && match.endReplace >= 0`
- 6e0248a7f10a9d4caf9552028453c0f3ac3bf437 : Fix #1533; If a bad translation occurs, break the loop and skip some processing.
- 6da6d2754eb61194e668a47f3e0f0c8c79d60bca : Fix #1535; Make `_lou_extParseChars` a pure function, i.e., the same input always results in the same behavior.
- f6caa1914e0feee9da924dbcc36a7d6ae730942e : Fix #1537; Refer to the handling of `expectedbuf` and `outbuf`, and additionally check cases other than `i < expectedlen & & i < outlen`
- c5668edea1920c966d6066626e968bb0bb217b35 : Fix #1538; Allocate `outbuf` with one more unit memory for tailing `'\0'` in printing
