### PR TITLE
EPython: Add support to much of the metadata api

### DIFF
--- a/python/louis/__init__.py.in
+++ b/python/louis/__init__.py.in
@@ -39,7 +39,12 @@ function for information about how liblouis searches for these tables.
 @author: Andre-Abush Clause <dev@andreabc.net>
 """
 
-from sys import byteorder, getfilesystemencoding, platform, version_info
+from sys import (
+    byteorder,
+    getdefaultencoding,
+    getfilesystemencoding,
+    platform,
+)
 from atexit import register
 from ctypes import (
     c_ushort,
@@ -51,10 +56,12 @@ from ctypes import (
     POINTER,
     byref,
     create_string_buffer,
+    string_at,
 )
 
 try:  # Native win32
     from ctypes import WINFUNCTYPE, windll
+
     _loader, _functype = windll, WINFUNCTYPE
 except ImportError:  # Unix/Cygwin
     _loader, _functype = cdll, CFUNCTYPE
@@ -82,6 +89,7 @@ fileSystemEncoding = "mbcs" if _is_windows else getfilesystemencoding()
 conversionEncoding = "utf_%d_%s" % (wideCharBytes * 8, _endianness)
 # }
 
+
 # Some general utility functions
 def _createTablesString(tablesList):
     """Creates a tables string for liblouis calls"""
@@ -105,6 +113,38 @@ def createEncodedByteString(
     x, encoding=conversionEncoding, errors=ENCODING_ERROR_HANDLER
 ):
     return str(x).encode(encoding, errors)
+
+
+def _getAndFreeString(charArray, encoding=getdefaultencoding()):
+    """Get a string from a char array and free the array afterwards"""
+    if not charArray:
+        return None
+    string = string_at(charArray).decode(encoding, errors=ENCODING_ERROR_HANDLER)
+    liblouis.lou_freePtr(charArray)
+    return string
+
+
+def _postProcessStringArray(stringArray, encoding=getdefaultencoding()):
+    stringList = []
+    if not stringArray:
+        return stringList
+    i = 0
+    while (string := _getAndFreeString(stringArray[i], encoding)) is not None:
+        stringList.append(string)
+        i += 1
+    liblouis.lou_freePtr(stringArray)
+    return stringList
+
+
+def _createQueryString(dct):
+    """Create a query string from a dictionary"""
+    if not isinstance(dct, dict):
+        raise TypeError("Query should be a dictionary")
+    return " ".join(
+        "%s:%s" % (k, v)
+        for k, v in dct.items()
+        if isinstance(k, str) and isinstance(v, str)
+    ).encode(getdefaultencoding(), errors=ENCODING_ERROR_HANDLER)
 
 
 register(liblouis.lou_free)
@@ -199,6 +239,21 @@ liblouis.lou_registerLogCallback.restype = None
 
 liblouis.lou_setLogLevel.restype = None
 liblouis.lou_setLogLevel.argtypes = (c_int,)
+
+liblouis.lou_findTable.restype = POINTER(c_char)
+liblouis.lou_findTable.argtypes = (c_char_p,)
+
+liblouis.lou_findTables.restype = POINTER(POINTER(c_char))
+liblouis.lou_findTables.argtypes = (c_char_p,)
+
+liblouis.lou_getTableInfo.restype = POINTER(c_char)
+liblouis.lou_getTableInfo.argtypes = (
+    c_char_p,
+    c_char_p,
+)
+
+liblouis.lou_listTables.restype = POINTER(POINTER(c_char))
+liblouis.lou_listTables.argtypes = ()
 
 
 def version():
@@ -504,7 +559,7 @@ def getTypeformForEmphClass(tableList, emphClass):
 
 
 def dotsToChar(tableList, inbuf):
-    """"Convert a string of dot patterns to a string of characters according to the specifications in tableList.
+    """Convert a string of dot patterns to a string of characters according to the specifications in tableList.
     @param tableList: A list of translation tables.
     @type tableList: list of str
     @param inbuf: a string of dot patterns, either in liblouis format or Unicode braille.
@@ -526,7 +581,7 @@ def dotsToChar(tableList, inbuf):
 
 
 def charToDots(tableList, inbuf, mode=0):
-    """"Convert a string of characterss to a string of dot patterns according to the specifications in tableList.
+    """Convert a string of characterss to a string of dot patterns according to the specifications in tableList.
     @param tableList: A list of translation tables.
     @type tableList: list of str
     @param inbuf: a string of characters.
@@ -585,6 +640,54 @@ def setLogLevel(level):
     if level not in logLevels:
         raise ValueError("Level %d is an invalid log level" % level)
     return liblouis.lou_setLogLevel(level)
+
+
+def findTable(query):
+    """Find the best match for a query
+
+    Returns the name of the table, or None when no match can be
+    found. An error message is given when the query is invalid. Freeing.
+    @param query: The query to lookup.
+    @type query: dict[str, str]
+    """
+    query = _createQueryString(query)
+    result = liblouis.lou_findTable(query)
+    return _getAndFreeString(result, fileSystemEncoding)
+
+
+def findTables(query):
+    """Find all matches for a query, best match first.
+
+    Returns the names of the matched tables.
+    An error message is given when the query is invalid.
+    @param query: The query to lookup.
+    @type query: dict[str, str]
+    """
+    query = _createQueryString(query)
+    result = liblouis.lou_findTables(query)
+    return _postProcessStringArray(result, fileSystemEncoding)
+
+
+def getTableInfo(tableName, key):
+    """Read metadata from a file.
+
+    Returns the value of the first occurring metadata field specified by
+    `key' in `table', or None when the field does not exist.
+    """
+    tableName = createEncodedByteString(tableName, fileSystemEncoding)
+    key = createEncodedByteString(key, getdefaultencoding())
+    result = liblouis.lou_getTableInfo(tableName, key)
+    return _getAndFreeString(result)
+
+
+def listTables():
+    """List available tables.
+
+    Returns the names of available tables as list  of strings.
+    Only tables that are discoverable, i.e. the have active metadata, are listed.
+    """
+    result = liblouis.lou_listTables()
+    return _postProcessStringArray(result, fileSystemEncoding)
 
 
 # { Typeforms

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -38,4 +38,6 @@ setup(name="louis",
       license="LGPLv2.1+",
       classifiers=classifiers,
       version='@VERSION@',
-      packages=["louis"])
+      packages=["louis"],
+      python_requires=">=3.8",
+)


### PR DESCRIPTION
Note, this depends on https://github.com/liblouis/liblouis/pull/1791.

This adds the following to the python module:

- `findTable`
- `findTables`
- `listTables`
- `getTableInfo`

Additional notes:
- The query functions expect a python dictionary, e.g.: `{"language":"nl"}`
- The internal `_postProcessStringArray` has a while loop with walrus operator. The walrus operator was added to Python 3.8, so that's why I increased the minimum python version. Note that Python 3.7 has long been deprecated, I think even 3.8 is gone now. See #1587
cc @AAClause @danigm @rbeezer as former Python contributors