### PR TITLE
Merge files from tests/ueb_test_data into en-ueb.yaml, solves #262

### DIFF
--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -94,6 +94,12 @@ tests:
   - ',-,,grt'
 - - OUT OF TOWN
   - ',,,| ( t{n,'''
+- - '[open TN]every'
+  - '`.<e'
+  - {xfail: 'transcriber note not defined'}
+- - '[open TN]In'
+  - '`.<,9'
+  - {xfail: 'transcriber note not defined'}
 - - –“[Be true.]”
   - ',-8.<,2 true4.>0'
 - - <x, y>
@@ -146,6 +152,9 @@ tests:
   - {typeform: {italic: '++++++++++++++++++++++++++++'}}
 - - ALWAYS BE YOURSELF
   - ',,,alw 2 yrf,'''
+- - '[open TN]His choice was D.[close TN]'
+  - '`.<,8 *oice 0 ;,d4`.>'
+  - {xfail: 'transcriber note not defined'}
 - - t'night
   - t'ni<t
 - - word(s)
@@ -176,6 +185,8 @@ tests:
   - ',braillex~r'
 - - Braille4All
   - ',braille#d,all'
+
+#   2.6.4 page 18
 - - ‘It'll
   - ',8,x''ll'
 - - '[X''ll'
@@ -248,6 +259,15 @@ tests:
   - '"9 "9 "9'
 
 # 3.4.1 page 23
+
+- - spo͞on
+  - sp@-<oo>n
+  - {xfail: true}
+- - masssun
+  - mass;;5<sun>
+  - {xfail: true}
+
+#   3.5.1 page 24
 
 - - 'Nutritional considerations include: • carbohydrates • protein • fat • cholesterol • fiber • sodium'
   - ',nutri;nal 3sid}a;ns 9clude3 _4 c>bohydrates _4 prote9 _4 fat _4 *ole/}ol _4 fib} _4 sodium'
@@ -400,6 +420,117 @@ tests:
 - - Joan – 〃 〃
   - ',joan ,- "1 "1'
 
+#   3.13.1 page 28
+
+#   3.14.1 page 29
+
+#   3.15.1 page 30
+- - 6′
+  - '#f7'
+- - 9″
+  - '#i77'
+- - 5′10″
+  - '#e7#aj77'
+- - 4' 11"
+  - '#d'' #aa,7'
+- - X″ long
+  - ',x77 l;g'
+
+#   3.16.1 page 30
+- - Amy Florence SAMPSON ♀ 1881-1956
+  - ',amy ,flor;e ,,sampson ^x #ahha-#aief'
+  - {xfail: true}
+- - Carlyle Kennedy SAMPSON ♂ 1885-1975
+  - ',c>lyle ,k5n$y ,,sampson ^y #ahhe-#aige'
+  - {xfail: true}
+
+#   3.17.1 page 31
+- - as easy as 2 + 2 = 4
+  - 'z easy z #b "6 #b "7 #d'
+- - corn − c + b = born
+  - 'corn "- ;c "6 ;b "7 born'
+- - 5 is 25% of 20 (5 ÷ 20 × 100)
+  - '#e is #be.0 ( #bj "<#e "/ #bj "8 #ajj">'
+- - positron < posi(tive) + (elec)tron
+  - 'positron @< posi"<tive"> "6 "<elec">tron'
+  - {xfail: true}
+- - +44 1234 567890 (UK phone number)
+  - '"6#dd"abcd"efghij "<,,UK ph"o numb]">'
+  - {xfail: true}
+- - a frame with an opening 7″W×5″H
+  - 'a frame ) an op5+ #g77,w"8#e77,h'
+- - 'a map with a scale of 1:500,000'
+  - 'a map ) a scale ( #a3#ejj1jjj'
+- - 'hand : arm :: foot : leg'
+  - 'h& 3 >m 33 foot 3 leg'
+
+#   3.18.1 page 32
+- - B♭ trumpet
+  - ',b#< trumpet'
+- - The C♯ pavilion is named for Cecil Sharp.
+  - ',! ,c#% pavilion is "nd = ,cecil ,%>p4'
+- - The scale of G major includes the note F♯.
+  - ',! scale ( ;,g major 9cludes ! note ,f#%4'
+- - A jazz 2-5-1 progression in C minor could be Dm7♭5 - G7♯9 - Cm7.
+  - ',a jazz #b-#e-#a progres.n 9 ;,c m9or cd 2 ,dm#g#<#e - ,g#g#%#i - ,cm#g4'
+- - The ♮ sign on a note cancels the effect of any ♯ or ♭ in the key signature.
+  - ',! #* sign on a note c.els ! e6ect ( any #% or #< 9 ! key signature4'
+- - the dominant chord g-b♮-d
+  - '! dom9ant *ord ;g-b#*-;d'
+- - ... we obtain the somewhat more transparent relation
+  - '444 we obta9 ! "s:at m transp>5t rela;n'
+# The following test results in an error with 16 bit unicode
+# - - 𝑋♭(𝑌) = 〈𝑋, 𝑌〉
+#   - ',x;9#<"<,y"> "7 @<,x1 ,y@>'
+- - for all vectors X and Y.
+  - '= all vectors ;,x & ;,y4'
+
+#   3.19.1 page 33
+- - '#4'
+  - '_?#d'
+- - 'Apt. #D'
+  - ',apt4 _?,d'
+- - '20# bag of flour'
+  - '#bj_? bag ( fl\r'
+  - {xfail: true}
+- - 'Press the # key on the telephone.'
+  - ',press ! _? key on ! teleph"o4'
+
+#   3.20.1 page 33
+- - ¶3
+  - '^p#c'
+  - {xfail: true}
+- - ¶C
+  - '^p,c'
+  - {xfail: true}
+- - ¶g
+  - '^pg'
+  - {xfail: true}
+- - Click on the ¶ icon on the toolbar.
+  - ',click on ! ^p icon on ! toolb>4'
+  - {xfail: true}
+- - §5
+  - '^s#e'
+  - {xfail: true}
+- - §K
+  - '^s,k'
+  - {xfail: true}
+- - §d
+  - '^sd'
+  - {xfail: true}
+- - §§ 5-15
+  - '^s^s #e-#ae'
+  - {xfail: true}
+
+#   3.21.1 page 33
+- - '5%'
+  - '#e.0'
+- - '95 %'
+  - '#ie .0'
+- - 'a 50% increase'
+  - 'a #ej.0 9cr1se'
+- - '% of population'
+  - '.0 ( popula;n'
 
 # 3.22.1 page 34
 
