### PR TITLE
Fix stack overflow when invalid LOUIS_LOGLEVEL string provided

### DIFF
--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -106,28 +106,28 @@ getLogLevelFromEnvironment() {
 		/* Log levels names are unique by their first character */
 		switch (tolower(log_level_str[0])) {
 		case 'a':
-			logLevel = LOU_LOG_ALL;
+			lou_setLogLevel(LOU_LOG_ALL);
 			break;
 		case 'd':
-			logLevel = LOU_LOG_DEBUG;
+			lou_setLogLevel(LOU_LOG_DEBUG);
 			break;
 		case 'i':
-			logLevel = LOU_LOG_INFO;
+			lou_setLogLevel(LOU_LOG_INFO);
 			break;
 		case 'w':
-			logLevel = LOU_LOG_WARN;
+			lou_setLogLevel(LOU_LOG_WARN);
 			break;
 		case 'e':
-			logLevel = LOU_LOG_ERROR;
+			lou_setLogLevel(LOU_LOG_ERROR);
 			break;
 		case 'f':
-			logLevel = LOU_LOG_FATAL;
+			lou_setLogLevel(LOU_LOG_FATAL);
 			break;
 		case 'o':
-			logLevel = LOU_LOG_OFF;
+			lou_setLogLevel(LOU_LOG_OFF);
 			break;
 		default:
-			logLevel = LOU_LOG_INFO;
+			lou_setLogLevel(LOU_LOG_INFO);
 			_lou_logMessage(LOU_LOG_WARN,
 					"Unknown log level set by LOUIS_LOGLEVEL environment variable: %s",
 					log_level_str);


### PR DESCRIPTION
If an unknown/invalid value was provided in the LOUIS_LOGLEVEL environment variable, an infinite loop would result due to trying to log a warning about that fact. This fix ensures that the env variable detection does not re-run for the warning message.

Fixes #1861