### PR TITLE
Small fix to UEB, words containing "somer"

### DIFF
--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -20,7 +20,9 @@
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
 #  Copyright (C) 2016 American Printing House for the Blind, Inc. www.aph.org
 #  Copyright (C) 2016 Joseph Lee <joseph.lee22590@gmail.com>
-#  Copyright (C) 2019-2021 RNIB, www.rnib.org.uk
+#  Copyright (C) 2019-2025 RNIB <www.rnib.org.uk>
+#  Copyright (C) 2022 Krzysztof Drewniak <krzysdrewniak@gmail.com>
+#  Copyright (C) 2023-2024 Anthony Tibbs
 #
 #  This file is part of liblouis.
 #

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -1394,20 +1394,16 @@ always right 5-1235
 # some   10.7.7
 always some 5-234
 
-match - somer [Ii][Cc] 234-135-134-12456
-match - somer [Ii][Ss][MTmt] 234-135-134-12456
-match - somer [Oo][Uu][Ss] 234-135-134-12456
+match - somer %a 234-135-134-12456
 match - some [Tt][Ee][Rr] 234-135-134-15
 match - some [Tt][Rr][AaEeIiOoUuYy] 234-135-134-15
 always somever 234-135-134-5-15
 
 sufword besomer 23-234-135-134-12456
 sufword blossomed 12-123-135-234-234-135-134-1246
-always isomer 24-234-135-134-12456
-sufword ransomed 1235-1-1345-234-135-134-1246
-sufword somersault 234-135-134-12456-234-1-136-123-2345
-sufword somerset 234-135-134-12456-234-15-2345
-sufword unbosomed 136-1345-12-135-234-135-134-1246
+match - isom [Ee][DRdr] =
+match - osom [Ee][DRdr] =
+match - ransom [Ee][DNRdnr] =
 
 # spirit
 always spirit 456-234


### PR DESCRIPTION
Originally created by @jrbowden (https://github.com/liblouis/liblouis/pull/1733):

Fix a small number of words containing "somer", e.g. the place "Somerville".
Updated tests to match.