### PR TITLE
Make the lou_checktable node unique

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -162,7 +162,7 @@ Testing Translation Tables interactively
 
 * lou_debug::
 * lou_trace::
-* lou_checktable::
+* lou_checktable (program)::
 * lou_allround::
 * lou_translate (program)::
 * lou_checkhyphens::
@@ -2468,7 +2468,7 @@ found}, for a description on how the tables are located.
 @menu
 * lou_debug::
 * lou_trace::
-* lou_checktable::
+* lou_checktable (program)::
 * lou_allround::
 * lou_translate (program)::
 * lou_checkhyphens::
@@ -2637,7 +2637,7 @@ the u.s. postal service
 21.     pass2   $s1-10  @@0
 @end example
 
-@node lou_checktable
+@node lou_checktable (program)
 @section lou_checktable
 @pindex lou_checktable
 


### PR DESCRIPTION
makeinfo (on Mac) seems to have a problem with texinfo nodes that only differ in capitalization

Original PR: https://github.com/liblouis/liblouis/pull/1621