### PR TITLE
Deprecate no_translate for input

### DIFF
--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -76,6 +76,8 @@ typedef enum {
 	emph_9 = 0x0100,
 	emph_10 = 0x0200,
 	computer_braille = 0x0400,
+	// @deprecated for input. This feature is unreliable and will be removed in a future
+	// release
 	no_translate = 0x0800,
 	no_contract = 0x1000,
 	// SYLLABLE_MARKER_1  0x2000,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3628,6 +3628,7 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 	int repwordStart;
 	int repwordLength;
 	const InString *origInput = input;
+	int warnedForNoTranslate = 0;
 	/* Main translation routine */
 	int k;
 	translation_direction = 1;
@@ -3665,6 +3666,11 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 
 		if (!dontContract) dontContract = typebuf[pos] & no_contract;
 		if (typebuf[pos] & no_translate) {
+			if (!warnedForNoTranslate) {
+				_lou_logMessage(LOU_LOG_WARN,
+						"warning: Typeform no_translate is deprecated for input.");
+				warnedForNoTranslate = 1;
+			}
 			if (input->chars[pos] < 32 || input->chars[pos] > 126) goto failure;
 			widechar d = LOU_DOTS;
 			TranslationTableOffset offset = getChar(input->chars[pos], table)->otherRules;

--- a/tests/yaml/computer_braille.yaml
+++ b/tests/yaml/computer_braille.yaml
@@ -40,7 +40,8 @@ tests:
     - abc abc abc
     - xfail: begcompbrl and endcompbrl are apparently consumed but not processed
 
-# no_translate typeform can not be used instead of computer_braille:
+# #1782: The no_translate typeform is deprecated for input.
+# - it can not be used instead of computer_braille:
 # - it ignores comp6 rules
 # - it does not insert begcomp and endcomp
 # - it ignores character definition rules that map to more than one cell


### PR DESCRIPTION
See https://github.com/liblouis/liblouis/issues/1712

The no_translate typeform bit is undocumented and probably unreliable. Therefore, deprecate it for input. Might use it for output later on, see https://github.com/liblouis/liblouis/issues/1712#issuecomment-2849049632