### PR TITLE
Fix #1650: Allow log level override via LOUIS_LOGLEVEL env var

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -186,6 +186,7 @@ Programming with liblouis
 * lou_charToDots::
 * lou_registerLogCallback::
 * lou_setLogLevel::
+* lou_getLogLevel::
 * lou_logFile::
 * lou_logPrint::
 * lou_logEnd::
@@ -3311,6 +3312,7 @@ tests:
 * lou_charToDots::
 * lou_registerLogCallback::
 * lou_setLogLevel::
+* lou_getLogLevel::
 * lou_logFile::
 * lou_logPrint::
 * lou_logEnd::
@@ -3481,8 +3483,8 @@ path-checking is skipped.
 
 As of version 2.6.0 @code{lou_logFile}, @code{lou_logPrint} and
 @code{lou_logEnd} are deprecated. They are replaced by a more powerful,
-abstract API consisting of @code{lou_registerLogCallback} and
-@code{lou_setLogLevel}. 
+abstract API consisting of @code{lou_registerLogCallback},
+@code{lou_setLogLevel}, and @code{lou_getLogLevel}.
 
 Usage of @code{lou_logFile}, @code{lou_logPrint} and @code{lou_logEnd} is
 discouraged as they may not be part of future releases. Applications using
@@ -3904,6 +3906,24 @@ values are @code{LOU_LOG_DEBUG}, @code{LOU_LOG_INFO},
 @code{LOU_LOG_OFF}. Enabling logging at a given level also enables
 logging at all higher levels. Setting the level to @code{LOU_LOG_OFF}
 disables logging. The default level is @code{LOU_LOG_INFO}.
+
+Alternatively, the @code{LOUIS_LOGLEVEL} environment variable can be
+set to one of @code{all}, @code{debug}, @code{info}, @code{warn}, 
+@code{error}, @code{fatal}, or @code{off}. If set, this value will take
+precedence over any calls to @code{lou_setLogLevel()} by the application.
+Values are case-insensitive, and if brevity matters, only the first letter
+(i.e. @code{a} for @code{all} or @code{w} for @code{warn}) matters.
+
+@node lou_getLogLevel
+@section lou_getLogLevel
+@findex lou_getLogLevel
+
+@example
+logLevels lou_getLogLevel ();
+@end example
+
+This function returns the currently active logging level. (See 
+@ref{lou_setLogLevel} for details.)
 
 @node lou_logFile
 @section lou_logFile (deprecated)

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -366,6 +366,13 @@ void EXPORT_CALL
 lou_registerLogCallback(logcallback callback);
 
 /**
+ * Returns the level that the logging callback will be called at
+ */
+LIBLOUIS_API
+logLevels EXPORT_CALL
+lou_getLogLevel();
+
+/**
  * Set the level for logging callback to be called at
  */
 LIBLOUIS_API


