### PR TITLE
Fix stack buffer overflow triggered by a crafted translation table

### DIFF
--- a/liblouis/pattern.c
+++ b/liblouis/pattern.c
@@ -604,6 +604,7 @@ pattern_compile_expression(const widechar *input, const int input_max, int *inpu
 	int attrs0, attrs1;
 	int set, esc, nest, i;
 
+	if (*input_crs >= input_max) return 0;
 	switch (input[*input_crs]) {
 	case '(':
 


### PR DESCRIPTION
Fixes #1871

The root cause of the stack buffer overflow is that `pattern_compile_expression` dereferences `input[*input_crs]` without verifying that `*input_crs` is less than `input_max`. Because this function is called recursively and within loops that advance the cursor, the cursor can reach the boundary before a new activation record or iteration begins.

The fix involves adding a boundary check at the very beginning of `pattern_compile_expression` to ensure the cursor is valid before the `switch` statement.

## Verification Before Fix
Running the PoC triggers AddressSanitizer error:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3332480000
INFO: Loaded 1 modules   (5057 inline 8-bit counters): 5057 [0x559c4f8a5798, 0x559c4f8a6b59), 
INFO: Loaded 1 PC tables (5057 PCs): 5057 [0x559c4f8a6b60,0x559c4f8ba770), 
./fuzz_driver_55: Running 1 inputs 1 time(s) each.
Running: /new_issue/bug.input
No tables were indexed
=================================================================
==7264==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffcb8c3a42 at pc 0x559c4f7e89fa bp 0x7fffcb736bb0 sp 0x7fffcb736ba8
READ of size 2 at 0x7fffcb8c3a42 thread T0
    #0 0x559c4f7e89f9 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:607:10
    #1 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #2 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #3 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #4 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #5 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #6 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #7 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #8 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #9 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #10 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #11 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #12 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #13 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #14 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #15 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #16 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #17 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #18 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #19 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #20 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #21 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #22 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #23 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #24 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #25 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #26 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #27 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #28 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #29 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #30 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #31 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #32 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #33 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #34 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #35 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #36 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #37 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #38 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #39 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #40 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #41 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #42 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #43 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #44 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #45 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #46 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #47 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #48 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #49 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #50 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #51 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #52 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #53 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #54 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #55 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #56 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #57 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #58 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #59 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #60 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #61 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #62 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #63 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #64 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #65 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #66 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #67 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #68 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #69 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #70 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #71 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #72 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #73 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #74 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #75 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #76 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #77 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #78 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #79 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #80 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #81 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #82 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #83 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #84 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #85 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #86 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #87 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #88 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #89 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #90 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #91 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #92 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #93 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #94 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #95 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #96 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #97 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #98 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #99 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #100 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #101 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #102 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #103 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #104 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #105 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #106 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #107 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #108 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #109 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #110 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #111 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #112 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #113 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #114 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #115 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #116 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #117 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #118 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #119 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #120 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #121 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #122 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #123 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #124 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #125 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #126 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #127 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #128 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #129 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #130 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #131 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #132 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #133 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #134 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #135 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #136 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #137 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #138 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #139 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #140 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #141 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #142 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #143 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #144 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #145 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #146 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #147 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #148 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #149 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #150 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #151 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #152 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #153 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #154 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #155 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #156 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #157 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #158 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #159 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #160 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #161 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #162 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #163 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #164 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #165 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #166 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #167 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #168 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #169 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #170 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #171 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #172 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #173 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #174 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #175 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #176 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #177 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #178 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #179 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #180 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #181 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #182 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #183 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #184 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #185 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #186 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #187 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #188 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #189 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #190 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #191 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #192 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #193 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #194 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #195 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #196 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #197 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #198 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #199 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #200 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #201 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #202 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #203 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #204 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #205 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #206 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #207 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #208 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #209 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #210 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #211 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #212 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #213 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #214 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #215 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #216 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #217 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #218 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #219 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #220 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #221 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #222 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #223 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #224 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #225 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #226 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #227 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #228 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #229 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #230 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #231 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #232 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #233 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #234 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #235 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #236 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #237 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #238 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #239 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #240 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #241 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #242 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #243 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #244 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #245 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #246 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8
    #247 0x559c4f7e9d59 in pattern_compile_expression /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:680:8

Address 0x7fffcb8c3a42 is located in stack of thread T0 at offset 43618 in frame
    #0 0x559c4f804d5f in compileRule /src/liblouis/build_asan/liblouis/../../liblouis/compileTranslationTable.c:2885

  This frame has 52 object(s):
    [32, 4130) 'token' (line 2886)
    [4400, 8498) 'ruleChars' (line 2888)
    [8768, 12866) 'ruleDots' (line 2889)
    [13136, 17234) 'cells' (line 2890)
    [17504, 21602) 'scratchPad' (line 2891)
    [21872, 25970) 'emphClass' (line 2892)
    [26240, 26248) 'after' (line 2893)
    [26272, 26280) 'before' (line 2894)
    [26304, 30402) 'includedFile' (line 2931)
    [30672, 34824) 'tmpFile' (line 3000)
    [35088, 39186) 'arg' (line 3050)
    [39456, 39460) 'ruleOffset' (line 3095)
    [39472, 39480) 'rule' (line 3105)
    [39504, 39508) 'ruleOffset268' (line 3106)
    [39520, 43618) 'ptn_before' (line 3107) <== Memory access at offset 43618 overflows this variable
    [43888, 47986) 'ptn_after' (line 3107)
    [48256, 48260) 'patternsOffset' (line 3108)
    [48272, 48280) 'rule369' (line 3156)
    [48304, 48308) 'ruleOffset370' (line 3157)
    [48320, 52418) 'ptn_before371' (line 3158)
    [52688, 56786) 'ptn_after372' (line 3158)
    [57056, 57060) 'patternOffset' (line 3159)
    [57072, 57076) 'ruleOffset561' (line 3288)
    [57088, 57092) 'ruleOffset580' (line 3301)
    [57104, 57108) 'ruleOffset637' (line 3347)
    [57120, 57124) 'ruleOffset657' (line 3359)
    [57136, 57140) 'ruleOffset677' (line 3371)
    [57152, 57156) 'ruleOffset697' (line 3383)
    [57168, 57172) 'ruleOffset717' (line 3395)
    [57184, 57188) 'ruleOffset908' (line 3535)
    [57200, 57204) 'ruleOffset923' (line 3549)
    [57216, 57220) 'ruleOffset938' (line 3560)
    [57232, 57236) 'ruleOffset966' (line 3581)
    [57248, 57252) 'ruleOffset1000' (line 3601)
    [57264, 57268) 'ruleOffset1015' (line 3612)
    [57280, 57284) 'ruleOffset1039' (line 3630)
    [57296, 57300) 'ruleOffset1061' (line 3646)
    [57312, 57316) 'ruleOffset1205' (line 3714)
    [57328, 57332) 'ruleOffset1306' (line 3752)
    [57344, 57348) 'ruleOffset1314' (line 3761)
    [57360, 57364) 'ruleOffset1419' (line 3811)
    [57376, 57380) 'ruleOffset1623' (line 3893)
    [57392, 57396) 'ruleOffset1631' (line 3902)
    [57408, 57416) 'r'
    [57440, 61538) 'dots'
    [61808, 65906) 'x' (line 3990)
    [66176, 70274) 'y' (line 3990)
    [70544, 70548) 'ruleOffset1830' (line 4004)
    [70560, 70564) 'ruleOffset1897' (line 4032)
    [70576, 74674) 'characters' (line 4195)
    [74944, 74948) 'characterOffset'
    [74960, 74964) 'basechar2353'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /src/liblouis/build_asan/liblouis/../../liblouis/pattern.c:607:10 in pattern_compile_expression
Shadow bytes around the buggy address:
  0x7fffcb8c3780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffcb8c3800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffcb8c3880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffcb8c3900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffcb8c3980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7fffcb8c3a00: 00 00 00 00 00 00 00 00[02]f2 f2 f2 f2 f2 f2 f2
  0x7fffcb8c3a80: f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2
  0x7fffcb8c3b00: f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 00 00 00 00 00 00
  0x7fffcb8c3b80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffcb8c3c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffcb8c3c80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==7264==ABORTING
```

## Verification After Fix
Running the PoC:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3442839151
INFO: Loaded 1 modules   (5058 inline 8-bit counters): 5058 [0x5600fb68b798, 0x5600fb68cb5a), 
INFO: Loaded 1 PC tables (5058 PCs): 5058 [0x5600fb68cb60,0x5600fb6a0780), 
./fuzz_driver_55: Running 1 inputs 1 time(s) each.
Running: /new_issue/bug.input
No tables were indexed
Executed /new_issue/bug.input in 2 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***
```
