### PR TITLE
Fix heap buffer overflow in syllableBreak (lou_translateString.c)

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1578,7 +1578,9 @@ syllableBreak(const TranslationTableHeader *table, int pos, const InString *inpu
 		free(hyphens);
 		return 0;
 	}
-	for (k = pos - wordStart + 1; k < (pos - wordStart + transCharslen); k++)
+	int limit = pos - wordStart + transCharslen;
+	if (limit > wordSize) limit = wordSize;
+	for (k = pos - wordStart + 1; k < limit; k++)
 		if (hyphens[k] & 1) {
 			free(hyphens);
 			return 1;


### PR DESCRIPTION
Fixes #1924

To fix the heap-buffer-overflow in `syllableBreak`, we need to ensure that the loop iterating through the `hyphens` array does not exceed the bounds of the word identified. 

The `hyphens` array is allocated based on the length of a contiguous sequence of letters (`wordSize`). However, the translation rule being checked (`transCharslen`) might include non-letter characters or extend beyond the current word boundary. We must constrain the loop index `k` so it never exceeds `wordSize`.

## Verification Before Fix
Running the PoC triggers LeakSanitizer error:
```
Tables have not been indexed yet. Indexing LOUIS_TABLEPATH.
Best match: /src/liblouis/tables/en-g3.ctb (58)
=================================================================
==33438==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000d4cd3 at pc 0x7f9d60e72492 bp 0x7ffc993d7bf0 sp 0x7ffc993d7be8
READ of size 1 at 0x5020000d4cd3 thread T0
    #0 0x7f9d60e72491 in syllableBreak /src/liblouis/liblouis/lou_translateString.c:1582:7
    #1 0x7f9d60e5f3a5 in for_selectRule /src/liblouis/liblouis/lou_translateString.c:2037:9
    #2 0x7f9d60e4614c in translateString /src/liblouis/liblouis/lou_translateString.c:3706:3
    #3 0x7f9d60e412ec in _lou_translate /src/liblouis/liblouis/lou_translateString.c:1298:16
    #4 0x55cb59328aa3 in check_base /src/liblouis/tools/brl_checks.c:181:17
    #5 0x55cb59323682 in check_translation /src/liblouis/tools/lou_checkyaml.c:788:6
    #6 0x55cb59321fe2 in read_test /src/liblouis/tools/lou_checkyaml.c:888:4
    #7 0x55cb593210c5 in read_tests /src/liblouis/tools/lou_checkyaml.c:938:4
    #8 0x55cb5931e9d5 in main /src/liblouis/tools/lou_checkyaml.c:1139:5
    #9 0x7f9d60a4e082 in __libc_start_main /build/glibc-B3wQXB/glibc-2.31/csu/../csu/libc-start.c:308:16
    #10 0x55cb5924750d in _start (/src/liblouis/tools/.libs/lou_checkyaml+0x3050d)

0x5020000d4cd3 is located 0 bytes after 3-byte region [0x5020000d4cd0,0x5020000d4cd3)
allocated by thread T0 here:
    #0 0x55cb592e06e9 in calloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:75:3
    #1 0x7f9d60e723a9 in syllableBreak /src/liblouis/liblouis/lou_translateString.c:1576:20
    #2 0x7f9d60e5f3a5 in for_selectRule /src/liblouis/liblouis/lou_translateString.c:2037:9
    #3 0x7f9d60e4614c in translateString /src/liblouis/liblouis/lou_translateString.c:3706:3
    #4 0x7f9d60e412ec in _lou_translate /src/liblouis/liblouis/lou_translateString.c:1298:16
    #5 0x55cb59328aa3 in check_base /src/liblouis/tools/brl_checks.c:181:17
    #6 0x55cb59323682 in check_translation /src/liblouis/tools/lou_checkyaml.c:788:6
    #7 0x55cb59321fe2 in read_test /src/liblouis/tools/lou_checkyaml.c:888:4
    #8 0x55cb593210c5 in read_tests /src/liblouis/tools/lou_checkyaml.c:938:4
    #9 0x55cb5931e9d5 in main /src/liblouis/tools/lou_checkyaml.c:1139:5
    #10 0x7f9d60a4e082 in __libc_start_main /build/glibc-B3wQXB/glibc-2.31/csu/../csu/libc-start.c:308:16

SUMMARY: AddressSanitizer: heap-buffer-overflow /src/liblouis/liblouis/lou_translateString.c:1582:7 in syllableBreak
Shadow bytes around the buggy address:
  0x5020000d4a00: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fd
  0x5020000d4a80: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fa
  0x5020000d4b00: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x5020000d4b80: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fd
  0x5020000d4c00: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
=>0x5020000d4c80: fa fa fd fd fa fa fd fd fa fa[03]fa fa fa fd fd
  0x5020000d4d00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x5020000d4d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x5020000d4e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x5020000d4e80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x5020000d4f00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==33438==ABORTING
```

Running the tests `ASAN_OPTIONS=detect_leaks=0 make check`:
```
...
FAIL: braille-specs/en-g3.yaml
...
============================================================================
Testsuite summary for Liblouis 3.36.0
============================================================================
# TOTAL: 201
# PASS:  200
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See tests/test-suite.log
Please report to liblouis-liblouisxml@freelists.org
============================================================================
...
```

## Verification After Fix
Running the PoC:
```
Tables have not been indexed yet. Indexing LOUIS_TABLEPATH.
Best match: /src/liblouis/tables/en-g3.ctb (58)
SUCCESS (1 tests, 0 failures)
```

Running the tests `ASAN_OPTIONS=detect_leaks=0 make check`:
```
...
============================================================================
Testsuite summary for Liblouis 3.36.0
============================================================================
# TOTAL: 201
# PASS:  201
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
...
```
