### PR TITLE
Add hungarian braille-specs documentation subpage link

### DIFF
--- a/tables/hu-hu-comp8.ctb
+++ b/tables/hu-hu-comp8.ctb
@@ -11,14 +11,7 @@
 # as it is a computer Braille table.
 #+direction:both
 #
-# TODO: Please correct the metadata above. It is not meant to be
-# accurate nor complete. It hasn't been verified by the table
-# author yet. It is merely an attempt by the liblouis maintainers
-# to get some sensible initial values in place.
-#
-# TODO: Please add a reference to official documentation about
-# the implemented braille code. Preferably submit the documents
-# to https://github.com/liblouis/braille-specs.
+# Braille-specs documentation link: https://liblouis.io/braille-specs/hungarian
 # -----------
 #
 #  Based on the Linux screenreader BRLTTY, copyright (C) 1999-2011 by the BRLTTY Team

--- a/tables/hu-hu-g2.ctb
+++ b/tables/hu-hu-g2.ctb
@@ -12,9 +12,7 @@
 # as tests only run forward.
 #+direction:both
 #
-# TODO: Please add a reference to official documentation about
-# the implemented braille code. Preferably submit the documents
-# to https://github.com/liblouis/braille-specs.
+# Braille-specs documentation link: https://liblouis.io/braille-specs/hungarian
 # -----------
 #
 #  Copyright (C) 2017-2022 Attila Hammer from IT Foundation for the Visually Impaired - Hungary. www.infoalap.hu

--- a/tables/hu.tbl
+++ b/tables/hu.tbl
@@ -8,8 +8,6 @@
 # Marked as "direction:both" by Bue Vester-Andersen
 # as tests run both forward and backward
 #+direction:both
-# TODO: Please add a reference to official documentation about
-# the implemented braille code. Preferably submit the documents
-# to https://github.com/liblouis/braille-specs.
+# Braille-specs documentation link: https://liblouis.io/braille-specs/hungarian
 include hu-hu-g1.ctb
 include braille-patterns.cti


### PR DESCRIPTION
Hy Boys,

@egli, @bertfrees, I added new [Hungarian subpage braille-specification documentation page](https://liblouis.io/braille-specs/hungarian) with awailable the main Braille-specs liblouis.io page.
If good this type completion form and have a little time, please add this change to the 3.31 milestone list, approve these three table metadata  changes, and merge this change to the Liblouis master branch before 3.31 release publication.
I tryed doing a very short, absolute simple but good one line completion with affected tables/hu.tbl, hu-hu-comp8.ctb, and hu-hu-g2.ctb main table files with contains braille-specs required metadata part.
Other subtable files and test case files I think doesn't contains a required braille-specs page link request part, so doesn't need extending this files this one line related change.
If I known wrong, please tell me the other files and I paste this one line to the required files.

Thanks the good cooperation and wish a good Liblouis 3.31 release in september,

Attila