### PR TITLE
Russian Literary Braille table: smarter handling of spaces after commas and semicolons during back translation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,11 @@ issues]].
   Thanks to Lars Bjørndal.
 - Improvements to UEB forward translation, in particular fixes for
   rarer words and some proper names. Thanks to James Bowden.
+- Improvements to the back translation for the Russian literary Braille table:
+  Now, if a space is intentionally inputed after a comma or semicolon, a double
+  space will not occur. If no space was inputed, a space will still be
+  automatically added, as before. This change also applies to Ukrainian and
+  Belarusian literary Braille tables. Thanks to Andrey Yakuboy.
 ** Other changes
 - Hans Anton Ålien proof read the documentation and fixed quite a few
   typos.

--- a/tables/ru-litbrl.ctb
+++ b/tables/ru-litbrl.ctb
@@ -690,6 +690,8 @@ nofor partword ,\s 2
 nofor endnum ,\s 6-2
 nofor partword ;\s 23
 nofor endnum ;\s 6-23
+nofor correct ","$s[$s] ? # for cases where a space after a comma is intentionally inputed
+nofor correct ";"$s[$s] ? # for cases where a space after a semicolon is intentionally inputed
 noback correct ["*"$s"*"$s"*"] "***"
 noback correct `$s.%dashes[$s] ? # for dialogs and direct speech
 noback correct `%dashes[$s] ? # for dialogs and direct speech

--- a/tables/ru-litbrl.ctb
+++ b/tables/ru-litbrl.ctb
@@ -14,7 +14,7 @@
 #+direction: both
 #
 #  Copyright (C) 2013 Igor B. Poretsky <poretsky@mlbox.ru>
-#  Copyright (C) 2020-2022 Andrey Yakuboy <braille@yakuboy.ru>
+#  Copyright (C) 2020-2022, 2025 Andrey Yakuboy <braille@yakuboy.ru>
 #  Copyright (C) 2020 Bert Frees <bertfrees@gmail.com>
 #
 #  This file is part of liblouis.

--- a/tests/braille-specs/ru.yaml
+++ b/tests/braille-specs/ru.yaml
@@ -254,6 +254,12 @@ tests:
     - 1, 1, 2, 3, 5, 8...
   - - ⠠⠁⠂⠃
     - a, б
+# When a comma or semicolon with a intentional space after it is inputed, there should not be a double space, despite the automatic space after the comma
+  - - ⠘⠏⠗⠊⠺⠑⠞⠂ ⠙⠗⠥⠵⠾⠫⠖
+    - Привет, друзья!
+# At the same time, if two spaces are intentionally inputed after a comma or semicolon, there should be no further automatic corrections
+  - - ⠘⠏⠗⠊⠺⠑⠞⠂  ⠙⠗⠥⠵⠾⠫⠖
+    - Привет,  друзья!
 
 # Without indication of capital letters
 table:

--- a/tests/braille-specs/ru.yaml
+++ b/tests/braille-specs/ru.yaml
@@ -1,7 +1,7 @@
 # Tests for Russian braille
 #
 # Copyright © 2018 by Sergiy Moskalets <www.trosti.com.ua>
-# Copyright © 2020-2022 by Andrey Yakuboy <braille@yakuboy.ru>
+# Copyright © 2020-2022, 2025 by Andrey Yakuboy <braille@yakuboy.ru>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright


### PR DESCRIPTION
According to the Russian Braille standards, the space after the comma and semicolon is omitted, despite its necessity in flat-printed text. In the Russian literary Braille tables, there is a rule that, when back-translating, this space automatically appears after the comma or semicolon is inputed. However, some Braille users were used to typing a space after these characters on their own, which resulted in a double space. This improvement resolves this issue: now, when a space is intentionally typed after a comma or semicolon, the extra space is suppressed, while the automatic space still appears if the space was not intentionally typed. This PR contains the change itself (just two `correct`-rules), the corresponding test cases, and a news entry.