### PR TITLE
Drop prebuilt docs

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -129,6 +129,16 @@ Unicode run configure with ~--enable-ucs4~.
 After running configure run ~make~ and then ~make install~. You must
 have root privileges for the installation step.
 
+** Build documentation
+As with any project that uses the autotools the documentation can be
+built using any of the provided make targets:
+
+- For html documentation type ~make html~
+- For html documentation in a single file type ~make html MAKEINFOFLAGS="--no-headers --no-split"~
+- For documentation in the [[https://www.gnu.org/software/texinfo/manual/info-stnd/html_node/index.html#Top][info]] format type ~make info~
+- For pdf documentation type ~make pdf~
+- For plain text documentation type ~cd doc; make liblouis.txt~
+
 ** Install with Homebrew
 Homebrew (http://brew.sh) is a package manager for Mac OS X that
 installs software from source. There is nothing special about the

--- a/README
+++ b/README
@@ -31,12 +31,14 @@ file COPYING).
 
 * Documentation
 
-For documentation, see the [[http://www.liblouis.io/documentation/liblouis.html][liblouis documentation]] (either as info
-file, html, txt or pdf) in the doc directory. For examples of
-translation tables, see =en-us-g2.ctb=, =en-us-g1.ctb=,
-=chardefs.cti=, and whatever other files they may include in the
-tables directory. This directory contains tables for many languages.
-The Nemeth files will only work with the sister library [[http://www.liblouis.io/][liblouisutdml]].
+For documentation, see the [[http://www.liblouis.io/documentation/liblouis.html][liblouis documentation]]. If you build
+liblouis from source you can get the documentation in various formats
+(either as info file, html, txt or pdf) in the doc directory, see the
+HACKING file for details.
+
+For examples of translation tables, see =en-us-g2.ctb=,
+=en-us-g1.ctb=, =chardefs.cti=, and other files in the tables
+directory which contains tables for many languages.
 
 * Installation
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,17 +1,5 @@
-doc_DATA = \
-	liblouis.html \
-	liblouis.txt
-
-EXTRA_DIST = \
-	liblouis.html \
-	liblouis.txt
-
-CLEANFILES = $(EXTRA_DIST)
 
 info_TEXINFOS = liblouis.texi
-
-# generate one big html file
-AM_MAKEINFOHTMLFLAGS = --no-headers --no-split
 
 SUFFIXES                = .txt
 


### PR DESCRIPTION
We no longer include the html and the txt version of the docs in the distribution tar ball. Instead we explain how the different formats can be built from source in the README and in HACKING