### PR TITLE
Fix a bug in the handling of nocont in conjunction with seqdelimiter

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3658,7 +3658,9 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 	markEmphases(table, input, typebuf, wordBuffer, emphasisBuffer);
 
 	while (pos <= input->length) { /* the main translation loop */
-		if (pos > 0 && checkCharAttr(input->chars[pos - 1], CTC_Space, table) &&
+		if (pos > 0 &&
+				checkCharAttr(
+						input->chars[pos - 1], CTC_SeqDelimiter | CTC_Space, table) &&
 				(transOpcode != CTO_JoinableWord))
 			lastWord = (LastWord){ pos, output->length, insertEmphasesFrom };
 		if (pos == input->length) break;


### PR DESCRIPTION
The nocont opcode works by going back to a previous state in the translation process when a certain character sequence is encountered. This was causing an endless loop in some situations involving seqdelimiter.

see https://github.com/liblouis/liblouis/issues/1830#issuecomment-3232756788