### PR TITLE
INBAF Irish Braille Code October 2025 version

### DIFF
--- a/tables/ga-g1.utb
+++ b/tables/ga-g1.utb
@@ -1,26 +1,26 @@
 # liblouis: Updated Irish Braille (UIB) Grade 1 uncontracted
-# Version: INBAF October 2025
 # -----------
 #-index-name: Irish, uncontracted
 #-display-name: Irish uncontracted braille
 #
-#+language:ga
-#+type:literary
-#+contraction:no
-#+grade:1
-#+system:INBAF
+#+language: ga
+#+type: literary
+#+contraction: no
+#+grade: 1
 # Marked as "direction:forward" by Bue Vester-Andersen
 # as tests only run forward.
-#+direction:forward
+#+direction: forward
 #
 # Updated Irish Braille (UIB) version 2025 by INBAF
 # https://liblouis.io/braille-specs/irish/#updated-irish-braille-2025
+#+system: INBAF
+#+version: 2025
 # -----------
-#
+
 #  Copyright (C) 2004-2006 JJB Software, Inc. www.jjb-software.com
 #  Copyright (C) 2016 American Printing House for the Blind, Inc. www.aph.org
 #  Copyright (C) 2019 Ronan McGuirk <ronan.p.mcguirk@gmail.com>
-#  Copyright (C) 2025 Irish National Braille and Alternative Formats Authority (INBAF) www.inbaf.ie
+#  Copyright (C) 2025 Irish National Braille and Alternative Formats Authority (INBAF) <www.inbaf.ie>
 #
 #  This file is part of liblouis.
 #
@@ -37,9 +37,9 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
-#
-#  Maintained by Ronan McGuirk <ronan.p.mcguirk@gmail.com>
 
+#  Maintained by Ronan McGuirk <ronan.p.mcguirk@gmail.com>
+#-maintainer: Ronan McGuirk <ronan.p.mcguirk@gmail.com>
 
 # This table is based on UEB Grade 1 and has a small number of
 # override rules below. Apart from these rules, Irish Grade 1 is the

--- a/tables/ga-g2.ctb
+++ b/tables/ga-g2.ctb
@@ -1,26 +1,24 @@
 # liblouis: Updated Irish Braille (UIB) Grade 2 Contracted
-# Version:  INBAF  October 2025
-# Copyright (C) 2025 Irish National Braille and Alternative Formats Authority - INBAF,
-#-index-name: Irish, Contracted
-#-display-name: Irish contracted braille
-
-# Maintained by Ronan McGuirk <ronan.p.mcguirk@gmail.com>.
-#
+# -----------
 #-index-name: Irish, contracted
 #-display-name: Irish contracted braille
 #
-#+language:ga
-#+type:literary
-#+contraction:full
-#+grade:2
-#+system:INBAF
+#+language: ga
+#+type: literary
+#+contraction: full
+#+grade: 2
 # Marked as "direction:both" by Bue Vester-Andersen
 # as tests run both forward and backward
-#+direction:both
+#+direction: both
 #
 # Updated Irish Braille (UIB) version 2025 by INBAF
 # https://liblouis.io/braille-specs/irish/#updated-irish-braille-2025
-#
+#+system: INBAF
+#+version: 2025
+# -----------
+
+#  Copyright (C) 2025 Irish National Braille and Alternative Formats Authority (INBAF) <www.inbaf.ie>
+
 #  This file is part of liblouis.
 #
 #  liblouis is free software: you can redistribute it and/or modify it
@@ -37,9 +35,8 @@
 #  License along with liblouis. If not, see
 #  <http://www.gnu.org/licenses/>.
 
-# www.inbaf.ie Irish Grade 2 Braille  Version 2.0 June 2019
-
 # Maintained by Ronan McGuirk, <ronan.p.mcguirk@gmail.com>
+#-maintainer: Ronan McGuirk <ronan.p.mcguirk@gmail.com>
 
 include ga-g1.utb
 contraction c


### PR DESCRIPTION
This update reflects the October 2025 revision of the Irish National Braille and Alternative Formats Authority (INBAF) Irish Braille code There are some minor word changes - leathanaach and leathanaigh..