### PR TITLE
tables/hu-backtranslate-word-corrections.cti, tables/hu-exceptionwords.cti: added newest founded few exceptions

### DIFF
--- a/tables/hu-backtranslate-word-corrections.cti
+++ b/tables/hu-backtranslate-word-corrections.cti
@@ -2832,6 +2832,10 @@ nofor correct "aladásszim" *	For example haladásszimpatizáns word
 nofor correct "ALADÁSSZIM" *	For example HALADÁSSZIMPATIZÁNS word
 nofor correct "ússzínj" "úszszínj"	For example túszszínjáték word
 nofor correct "ÚSSZÍNJ" "ÚSZSZÍNJ"	For example TÚSZSZÍNJÁTÉK word
+nofor correct "ultussztál" "ultuszsztál"	For example kultuszsztálinizmus word
+nofor correct "ULTUSSZTÁL" "ULTUSZSZTÁL"	For example KULTUSZSZTÁLINIZMUS word
+nofor correct "űzvésszez" "űzvészszez"	For example tűzvészszezon word
+nofor correct "ŰZVÉSSZEZ" "ŰZVÉSZSZEZ"	For example TŰZVÉSZSZEZON word
 
 #zszs backtranslated word corrections
 nofor correct "törzszsel" "törzzsel"


### PR DESCRIPTION
Hi Boys,

Yesterday I founds few backtranslation exceptions, with fortunatelly only minor important related word back-translation.
Test results is following:
* Other languages affected: no, only hungarian subtable files are accepted.
* Make -j12 check command into the test directory result: passed all Liblouis tests.
* Larger hungarian corpus test: passed.

Since this pull request contains a negligible new word (if I find any new exceptions by tonight, I will add them as fixup commits), please only add this pull request to the 3.33 milestone list if it is possible to approve and merge before the new release on March 3rd.
From tomorrow until March 3rd, I will be doing a complete freeze on Hungarian tables, during which time no new changes will be implemented to make your work easier.
As usual, the first commit contains the new reversion exceptions, the second commit contains the test case file expansion.

Sorry the late pull request, and thank you the good cooperation.
Larger back-translation exception changes are fortunatelly already merged the 3.33.0 future release.
I wish for you a very good new release,

Attila