### PR TITLE
Initialize table pointers to avoid unintitialized values

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5064,7 +5064,7 @@ void EXPORT_CALL
 _lou_getTable(const char *tableList, const char *displayTableList,
 		const TranslationTableHeader **translationTable,
 		const DisplayTableHeader **displayTable) {
-	TranslationTableHeader *newTable;
+	TranslationTableHeader *newTable = NULL;
 	DisplayTableHeader *newDisplayTable = NULL;
 	getTable(tableList, displayTableList, &newTable, &newDisplayTable);
 	if (newTable)
@@ -5076,8 +5076,8 @@ _lou_getTable(const char *tableList, const char *displayTableList,
 /* Checks and loads tableList. */
 const void *EXPORT_CALL
 lou_getTable(const char *tableList) {
-	const TranslationTableHeader *table;
-	const DisplayTableHeader *displayTable;
+	const TranslationTableHeader *table = NULL;
+	const DisplayTableHeader *displayTable = NULL;
 	_lou_getTable(tableList, tableList, &table, &displayTable);
 	if (!table || !displayTable) return NULL;
 	return table;
@@ -5085,7 +5085,7 @@ lou_getTable(const char *tableList) {
 
 const TranslationTableHeader *EXPORT_CALL
 _lou_getTranslationTable(const char *tableList) {
-	TranslationTableHeader *table;
+	TranslationTableHeader *table = NULL;
 	getTable(tableList, NULL, &table, NULL);
 	if (table)
 		if (!finalizeTable(table)) table = NULL;
@@ -5094,7 +5094,7 @@ _lou_getTranslationTable(const char *tableList) {
 
 const DisplayTableHeader *EXPORT_CALL
 _lou_getDisplayTable(const char *tableList) {
-	DisplayTableHeader *table;
+	DisplayTableHeader *table = NULL;
 	getTable(NULL, tableList, NULL, &table);
 	return table;
 }


### PR DESCRIPTION
The oss-fuzz project discovered some problems with uninitialized values in the various `getTable` functions. See below for a very thorough report. The problems should be fixed with this change.

See also issue 71354 : liblouis: Unintialized pointer in _lou_getTable (https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=71354)

> The root cause is that is an unintialized pointer (`newTable`) here: https://github.com/liblouis/liblouis/blob/9741262fb98f6f569d10c27f442d69c71a3abd19/liblouis/compileTranslationTable.c#L5067

```
void EXPORT_CALL
_lou_getTable(const char *tableList, const char *displayTableList,
		const TranslationTableHeader **translationTable,
		const DisplayTableHeader **displayTable) {
	TranslationTableHeader *newTable;
	DisplayTableHeader *newDisplayTable = NULL;
	getTable(tableList, displayTableList, &newTable, &newDisplayTable);
	if (newTable)
		if (!finalizeTable(newTable)) newTable = NULL;
	*translationTable = newTable;
	*displayTable = newDisplayTable;
}
```

> `getTable()` is not guaranteed to set `newTable`. For instance, in this case here (https://github.com/liblouis/liblouis/blob/9741262fb98f6f569d10c27f442d69c71a3abd19/liblouis/compileTranslationTable.c#L5108):

```
void
getTable(const char *translationTableList, const char *displayTableList,
		TranslationTableHeader **translationTable, DisplayTableHeader **displayTable) {
	/* Keep track of which tables have already been compiled */
	int translationTableListLen, displayTableListLen = 0;
	if (translationTableList == NULL || *translationTableList == 0)
		translationTable = NULL;
```

> If `translationTableList` is an empty string, then the passed `translationTable` (pointer to `newTable`) is reset to NULL, leaving `newTable` with an unintitialized value. 

> This then leads to `finalizeTable()` being called on an uninitalized `newTable` value.
