### PR TITLE
Add #+language:sv-FI to Finnish tables

### DIFF
--- a/tables/fi-fi-8dot.ctb
+++ b/tables/fi-fi-8dot.ctb
@@ -5,6 +5,7 @@
 #-display-name: Finnish computer braille
 #
 #+language:fi
+#+language:sv-FI
 #+type:computer
 #+dots:8
 # Marked as "direction:both" by Bue Vester-Andersen

--- a/tables/fi.utb
+++ b/tables/fi.utb
@@ -6,6 +6,7 @@
 #-name: Suomenkielinen 6-pisteen pistekirjoitustaulukko
 #
 #+language: fi
+#+language: sv-FI
 #+type: literary
 #+contraction: no
 #+dots: 6


### PR DESCRIPTION
This means Finland Swedish. See https://github.com/liblouis/braille-specs/pull/24#pullrequestreview-2359550033.

@samimaattaCelia Can you please verify this change?