### PR TITLE
Norwegian: don't use permanent cap sign in words with mixed case

### DIFF
--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -205,9 +205,11 @@ nocont .zip
 noback pass2 @126-246-3 @126
 noback pass2 @135-2-345 @345
 noback pass2 @3456-3456 @3456-6-3456
-noback pass2 @5-356-0-6-14 @5-356-6-14
-noback pass2 @5-356-0-6-124 @5-356-6-124
-noback pass2 @5-356-0-6-13 @5-356-6-13
+
+# remove space after degree sign and before C (Celcius), F (Fahrenheit) or K (Kelvin)
+noback pass2 @5-356-0-6-14 @5-356-6-14    # ° C
+noback pass2 @5-356-0-6-124 @5-356-6-124  # ° F
+noback pass2 @5-356-0-6-13 @5-356-6-13    # ° K
 
 # subscript
 # ---------

--- a/tables/no-no-g0.utb
+++ b/tables/no-no-g0.utb
@@ -16,10 +16,12 @@
 #  Copyright (C) 2005 ViewPlus Technologies, Inc. www.viewplus.com
 #  Copyright (C) 2009-2023 Lars Bjørndal <lars@lamasti.net>
 #  Copyright (C) 2015-2018 NLB Norwegian library of talking books and braille, http://www.nlb.no/
+#  Copyright (C) 2025 Bert Frees
 #
 #-copyright: 2005, ViewPlus Technologies, Inc. www.viewplus.com
 #-copyright: 2009-2019, Lars Bjørndal
 #-copyright: 2015-2018, Norwegian library of talking books and braille (NLB), http://www.nlb.no/
+#-copyright: 2025, Bert Frees
 #-license: LGPLv2.1
 #
 # Created June 9, 2005 by Leon Ungier <Leon.Ungier@ViewPlus.com> with
@@ -96,13 +98,27 @@ comp6 Å 6-16
 #lowword - 36-36              # make double when hyphen surrounded by white spaces
 
 numsign 3456
-capsletter 6                    # single capital letter indicator
-begcapsword 6-6                  # a block of consecutive capital letters indicator
-noback endcapsword 56                   # TODO
+
+capsletter 6
+begcapsword 69-6
+noback endcapsword 569
 begcapsphrase 6-6-6
 lencapsphrase 2
 endcapsphrase after 6
 
+# variable #1 keeps track of when begcapsword has been suppressed
+noback pass2 _!$sp[@69-6]          ?#1=1   # suppress begcapsword when it is not the first character of the word
+noback pass2 [@69-6]$l.@569@234$sp @6-6    # suppress begcapsword if it needs to be terminated by a endcapsword,
+noback pass2 [@69-6]$l.@569@234~   @6-6    # unless the endcapsword is followed by a single "s"
+noback pass2 [@69-6]$l.@569        ?#1=1   #
+noback pass2 #1=1[]$l              @6      # insert capsletter before (uppercase) letter if begcapsword was suppressed
+noback pass2 #1=1@569              ?#1=0   # caps mode is terminated by endcapsword; suppress endcapsword if
+                                           # begcapsword was suppressed
+noback pass2 #1=1!$l               *#1=0   # caps mode is terminated by character that is not a letter
+
+# remove dot 9
+swapdd cleanvirtual 69,569 6,56
+noback pass4 %cleanvirtual %cleanvirtual
 
 emphclass italic
 emphclass underline

--- a/tests/braille-specs/no.yaml
+++ b/tests/braille-specs/no.yaml
@@ -246,25 +246,20 @@ tests:
   -
     - MediaLT RadiOrakel
     - ⠠⠍⠑⠙⠊⠁⠠⠇⠠⠞ ⠠⠗⠁⠙⠊⠠⠕⠗⠁⠅⠑⠇
-    - {xfail: true}
   - [KrFs leder er Knut Arild Hareide., ⠠⠅⠗⠠⠋⠎ ⠇⠑⠙⠑⠗ ⠑⠗ ⠠⠅⠝⠥⠞ ⠠⠁⠗⠊⠇⠙ ⠠⠓⠁⠗⠑⠊⠙⠑⠄]
   -
     - TVNorge har flere nyhetssendinger pr. dag.
     - ⠠⠞⠠⠧⠠⠝⠕⠗⠛⠑ ⠓⠁⠗ ⠋⠇⠑⠗⠑ ⠝⠽⠓⠑⠞⠎⠎⠑⠝⠙⠊⠝⠛⠑⠗ ⠏⠗⠄ ⠙⠁⠛⠄
-    - {xfail: true}
   -
     - DTBook NBfU
     - ⠠⠙⠠⠞⠠⠃⠕⠕⠅ ⠠⠝⠠⠃⠋⠠⠥
