### PR TITLE
Fix back-translation of capital sign in Dutch

### DIFF
--- a/tables/nl-NL-g0.utb.in
+++ b/tables/nl-NL-g0.utb.in
@@ -419,7 +419,7 @@ _unibrl(    \x2824,  36)       ⠤
 _unibrl(    \x2825,  136)      ⠥
 _unibrl(    \x2826,  236)      ⠦
 _unibrl(    \x2827,  1236)     ⠧
-_unibrl(    \x2828,  46)       ⠨
+sign        \x2828   46e       ⠨
 _unibrl(    \x2829,  146)      ⠩
 _unibrl(    \x282A,  246)      ⠪
 _unibrl(    \x282B,  1246)     ⠫

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -384,7 +384,7 @@ tests:
 # back-translation of capital sign (see https://github.com/liblouis/liblouis/issues/1704)
 flags: {testmode: bothDirections}
 tests:
-  - [Winston Churchill, ⠨⠺⠊⠝⠎⠞⠕⠝ ⠨⠉⠓⠥⠗⠉⠓⠊⠇⠇, xfail: {backward: received "⠨winston ⠨churchill"}]
+  - [Winston Churchill, ⠨⠺⠊⠝⠎⠞⠕⠝ ⠨⠉⠓⠥⠗⠉⠓⠊⠇⠇]
 
 # Test virtual dots
 # The forward tests from above (except the xfail ones) are repeated

--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -381,6 +381,11 @@ tests:
     - ⠼⠁⠠⠁ ⠼⠁⠲⠠⠁ ⠼⠁⠂⠠⠁ ⠼⠁⠒⠠⠁
     - 1a 1.a 1,a 1:a
 
+# back-translation of capital sign (see https://github.com/liblouis/liblouis/issues/1704)
+flags: {testmode: bothDirections}
+tests:
+  - [Winston Churchill, ⠨⠺⠊⠝⠎⠞⠕⠝ ⠨⠉⠓⠥⠗⠉⠓⠊⠇⠇, xfail: {backward: received "⠨winston ⠨churchill"}]
+
 # Test virtual dots
 # The forward tests from above (except the xfail ones) are repeated
 # but with display table nl-print.dis instead of nl-unicode.dis.


### PR DESCRIPTION
Thanks @MarcWijnhoven for the bug report.