### PR TITLE
Use "config.h" instead of <config.h> for portability

### DIFF
--- a/liblouis/commonTranslationFunctions.c
+++ b/liblouis/commonTranslationFunctions.c
@@ -24,7 +24,7 @@
    License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 #include "internal.h"

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -29,7 +29,7 @@
  * @brief Read and compile translation tables
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -24,7 +24,7 @@
  * @brief Logging
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <ctype.h>
 #include <stddef.h>

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -27,7 +27,7 @@
  * @brief Translate from braille
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -29,7 +29,7 @@
  * @brief Translate to braille
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/liblouis/maketable.c
+++ b/liblouis/maketable.c
@@ -18,7 +18,7 @@
    License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -23,7 +23,7 @@
  * @brief Find translation tables
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/liblouis/pattern.c
+++ b/liblouis/pattern.c
@@ -18,7 +18,7 @@
    License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/liblouis/utils.c
+++ b/liblouis/utils.c
@@ -29,7 +29,7 @@
  * @brief Common utility functions
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>


### PR DESCRIPTION
This patch replaces `#include <config.h>` with `#include "config.h"`.

Rationale:
- According to the ISO C/C++ standards, `#include "..."` is intended for project-local headers, while `#include <...>` is reserved for system headers.
- `config.h` is a locally generated header, not a system header.
- Many GNU projects (e.g. glibc, coreutils, gnulib) follow this convention.
- Using `<config.h>` assumes that the current directory (`.`) is always on the include path, which is true for autotools-generated builds (because they add `-I.` by default), but not guaranteed in other build systems.
- In particular, cross-compilation environments such as the Android NDK fail to build when `config.h` is included with `<...>`.

This change does not affect normal autotools builds, but improves portability for alternative build systems such as CMake, Bazel, or the Android NDK.
