### PR TITLE
Use _strnicmp on windows

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #ifdef _MSC_VER
 #include <windows.h>
+#define strncasecmp _strnicmp
 #else
 #include <dirent.h>
 #endif


### PR DESCRIPTION
On windows, strncasecmp is not available. _strnicmp should be functionally equivalent.

cc @bertfrees @egli 

fixes #1685 