### PR TITLE
Updated sk-g1 table

### DIFF
--- a/tables/sk-g1.ctb
+++ b/tables/sk-g1.ctb
@@ -698,7 +698,6 @@ midendnumericmodechars ,.-':/()
 capsletter  6
 begcapsword  6-6
 endcapsword  56
-capsmodechars -
 
 # ----------------------------------------------------------------------------------------------
 # Braille emphasis

--- a/tests/braille-specs/sk-g1_harness.yaml
+++ b/tests/braille-specs/sk-g1_harness.yaml
@@ -74,6 +74,9 @@ tests:
     - "ADAM.eva"
     - "⠠⠠⠁⠙⠁⠍⠲⠑⠧⠁"
   -
+    - "Na koncerte vystúpili so SĽUK-om."
+    - "⠠⠝⠁ ⠅⠕⠝⠉⠑⠗⠞⠑ ⠧⠽⠎⠞⠬⠏⠊⠇⠊ ⠎⠕ ⠠⠠⠎⠸⠥⠅⠤⠕⠍⠲"
+  -
     - "Pamätajte si, že páni Köböl a Müller sa pôjdu kĺzať na ľad. Pri klzisku je vŕba. Na vŕbe je kŕdeľ vrabcov. Väčšina kĺzajúcich sa sú chlapci. Ôsmy je Walter. Je tam však aj Ľubica. Celkom je tam deväť ľudí. Zajtra pôjdu zase. Môžu sa k nim pridať aj ďalší lebo ľad je dosť pevný."
     - "⠠⠏⠁⠍⠈⠞⠁⠚⠞⠑ ⠎⠊⠂ ⠮⠑ ⠏⠡⠝⠊ ⠠⠅⠐⠕⠃⠐⠕⠇ ⠁ ⠠⠍⠐⠥⠇⠇⠑⠗ ⠎⠁ ⠏⠾⠚⠙⠥ ⠅⠨⠵⠁⠳ ⠝⠁ ⠸⠁⠙⠲ ⠠⠏⠗⠊ ⠅⠇⠵⠊⠎⠅⠥ ⠚⠑ ⠧⠷⠃⠁⠲ ⠠⠝⠁ ⠧⠷⠃⠑ ⠚⠑ ⠅⠷⠙⠑⠸ ⠧⠗⠁⠃⠉⠕⠧⠲ ⠠⠧⠈⠩⠱⠊⠝⠁ ⠅⠨⠵⠁⠚⠬⠉⠊⠉⠓ ⠎⠁ ⠎⠬ ⠉⠓⠇⠁⠏⠉⠊⠲ ⠠⠾⠎⠍⠽ ⠚⠑ ⠠⠺⠁⠇⠞⠑⠗⠲ ⠠⠚⠑ ⠞⠁⠍ ⠧⠱⠁⠅ ⠁⠚ ⠠⠸⠥⠃⠊⠉⠁⠲ ⠠⠉⠑⠇⠅⠕⠍ ⠚⠑ ⠞⠁⠍ ⠙⠑⠧⠈⠳ ⠸⠥⠙⠌⠲ ⠠⠵⠁⠚⠞⠗⠁ ⠏⠾⠚⠙⠥ ⠵⠁⠎⠑⠲ ⠠⠍⠾⠮⠥ ⠎⠁ ⠅ ⠝⠊⠍ ⠏⠗⠊⠙⠁⠳ ⠁⠚ ⠹⠁⠇⠱⠌ ⠇⠑⠃⠕ ⠸⠁⠙ ⠚⠑ ⠙⠕⠎⠳ ⠏⠑⠧⠝⠯⠲"
   - ['www.', '⠺⠺⠺⠲']


### PR DESCRIPTION
Hello,

In line with the corresponding [braille-specs pull request](https://github.com/liblouis/braille-specs/pull/29) here are updates to the slovak braille table.

Both forward as well as backward translations are tested with the braille display. We'd appreciate accepting this update into the upcoming release of liblouis.

We are addressing these issues / new features with this update:

* Adding emphasis indicator op codes for bold, italic and underline.
* Fixing some back translation issues with specific multy cell symbols [discussed by email](https://www.freelists.org/post/liblouis-liblouisxml/skg1ctb-back-translation-conflict) more than 2 years ago
* Adding some additional symbols representing foreign latin alphabed characters that are sometimes used within casual life
* Fixing an issue with sum math symbol
* Slightly improving tests.
Thanks for including this.

Please let us know in case there are issues accepting these changes.

Thanks and greetings

Michal, Peter and all the Council of SABP members