### PR TITLE
Add test to cover issue in Dutch g0 table that was fixed by Davy Kager

### DIFF
--- a/tests/braille-specs/nl-g0_harness.yaml
+++ b/tests/braille-specs/nl-g0_harness.yaml
@@ -339,6 +339,10 @@ tests:
     - ⠄⠸⠸⠍⠑⠑⠗ ⠙⠁⠝ ⠙⠗⠊⠑ ⠺⠕⠕⠗⠙⠑⠝ ⠊⠝ ⠸⠉⠥⠗⠎⠊⠑⠋⠄
     - typeform:
         italic: ' ++++++++++++++++++++++++++++++++ '
+  - - "Namens de jury heet ik jullie allen hartelijk welkom voor de wedstrijd Wie maakt de lekkerste bonbon van Nederland."
+    - ⠨⠝⠁⠍⠑⠝⠎ ⠙⠑ ⠚⠥⠗⠽ ⠓⠑⠑⠞ ⠊⠅ ⠚⠥⠇⠇⠊⠑ ⠁⠇⠇⠑⠝ ⠓⠁⠗⠞⠑⠇⠊⠚⠅ ⠺⠑⠇⠅⠕⠍ ⠧⠕⠕⠗ ⠙⠑ ⠺⠑⠙⠎⠞⠗⠊⠚⠙ ⠸⠸⠨⠺⠊⠑ ⠍⠁⠁⠅⠞ ⠙⠑ ⠇⠑⠅⠅⠑⠗⠎⠞⠑ ⠃⠕⠝⠃⠕⠝ ⠧⠁⠝ ⠸⠨⠝⠑⠙⠑⠗⠇⠁⠝⠙⠸⠲
+    - typeform:
+        italic: '                                                                       +++++++++++++++++++++++++++++++++++++++++++ '
   # volgorde van hoofdletterteken en drukwijzigingsteken (drukwijzigingsteken eerst)
   - - CURSIEF
     - ⠸⠘⠉⠥⠗⠎⠊⠑⠋
@@ -773,6 +777,10 @@ tests:
     - "'⠸⠸meer dan drie woorden in ⠸cursief'"
     - typeform:
         italic: ' ++++++++++++++++++++++++++++++++ '
+  - - "Namens de jury heet ik jullie allen hartelijk welkom voor de wedstrijd Wie maakt de lekkerste bonbon van Nederland."
+    - "⠨Namens de jury heet ik jullie allen hartelijk welkom voor de wedstrijd ⠸⠸⠨Wie maakt de lekkerste bonbon van ⠸⠨Nederland⠸."
+    - typeform:
+        italic: '                                                                       +++++++++++++++++++++++++++++++++++++++++++ '
   - - CURSIEF
     - ⠸⠘CURSIEF
     - typeform:


### PR DESCRIPTION
When an emphasized segment is followed by a period (but the period is not emphasized), the emphasis should be ended at the last word, not the second-to-last word.

See https://github.com/liblouis/liblouis/commit/5ebac22a54