### PR DESCRIPTION
- **build(deps): bump golang.org/x/text in /extra/generate-display-names**
- **Add test that shows back-translation issue in Dutch table**
- **Fix the table**
- **Ensure that backtranslation of slash is possible with 6-dot input.**
- **Fix looking for libclang_rt.fuzzer_no_main-*.a**
- **Update copyright in Dutch table**
- **Use the old ubuntu runner to cross-compile with mingw**
- **Fix free error by early fail**
- **build(deps): bump github/codeql-action from 3.27.5 to 3.28.8**
- **build(deps): bump actions/upload-artifact from 4.4.3 to 4.6.0**
- **build(deps): bump step-security/harden-runner from 2.10.2 to 2.10.4**
- **build(deps): bump actions/cache from 4.1.2 to 4.2.0**
- **Fix leaks by free k & v before goto and return**
- **Norwegian: don't use permanent cap sign in words with mixed case**
- **Clarify rule that removes space between degree sign and C/F/K**
- **Fix default table search path on Windows**
- **Make value in table metadata field mandatory**
- **Replace an obsolete emacs lisp function in ascii-braille-mode**
- **Return from finalizeCharacter if a recursive invocation failed**
- **tables/hu-exceptionwords.cti, tables/hu-backtranslate-word-corrections.cti: Added new collected exceptions**
- **added new collected exceptions related testcases**
- **All quotation marks should be dot 256: correct left and right single quotationmark into 256**
- **Add rules for separating quotation mark and dollar sign with dot 6**
- **Most of the times we want to NO-BREAK SPACE as blank: change this sign from dot 8 to 0 (blank)**
- **Add definition for ALMOST EQUAL TO**
- **Add definition for INFINITY and PLUS-MINUS SIGN**
- **Add DOUBLE PRIME sign**
- **Fix SUPERSCRIPT TWO and SUPERSCRIPT THREE**
- **Put dot 6 after the DEGREE SIGN if followed by RIGHT PARENTHESIS**
- **Add several dollar quotation mark combinations with dot 6 in between**
- **Add test for dollar sign followed by right quotation mark**
- **Add tests for capital norrøn letters**
- **Add and fix Greek small and capital letters**
- **Fix latin diacritic letters: we want to use a universal mark for most of them**
- **Update copyright notices, and correct them so that they conform to GPL licence rules**
- **Collect all Norwegian tests in a single YAML file**
- **Fix overflow in passDoAction and doPassSearch**
- **Quote special characters in a yaml test**
- **Fix heap-buffer-overflow error in compileRule and _lou_extParseChars**
- **en-ueb-g2.ctb: Update rules for "some" followed by "r"**
- **Update copyright line**
- **Add BUFFER OVERFLOW RISK to doc string of lou_translateString and lou_translate**
- **First cut at NEWS entry for release**
- **Fix a cut'n'paste error in the doc string**
- **Inlcude News entries for all closed PRs**
- **build(deps): bump ossf/scorecard-action from 2.4.0 to 2.4.1**
- **build(deps): bump actions/upload-artifact from 4.6.0 to 4.6.1**
- **build(deps): bump github/codeql-action from 3.28.8 to 3.28.10**
- **build(deps): bump actions/cache from 4.2.0 to 4.2.2**
- **build(deps): bump step-security/harden-runner from 2.10.4 to 2.11.0**
- **build(deps): bump golang.org/x/text in /extra/generate-display-names**
- **Tables/hu-backtranslate-word-corrections.cti, tables/hu-exceptions.cti: Added newest founded exceptions**
- **tests/braille-specs/hu-hu-g1_dictionary_special_consonants.yaml: Added newest testcases**
- **New table for transliterated and normalized Cuneiform and other ancient languages**
- **armi-Latn is not a valid language tag**
- **Add table to build system**
- **New table for Coptic 6-dot braille**
- **YAML test for new table**
- **Add table to the build system**
- **Fix the (lowercase) link to the braille spec**
- **Table header cleanup and fix metadata**
- **Merge the test files for Coptic computer braille and Coptic literary**
- **Rename the table file**
- **Add table to display-names**
- **Add #+variant metadata**
- **Merge the test files of the two transliterated Cuneiform tables**
- **ipa.utb: add several missing symbols**
- **Add test to the build system and make it pass**
- **Add copyright notice to the test**
- **Add table metadata**
- **Update copyright lines**
- **Add new table for Portuguese 6 dot computer braille**
- **Move the license text**
- **Add new table to display-names**
- **Update the official reference link of the braille code**
- **Table header cleanup**
- **Merge all tests for Portugese tables in a single file**
- **Add a few sentences in the header about how the 6- and 8-dot tables relate**
- **Update NEWS entry**
- **Add release summary**
- **pass_endTest should only return 1 (match) when "pass_endTest" instruction is reached**
- **Add a NEWS entry for the last minute memory fix**
- **Clarify the backwards incompatible change**
- **Add Announcement**
- **Thank Robert Englebretson for his contributions to IPA**
- **Add NEWS entry for next release**
- **Add test to cover issue in Dutch g0 table that was fixed by Davy Kager**
- **Update "Sponsor this project" section on Github**
- **build(deps): bump actions/upload-artifact from 4.6.1 to 4.6.2**
- **build(deps): bump actions/cache from 4.2.2 to 4.2.3**
- **build(deps): bump github/codeql-action from 3.28.10 to 3.28.13**
- **build(deps): bump shogo82148/actions-upload-release-asset**
- **build(deps): bump step-security/harden-runner from 2.11.0 to 2.12.0**
- **build(deps): bump github/codeql-action from 3.28.13 to 3.28.16**
- **Fix incorrect links**
- **Add --enable-macos-universal-binary configuration option**
- **Files for expanded Hebrew system.**
- **Improve he-common-consonants.uti consistency**
- **Improve he-common-vowels-ihbc.uti consistency**
- **Improve hbo-common-rules.uti consistency**
- **Improve hbo-slim-rules.uti conssitency**
- **Improve hbo-cantillated-rules.uti consistency**
- **Improve utb consistency**
- **Update build**
- **Update ancient biblical study tables to stick with cantillated Hebrew**
- **Upgrade the golang version**
- **build(deps): bump golang.org/x/text in /extra/generate-display-names**
- **Update go version in go.mod**
- **Rename Russian tables**
- **Fix metadata of Russian 6-dot computer braille table**
- **Use metadata to select tables in tests**
- **Tables/hu-exceptionwords.cti, tables/hu-backtranslate-word-corrections.cti: Added new collected exceptions**
- **Added new testcases**
- **Add tests that were previously deleted but still work**
- **Back-translation improvements for compact cuneiform transliteration**
- **Slight optimization of test file**
- **Fixed spelling of LibLouis and Abby Howell's name.**
- **Fixed final test in hbo.yaml**
- **Deprecate no_translate for input**
- **Add deprecation notice to computer_braille.yaml**
- **Bug in Dutch table: an apostrophe after a number is not always a minute sign**
- **Dutch: Use section numbering of the most recent braille specification**
- **New include table to detect pairs of quotation marks**
- **Add test for issue #1783**
- **Fix listDir on Windows to list files instead of dirs**
- **merged input-ueb-02-stand_alone.txt and input-ueb-03-symbols.txt into en-ueb.yaml.**
- **merged inputinput-ueb-05-grade_1_mode.txt and input-ueb-06-numeric_mode.txt into en-ueb.yaml.**
- **merged input-ueb-08-capitalization.txt into en-ueb.yaml.**
- **merged the last 3 files. need to mark (or fix) a lot of failed tests.**
- **All failures now fixed or marked.**
- **Further improvements to en-ueb.yaml**
- **Delete tests/ueb_test_data and related files**
- **ueb_test_data needs to be removed from configure.ac**
- **Fix an unexpected pass**
- **Fix YAML quotation problems**
- **Add Thai grade 2 braille table**
- **Move the duplicate data from th-g1.utb and th-g2.ctb to th-g1.uti**
- **Fix the metadata**
- **Add a license to the test file**
- **Move all Thai tests into single file**
- **We need back translation of dots 23 to be semicolon.**
- **Added Prime character + small and caiptal cyrillic letters.**
- **Change back RIGHT and LEFT SINGLE QUOTATION MARK to dit 6, according to discussion on mailing list, see https://www.freelists.org/post/liblouis-liblouisxml/EXTERNAL-Apostrophe-in-braille,1.**
- **Added the new file no-no-cyrillic6dot.uti to Makefile.am.**
- **When using Liblouis for 8 dot in JAWS, a lot of new characters have to be added, include for dot lists.**
- **Mention new tables in NEWS**
- **Fixes to display- and index-name metadata**
- **Change contraction from yes to partial in metadata**
- **Trying to enable the ancient-languages tests again**
- **Match ancient-languages-us.utb and ancient-languages-borger.utb with correct set of tests**
- **Change include order to keep user-defined attributes straight**
- **Add rules to cover non-normative unicode for holam waw**
- **Refactor the two Lithuanian braille tables**
- **Fixes to metadata**
- **Add back tests for the official 8-dot system**
- **Merge tests into a single file**
- **Drop all uneeded rules from the documentation Makefile**
- **Mention that the documentation can be built from source**
- **Corrections for Turkish**
- **Add Ozancan's name to copyright sections**
- **Add note about status of tables vs. official standard**
- **Make the list of tables in fuzzing.yml a multiline list**
- **Make the lou_checktable node unique**
- **Fix vowel attribute**
- **Add missing NEWS entries for next release**
- **Update version number**
- **Add a NEWS entry for the Classical/Biblical Hebrew**
- **Spell check of the NEWS entry**
- **Add a release summary**
- **Update the toc of HACKING**
- **Update the version number**
- **Update the announcement**
- **lt-8dot.utb should be listed under New, and lt.ctb is still present.**
- **build(deps): bump github/codeql-action from 3.28.16 to 3.29.2**
- **build(deps): bump step-security/harden-runner from 2.12.0 to 2.12.2**
- **build(deps): bump shogo82148/actions-upload-release-asset**
- **build(deps): bump ossf/scorecard-action from 2.4.1 to 2.4.2**
- **Fix #1650: Add support for LOUIS_LOGLEVEL environment variable**
- **Update docs re: LOUIS_LOGLEVEL environment variable and new lou_getLogLevel() API**