@@ -414,6 +545,63 @@ tests:
 - - '□ Director Rehabilitation Services'
   - ;$#d ,director ,rehabilita;n ,s}vices
 
+#   3.23.1 page 35
+
+#   3.24.1 page 36
+- - Wm
+  - ',w;9m'
+  - {xfail: true}
+- - H2O
+  - ',h;5#b,o'
+  - {xfail: true}
+- - 3 yd3
+  - '#c yd;9#c'
+  - {xfail: true}
+- - 4m2
+  - '#dm9#b'
+  - {xfail: true}
+- - vitamin B12
+  - 'vitam9 ,b;5#ab'
+  - {xfail: true}
+- - born in 1682.3
+  - 'born 9 #afhb49#c'
+  - {xfail: true}
+- - born in 1982.c
+  - 'born 9 #aihb49c'
+  - {xfail: true}
+- - 'America3 (America Cubed–name of a sailing ship)'
+  - ',am]ica;9#c "<,Am]ica ,cub$,-"n ( a sail+ %ip">'
+  - {xfail: true}
+- - an earthquake measuring 6.5MW
+  - an e>?quake m1sur+ #f4e,m5,w
+  - {xfail: true}
+- - the clarion1 horn
+  - '! cl>ion;9#a horn'
+  - {xfail: true}
+- - '1 clarion: loud and clear'
+  - ';9#a cl>ion3 l|d & cle>'
+  - {xfail: true}
+
+#   3.25.1 page 36
+- - 'head n. the top part of the body ... –by a ~ by the length of the animal''s head, as in horse racing –~ over heels tumbling as in a somersault'
+  - 'h1d ;n4 ! top "p ( ! body 444 ,-^7by a @9^'' by ! l5g? ( ! animal''s h1d1 z 9 horse rac+ ,-^7@9 ov] heels^'' tumbl+ z 9 a som]sault'
+  - {xfail: true}
+- - '~ vt. to be in charge of ...'
+  - '@9 vt4 to 2 9 *>ge ( 444'
+  - {xfail: true}
+- - 'An economist would write x ~ y to indicate that a consumer is indifferent between the goods x and y.'
+  - ',an economi/ wd write ;x @9 ;y to 9dicate t a 3sum] is 9di6]5t 2t ! gds ;x & ;y4'
+  - {xfail: true}
+- - 'http://www.business.com/~yourname'
+  - 'http3_/_/www4busi;s4com_/@9y\r"n'
+  - {xfail: true}
+- - 'Some people use the tilde around words to indicate an inflected tone of voice or singing as in ~Happy birthday to you~'
+  - ',"s p use ! tilde >.d ^ws to 9dicate an 9flect$ t"o ( voice or s++ z 9 @9,happy bir?"d to y\\@9'
+  - {xfail: true}
+
+#   3.26.1 page 37
+
+#   3.27.1 page 39
 
 # 3.28.1 (2019 update) page 2
 


### PR DESCRIPTION
The files contain most of the tests in en-ueb.yaml as well as other tests that were not added to en-ueb.yaml because they fail or contain other problems, e.g. containing unicode chars above \xffff. Some failed because an incorrect character had been used in the output, e.g. a capital in stead of a small letter. The really obvious ones have been fixed.
At some point, someone should convert the tests to using unicode braille instead, but not my decision.
