### PR TITLE
Fix misc syntax fixes

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -1860,13 +1860,18 @@ suboperand begins with a non-alphanumeric character and ends when
 another non-alphanumeric character is encountered. The suboperands and
 their initial characters are as follows.
 
+Note that the @code{test} and @code{action} operands are separated by
+whitespace. As a consequence, neither operand may contain a literal
+space character. Within string suboperands (delimited by double
+quotes), use the escape sequence @samp{\s} to represent a space.
+
 @table @kbd
 @item " (double quote)
 a string of characters. This string must be terminated by another
-double quote. It may contain any characters. If a double quote is
+double quote. It may contain any characters except a literal space
+(use the escape sequence @samp{\s} instead). If a double quote is
 needed within the string, it must be preceded by a backslash
-(@samp{\}). If a space is needed, it must be represented by the escape
-sequence \s. This suboperand is valid
+(@samp{\}). This suboperand is valid
 in the test and action parts of the @code{correct} opcode,
 in the test part of the @code{context} opcode when forward translating,
 and in the action part of the @code{context} opcode when back translating.

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1886,11 +1886,13 @@ compilePassOpcode(const FileInfo *file, TranslationTableOpcode opcode, int nobac
 		passHoldString.chars[passHoldString.length++] = file->line[k];
 #define SEPCHAR 0x0001
 	/* FIXME: The separation of the test and the action operand works by testing for a
-	   space character. This mostly works even if the action contains strings that contain
-	   spaces, since `passGetString` handles strings with spaces. In fact `passGetString`
-	   needs to handle spaces as any escaped spaces (\s) have been expanded by
-	   `parseChars`. But to be compatible with louis-rs we should disallow spaces in the
-	   action part and report an error. */
+	   space character. We can do this because the operands are not allowed to contain
+	   spaces (as per the documentation). (We are doing this for consistency and
+	   compatibility with louis-rs.) We are however not actually checking that the action
+	   operand does not contain spaces. It is not trivial to implent because: We can not
+	   simply check the remainder of `passHoldString` after the first space, since we need
+	   to allow comments. We can also not simply adapt `passGetString`: it needs to handle
+	   spaces as any escaped spaces (\s) have been expanded by `parseChars`. */
 	for (k = 0; k < passHoldString.length && passHoldString.chars[k] > 32; k++);
 	if (k < passHoldString.length)
 		passHoldString.chars[k] = SEPCHAR;

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -1885,6 +1885,12 @@ compilePassOpcode(const FileInfo *file, TranslationTableOpcode opcode, int nobac
 	for (k = file->linepos; k < file->linelen; k++)
 		passHoldString.chars[passHoldString.length++] = file->line[k];
 #define SEPCHAR 0x0001
+	/* FIXME: The separation of the test and the action operand works by testing for a
+	   space character. This mostly works even if the action contains strings that contain
+	   spaces, since `passGetString` handles strings with spaces. In fact `passGetString`
+	   needs to handle spaces as any escaped spaces (\s) have been expanded by
+	   `parseChars`. But to be compatible with louis-rs we should disallow spaces in the
+	   action part and report an error. */
 	for (k = 0; k < passHoldString.length && passHoldString.chars[k] > 32; k++);
 	if (k < passHoldString.length)
 		passHoldString.chars[k] = SEPCHAR;

--- a/tables/da-dk-g16-lit_1993.ctb
+++ b/tables/da-dk-g16-lit_1993.ctb
@@ -167,10 +167,10 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
 noback correct `["\x2030"] *
-noback correct !$sx["%"] " %"
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["%"] "\s%"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g16.ctb
+++ b/tables/da-dk-g16.ctb
@@ -165,11 +165,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g16_1993.ctb
+++ b/tables/da-dk-g16_1993.ctb
@@ -164,11 +164,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g26-lit_1993.ctb
+++ b/tables/da-dk-g26-lit_1993.ctb
@@ -218,11 +218,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g26.ctb
+++ b/tables/da-dk-g26.ctb
@@ -225,11 +225,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g26_1993.ctb
+++ b/tables/da-dk-g26_1993.ctb
@@ -219,11 +219,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g26l-lit_1993.ctb
+++ b/tables/da-dk-g26l-lit_1993.ctb
@@ -215,11 +215,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/da-dk-g26l_1993.ctb
+++ b/tables/da-dk-g26l_1993.ctb
@@ -215,11 +215,11 @@ attribute charsWDoubleDash .,?!/:"'() # class w
 # Chars that don't require a space before percent and permille:
 attribute charsBeforePercent "(\x201e\x0084\x201c\x0093\x201d\x0094\x00ab\x00bb #class x
 noback correct `["%"] *
-noback correct !$sx["%"] " %"
+noback correct !$sx["%"] "\s%"
 noback correct `["\x2030"] *
-noback correct !$sx["\x2030"] " \x2030"
+noback correct !$sx["\x2030"] "\s\x2030"
 noback correct `["\x0089"] *
-noback correct !$sx["\x0089"] " \x2030"
+noback correct !$sx["\x0089"] "\s\x2030"
 
 # Chars to be treated like digits when switching back to letter mode
 attribute extraDigits \x00bc\x00bd\x00be

--- a/tables/hu-hu-g1_braille_input.cti
+++ b/tables/hu-hu-g1_braille_input.cti
@@ -90,7 +90,7 @@ nofor endnum – 5-36
 nofor always – 5-36
 nofor context @8 "\n"
 nofor context @235-8 "!\n"
-nofor context @235-0 "! "
+nofor context @235-0 "!\s"
 
 #for plus sign related rule
 nofor context @5-235 "+"

--- a/tables/ru-litbrl-detailed.utb
+++ b/tables/ru-litbrl-detailed.utb
@@ -48,7 +48,7 @@ attribute uppergreek \x0391\x0392\x0393\x0394\x0395\x0396\x0397\x0398\x0399\x039
 
 # Mark uppercase cyrillic letters where it is appropriate.
 noback context #1=0#2=1[]%uppercyrillic ?
-noback context []%uppercyrillic2-65532 @45-45#1=0#2=1       # a word consists of several cyrillic uppercase letters: 45-45
+noback context []%uppercyrillic%uppercyrillic. @45-45#1=0#2=1       # a word consists of several cyrillic uppercase letters: 45-45
 noback context []%uppercyrillic @45#1=0#2=1                 # uppercase cyrillic letter not following uppercase cyrillic letter: 45
 
 # Mark uppercase latin letters where it is appropriate.

--- a/tables/ru-ru-g1.ctb
+++ b/tables/ru-ru-g1.ctb
@@ -65,10 +65,10 @@ punctuation \x203c 6-235-235		# 8252	double exclamation mark
 
 attribute dropspaceafter ,;\x00a7
 
-noback correct $D[","$s] "\x2820, " # \x2820 is the braille dot 6
-noback correct $d[","$s] "\x2820, "
-noback correct $D[";"$s] "\x2820; "
-noback correct $d[";"$s] "\x2820; "
+noback correct $D[","$s] "\x2820,\s" # \x2820 is the braille dot 6
+noback correct $d[","$s] "\x2820,\s"
+noback correct $D[";"$s] "\x2820;\s"
+noback correct $d[";"$s] "\x2820;\s"
 noback correct [%dropspaceafter$s] *
 
 # Table I


### PR DESCRIPTION
- Use `\s` instead of space in multipass operands to avoid spaces in multipass operands
- Only allow lowercase virtual dots
- Avoid long ranges in context opcodes. Instead of saying `%foo2-62532` we can just say `%foo%foo.`