### PR TITLE
Fix #1650: Allow log level override via LOUIS_LOGLEVEL environment variable

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -186,6 +186,7 @@ Programming with liblouis
 * lou_charToDots::
 * lou_registerLogCallback::
 * lou_setLogLevel::
+* lou_getLogLevel::
 * lou_logFile::
 * lou_logPrint::
 * lou_logEnd::
@@ -3311,6 +3312,7 @@ tests:
 * lou_charToDots::
 * lou_registerLogCallback::
 * lou_setLogLevel::
+* lou_getLogLevel::
 * lou_logFile::
 * lou_logPrint::
 * lou_logEnd::
@@ -3481,8 +3483,8 @@ path-checking is skipped.
 
 As of version 2.6.0 @code{lou_logFile}, @code{lou_logPrint} and
 @code{lou_logEnd} are deprecated. They are replaced by a more powerful,
-abstract API consisting of @code{lou_registerLogCallback} and
-@code{lou_setLogLevel}. 
+abstract API consisting of @code{lou_registerLogCallback},
+@code{lou_setLogLevel}, and @code{lou_getLogLevel}.
 
 Usage of @code{lou_logFile}, @code{lou_logPrint} and @code{lou_logEnd} is
 discouraged as they may not be part of future releases. Applications using
@@ -3904,6 +3906,24 @@ values are @code{LOU_LOG_DEBUG}, @code{LOU_LOG_INFO},
 @code{LOU_LOG_OFF}. Enabling logging at a given level also enables
 logging at all higher levels. Setting the level to @code{LOU_LOG_OFF}
 disables logging. The default level is @code{LOU_LOG_INFO}.
+
+Alternatively, the @code{LOUIS_LOGLEVEL} environment variable can be
+set to one of @code{all}, @code{debug}, @code{info}, @code{warn}, 
+@code{error}, @code{fatal}, or @code{off}. If set, this value will take
+precedence over any calls to @code{lou_setLogLevel()} by the application.
+Values are case-insensitive, and if brevity matters, only the first letter
+(i.e. @code{a} for @code{all} or @code{w} for @code{warn}) matters.
+
+@node lou_getLogLevel
+@section lou_getLogLevel
+@findex lou_getLogLevel
+
+@example
+logLevels lou_getLogLevel ();
+@end example
+
+This function returns the currently active logging level. (See 
+@ref{lou_setLogLevel} for details.)
 
 @node lou_logFile
 @section lou_logFile (deprecated)

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -366,6 +366,13 @@ void EXPORT_CALL
 lou_registerLogCallback(logcallback callback);
 
 /**
+ * Returns the level that the logging callback will be called at
+ */
+LIBLOUIS_API
+logLevels EXPORT_CALL
+lou_getLogLevel();
+
+/**
  * Set the level for logging callback to be called at
  */
 LIBLOUIS_API


### PR DESCRIPTION
If the LOUIS_LOGLEVEL environment variable has been set to one of the known logging levels (`all`, `debug`, `warn`, `info`, `error`, `fatal`, `off`), this will override the default logging level and any attempt by the running application to change the logging level via `lou_setLogLevel()`.

Environment variable values are case-insensitive, and as the first letter of the logging letters is unique (`a|d|w|i|e|f|o`), only the first letter truly matters.

Adds a publicly accessible `lou_getLogLevel()` that will return the current effective logging level (as set by default, the application, or a `LOUIS_LOGLEVEL` override).