### PR TITLE
Support back translation of the Greek final sigma

### DIFF
--- a/tables/grc-international-common.uti
+++ b/tables/grc-international-common.uti
@@ -64,7 +64,7 @@ letter	\x03BF	135	# ο Small Omicron
 letter	\x03C0	1234	# π Small Pi
 letter	\x03C1	1235	# ρ Small Rho
 noback letter	\x03C2	234	# ς Small Final Sigma
-letter	\x03C3	234	# σ Small Sigmaz
+letter	\x03C3	234	# σ Small Sigma
 letter	\x03C4	2345	# τ Small Tau
 letter	\x03C5	136	# υ Small Upsilon
 letter	\x03C6	124	# φ Small Phi

--- a/tables/grc-international-common.uti
+++ b/tables/grc-international-common.uti
@@ -73,10 +73,10 @@ letter	\x03C8	13456	# ψ Small Psi
 letter	\x03C9	2456	# ω Small Omega
 
 # Sigma back translation
-nofor correct "\x03C3"~ "\x03C2"
-nofor correct "\x03C3"[$sp] "\x03C2"*
-nofor correct "\x03C3"[$S.$sp] "\x03C2"*
-nofor correct "\x03C3"[$S.]~ "\x03C2"*
+nofor correct !`"\x03C3"~ "\x03C2"
+nofor correct !`"\x03C3"[$sp] "\x03C2"*
+nofor correct !`"\x03C3"[$S.$sp] "\x03C2"*
+nofor correct !`"\x03C3"[$S.]~ "\x03C2"*
 
 # letters no longer in use
 letter	\x03DD	1236	# ϝ Small Digamma

--- a/tables/grc-international-common.uti
+++ b/tables/grc-international-common.uti
@@ -64,13 +64,19 @@ letter	\x03BF	135	# ο Small Omicron
 letter	\x03C0	1234	# π Small Pi
 letter	\x03C1	1235	# ρ Small Rho
 noback letter	\x03C2	234	# ς Small Final Sigma
-letter	\x03C3	234	# σ Small Sigma
+letter	\x03C3	234	# σ Small Sigmaz
 letter	\x03C4	2345	# τ Small Tau
 letter	\x03C5	136	# υ Small Upsilon
 letter	\x03C6	124	# φ Small Phi
 letter	\x03C7	12346	# χ Small Chi
 letter	\x03C8	13456	# ψ Small Psi
 letter	\x03C9	2456	# ω Small Omega
+
+# Sigma back translation
+nofor correct "\x03C3"~ "\x03C2"
+nofor correct "\x03C3"[$sp] "\x03C2"*
+nofor correct "\x03C3"[$S.$sp] "\x03C2"*
+nofor correct "\x03C3"[$S.]~ "\x03C2"*
 
 # letters no longer in use
 letter	\x03DD	1236	# ϝ Small Digamma

--- a/tables/grc-international-common.uti
+++ b/tables/grc-international-common.uti
@@ -73,10 +73,10 @@ letter	\x03C8	13456	# ψ Small Psi
 letter	\x03C9	2456	# ω Small Omega
 
 # Sigma back translation
-nofor correct !`"\x03C3"~ "\x03C2"
-nofor correct !`"\x03C3"[$sp] "\x03C2"*
-nofor correct !`"\x03C3"[$S.$sp] "\x03C2"*
-nofor correct !`"\x03C3"[$S.]~ "\x03C2"*
+nofor correct _$l"\x03C3"~ "\x03C2"
+nofor correct _$l"\x03C3"[$sp] "\x03C2"*
+nofor correct _$l"\x03C3"[$S.$sp] "\x03C2"*
+nofor correct _$l"\x03C3"[$S.]~ "\x03C2"*
 
 # letters no longer in use
 letter	\x03DD	1236	# ϝ Small Digamma

--- a/tests/braille-specs/grc-international-common.yaml
+++ b/tests/braille-specs/grc-international-common.yaml
@@ -1,5 +1,5 @@
 # Copyright © 2019 by Dave Mielke <dave@mielke.cc>
-# Copyright © 2024 by Leonard de Ruijter <alderuijter@gmail.com>
+# Copyright © 2024-2025 by Leonard de Ruijter <alderuijter@gmail.com>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -40,6 +40,18 @@ table: spaces.uti,grc-international-composed.uti
 table: {language: grc, region: en, variant: composed} # decomposed variant does not back-translate lowercase greek
 flags: {testmode: backward}
 tests:
-- - ⠁⠃⠛⠙⠑⠵⠱⠹⠊⠅⠇⠍⠝⠭⠕⠏⠗⠎⠞⠥⠋⠯⠽⠺
-  - αβγδεζηθικλμνξοπρστυφχψω
+- - ⠁⠃⠛⠙⠑⠵⠱⠹⠊⠅⠇⠍⠝⠭⠕⠏⠗⠎⠞⠥⠋⠯⠽⠺⠎
+  - αβγδεζηθικλμνξοπρστυφχψως
 
+# words
+flags: {testmode: bothDirections}
+tests:
+- - λογος
+  - ⠇⠕⠛⠕⠎
+# A sign after the sigma should give a final sigma
+- - λογος¯
+  - ⠇⠕⠛⠕⠎⠸
+- - δοξα
+  - ⠙⠕⠭⠁
+- - Χριστος
+  - ⠨⠯⠗⠊⠎⠞⠕⠎

--- a/tests/braille-specs/grc-international-common.yaml
+++ b/tests/braille-specs/grc-international-common.yaml
@@ -42,6 +42,9 @@ flags: {testmode: backward}
 tests:
 - - ⠁⠃⠛⠙⠑⠵⠱⠹⠊⠅⠇⠍⠝⠭⠕⠏⠗⠎⠞⠥⠋⠯⠽⠺⠎
   - αβγδεζηθικλμνξοπρστυφχψως
+# A single sigma is never a final sigma
+- - ⠎
+  - σ
 
 # words
 flags: {testmode: bothDirections}


### PR DESCRIPTION
The greek final sigma (ς) will now be backtranslated properly when at the end of a word. Based on rules in hbo provided by @EricJHarvey 