### PR TITLE
Add tests for Satzzeichen in Wörtern

### DIFF
--- a/tests/braille-specs/de-g0.yaml
+++ b/tests/braille-specs/de-g0.yaml
@@ -882,3 +882,19 @@ tests:
     - "-.two words'."
     - typeform:
         downgrade: "+++++++++"
+
+# 2.13 Satzzeichen in Wörtern (see page 85 of "Das System der deutschen Brailleschrift")
+  - - "Hundert(e)"
+    - "hundert'=e="
+  - - "Hundert[e]"
+    - "hundert''=e'="
+  - - "Student(inn)en"
+    - "student'=inn'=en"
+  - - "Student[inn]en"
+    - "student''=inn''=en"
+  - - "Haus\"rats\"versicherung"
+    - "haus'(rats')versicherung"
+    - xfail: not implemented
+  - - "Haus'rats'versicherung"
+    - "haus''(rats'')versicherung"
+    - xfail: not implemented

--- a/tests/braille-specs/de-g1.yaml
+++ b/tests/braille-specs/de-g1.yaml
@@ -798,3 +798,19 @@ tests:
     - "-.two words'."
     - typeform:
         downgrade: "+++++++++"
+
+# 2.13 Satzzeichen in Wörtern (see page 86 of "Das System der deutschen Brailleschrift")
+  - - "Hundert(e)"
+    - "hundert'=e="
+  - - "Hundert[e]"
+    - "hundert''=e'="
+  - - "Student(inn)en"
+    - "}udent'=inn'=en"
+  - - "Student[inn]en"
+    - "}udent''=inn''=en"
+  - - "Haus\"rats\"versicherung"
+    - "h1s'(rats')versi4erung"
+    - xfail: not implemented
+  - - "Haus'rats'versicherung"
+    - "h1s''(rats'')versi4erung"
+    - xfail: not implemented

--- a/tests/braille-specs/de-g2.yaml
+++ b/tests/braille-specs/de-g2.yaml
@@ -770,3 +770,19 @@ tests:
     - "'w'"
   - - "z'"
     - "'z'"
+
+# 2.13 Satzzeichen in Wörtern (see page 86 of "Das System der deutschen Brailleschrift")
+  - - "Hundert(e)"
+    - "h/d7t'=e="
+  - - "Hundert[e]"
+    - "h/d7t''=e'="
+  - - "Student(inn)en"
+    - "}udct'=*n'=c"
+  - - "Student[inn]en"
+    - "}udct''=*n''=c"
+  - - "Haus\"rats\"versicherung"
+    - "h1s'(rats')v7s#7u"
+    - xfail: not implemented
+  - - "Haus'rats'versicherung"
+    - "h1s''(rats'')v7s#7u"
+    - xfail: not implemented


### PR DESCRIPTION
The examples are straight out of _Das System der deutschen Brailleschrift_.

These examples show IMHO that the bug report in #1097 is not correct and the corresponding PR #1407 is wrong