### PR TITLE
pass_endTest should only return 1 (match) when "pass_endTest" instruction is reached

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1492,7 +1492,7 @@ back_passDoTest(const TranslationTableHeader *table, int pos, const InString *in
 		if ((!notOperator && !itsTrue) || (notOperator && itsTrue)) return 0;
 		notOperator = 0;
 	}
-	return 1;
+	return 0;
 }
 
 static int


### PR DESCRIPTION
not when the while loop finishes without having reached the instruction. That it ever reaches this point might be another bug.

See https://github.com/liblouis/liblouis/issues/1719.