### PR TITLE
Updated Spanish grade 1 table

### DIFF
--- a/tables/es-chardefs.cti
+++ b/tables/es-chardefs.cti
@@ -60,7 +60,7 @@ base uppercase       \x00DC \x00FC  Üü                  LATIN CAPITAL LETTER U
 
 punctuation \x0021        235                 !                   EXCLAMATION MARK
 punctuation \x0022        236                 "                   QUOTATION MARK
-punctuation \x0027        3                   '                   APOSTROPHE
+noback punctuation \x0027        3                   '                   APOSTROPHE
 punctuation \x0028        126                 (                   LEFT PARENTHESIS
 punctuation \x0029        345                 )                   RIGHT PARENTHESIS
 sign        \x002A        35                  *                   ASTERISK
@@ -68,7 +68,6 @@ math        \x002B        235                 +                   PLUS SIGN
 punctuation \x002C        2                   ,                   COMMA
 punctuation \x002D        36                  -                   HYPHEN-MINUS
 punctuation \x002E        3                   .                   FULL STOP
-include loweredDigits6Dots.uti
 punctuation \x003A        25                  :                   COLON
 punctuation \x003B        23                  ;                   SEMICOLON
 math        \x003C        246                 <                   LESS-THAN SIGN

--- a/tables/es-g1.ctb
+++ b/tables/es-g1.ctb
@@ -28,7 +28,9 @@
 include es-chardefs.cti
 include braille-patterns.cti
 include litdigits6Dots.uti
+include digits6Dots.uti
 
 numsign 3456
 capsletter 46
 begcapsword 46-46
+numericmodechars .,

--- a/tests/braille-specs/es-g0-g1.yaml
+++ b/tests/braille-specs/es-g0-g1.yaml
@@ -307,7 +307,7 @@ tests:
   - ['$', '⠸⠎']
   - ['%', '⠸⠴']
   - ['&', '⠠⠯']
-  - ['\x0027', '⠄']
+  - ['\x0027', '⠄', {xfail: {backward: "Apostrophe cannot be back-translated with dot 3"}}]
   - ['(', '⠣']
   - [')', '⠜']
   - ['*', '⠔']
@@ -315,8 +315,7 @@ tests:
     {xfail: {backward: "! defined first"}}]
   - [',', '⠂']
   - ['-', '⠤']
-  - ['.', '⠄',
-    {xfail: {backward: "Same as apostrophe"}}]
+  - ['.', '⠄']
   - ['/', '⠠⠂']
   - ['0', '⠼⠚']
   - ['1', '⠼⠁']
@@ -328,14 +327,14 @@ tests:
   - ['7', '⠼⠛']
   - ['8', '⠼⠓']
   - ['9', '⠼⠊']
-  - [':', '⠒', {xfail: {backward: "punctuation should not back-translate to '3'"}}]
-  - [';', '⠆', {xfail: {backward: "punctuation should not back-translate to '2'"}}]
+  - [':', '⠒']
+  - [';', '⠆']
   - ['<', '⠐⠅',
     {xfail: "Wrong def according to CBE"}]
-  - ['=', '⠶', {xfail: {backward: "punctuation should not back-translate to '7'"}}]
+  - ['=', '⠶']
   - ['>', '⠨⠂',
     {xfail: "Wrong def according to CBE"}]
-  - ['?', '⠢', {xfail: {backward: "punctuation should not back-translate to '5'"}}]
+  - ['?', '⠢']
   - ['@', '⠐']
   - ['A', '⠨⠁']
   - ['B', '⠨⠃']
@@ -595,7 +594,7 @@ tests:
     {xfail: "Not defined in the table"}]
   - ['ö', '⠠⠕',
     {xfail: "Not defined in the table"}]
-  - ['÷', '⠲', {xfail: {backward: "punctuation should not back-translate to '4'"}}]
+  - ['÷', '⠲']
   - ['ø', '⠠⠕',
     {xfail: "Not defined in the table"}]
   - ['ù', '⠠⠥',
@@ -668,8 +667,10 @@ tests:
   - ['●', '',
     {xfail: "Not defined in the table"}]
 
-# Pangrama
+  # Pangrama
   - ['Jovencillo emponzoñado de whisky: ¡qué figurota exhibe!',
     '⠨⠚⠕⠧⠑⠝⠉⠊⠇⠇⠕ ⠑⠍⠏⠕⠝⠵⠕⠻⠁⠙⠕ ⠙⠑ ⠺⠓⠊⠎⠅⠽⠒ ⠖⠟⠥⠮ ⠋⠊⠛⠥⠗⠕⠞⠁ ⠑⠭⠓⠊⠃⠑⠖',
     {xfail: {backward: "Inv ecxl. is backtranslated as !"}}]
 
+  # Numbers with decimals
+  - ['123.456,789', '⠼⠁⠃⠉⠄⠙⠑⠋⠂⠛⠓⠊']


### PR DESCRIPTION
- Removed lowered digits definitely
- Added the noback operator to the apostrophe symbol, since it conflicts with the period, which is used more used.
- Added period and comma as supported characters in numeric mode