-    - {xfail: true}
   # when acronyms are mixed capitals and small letters, the capital sign should be present in front of each capital letter
   -
     - KrFU
     - ⠠⠅⠗⠠⠋⠠⠥
-    - {xfail: true}
   -
     - MHz kHz
     - ⠠⠍⠠⠓⠵ ⠅⠠⠓⠵
-    - {xfail: true}
   - [DnB NOR, ⠠⠙⠝⠠⠃ ⠠⠠⠝⠕⠗]
   -
     - CO2 NaCl
@@ -592,7 +587,6 @@ tests:
   -
     - Radiostasjonen sender på 98,4 MHz.
     - ⠠⠗⠁⠙⠊⠕⠎⠞⠁⠎⠚⠕⠝⠑⠝ ⠎⠑⠝⠙⠑⠗ ⠏⠡ ⠼⠊⠓⠂⠙ ⠠⠍⠠⠓⠵⠄
-    - {xfail: true}
   - [Dokumentet var ikke større enn 20 kB., ⠠⠙⠕⠅⠥⠍⠑⠝⠞⠑⠞ ⠧⠁⠗ ⠊⠅⠅⠑ ⠎⠞⠪⠗⠗⠑ ⠑⠝⠝ ⠼⠃⠚ ⠅⠠⠃⠄]
   # Degrees
   - [Vinkelen var 45°., ⠠⠧⠊⠝⠅⠑⠇⠑⠝ ⠧⠁⠗ ⠼⠙⠑⠐⠴⠄]
@@ -681,7 +675,7 @@ tests:
     - ⠓⠞⠞⠏⠎⠒⠌⠌⠺⠺⠺⠄⠃⠞⠄⠝⠕⠌⠅⠥⠇⠞⠥⠗⠌⠊⠌⠵⠠⠑⠼⠑⠭⠭⠃⠌⠏⠊⠁⠝⠊⠎⠞⠑⠝⠑⠤⠅⠕⠍⠤⠍⠑⠙⠤⠥⠝⠛⠙⠕⠍⠍⠑⠇⠊⠛⠤⠊⠧⠑⠗⠤⠍⠑⠝⠤⠕⠗⠅⠑⠎⠞⠑⠗⠑⠞⠤⠎⠁⠁⠤⠥⠞⠤⠞⠊⠇⠤⠁⠁⠤⠅⠚⠑⠙⠑⠤⠎⠑⠛
   -
     - https://www.faktisk.no/faktasjekker/wRV/100-havorner-funnet-drept-av-vindturbiner-på-smola
-    - ⠓⠞⠞⠏⠎⠒⠌⠌⠺⠺⠺⠄⠋⠁⠅⠞⠊⠎⠅⠄⠝⠕⠌⠋⠁⠅⠞⠁⠎⠚⠑⠅⠅⠑⠗⠌⠺⠠⠠⠗⠧⠌⠼⠁⠚⠚⠤⠓⠁⠧⠕⠗⠝⠑⠗⠤⠋⠥⠝⠝⠑⠞⠤⠙⠗⠑⠏⠞⠤⠁⠧⠤⠧⠊⠝⠙⠞⠥⠗⠃⠊⠝⠑⠗⠤⠏⠡⠤⠎⠍⠕⠇⠁
+    - ⠓⠞⠞⠏⠎⠒⠌⠌⠺⠺⠺⠄⠋⠁⠅⠞⠊⠎⠅⠄⠝⠕⠌⠋⠁⠅⠞⠁⠎⠚⠑⠅⠅⠑⠗⠌⠺⠠⠗⠠⠧⠠⠌⠼⠁⠚⠚⠤⠓⠁⠧⠕⠗⠝⠑⠗⠤⠋⠥⠝⠝⠑⠞⠤⠙⠗⠑⠏⠞⠤⠁⠧⠤⠧⠊⠝⠙⠞⠥⠗⠃⠊⠝⠑⠗⠤⠏⠡⠤⠎⠍⠕⠇⠁
 
   -
     - Ole.Martin.Hansen@cde.no
@@ -855,6 +849,11 @@ tests:
     - ⠠⠠⠉⠕⠡⠼⠃
   - - CO₂₂
     - ⠠⠠⠉⠕⠡⠦⠼⠃⠃⠴
+  - - H2O
+    - ⠠⠓⠡⠼⠃⠠⠕
+    - typeform: {sub: ' + '}
+  - - H₂O
+    - ⠠⠓⠡⠼⠃⠠⠕
   # Diacritics
   # Letter with diacritical mark, as precomposed character
   - - 'á' # U+00e1


### PR DESCRIPTION
Got conformation from @larsbjorndal  that the changed URL test was wrong and is now correct.

Fixes https://github.com/liblouis/liblouis/issues/1725