### PR TITLE
Ensure string buffer pools exist before use

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -91,7 +91,8 @@ getStringBuffer(int length) {
 static int
 releaseStringBuffer(int idx) {
 	if (!stringBufferPool) {
-		_lou_logMessage(LOU_LOG_ERROR, "Attempt to free string buffer prior to initialization of pool");
+		_lou_logMessage(LOU_LOG_ERROR,
+				"Attempt to free string buffer prior to initialization of pool");
 		return 0;
 	}
 

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -97,7 +97,8 @@ getStringBuffer(int length) {
 static int
 releaseStringBuffer(int idx) {
 	if (!stringBufferPool) {
-		_lou_logMessage(LOU_LOG_ERROR, "Attempt to free string buffer prior to initialization of pool");
+		_lou_logMessage(LOU_LOG_ERROR,
+				"Attempt to free string buffer prior to initialization of pool");
 		return 0;
 	}
 


### PR DESCRIPTION
The structure for the string buffer pool is setup in `initStringBufferPool()`. If `getStringBuffer()` or `releaseStringBuffer()` are called prior to the pool being initialized, a segfault occurs.

Fixes:

- `getStringBuffer()` will initialize the pool if necessary
- `releaseStringBuffer()` will do nothing (log error only) if there is an attempt to 'release' a string buffer that clearly has never been allocated

Fixes #1766 (and more, as the issue exists for both forward- and back-translation).