### PR TITLE
Fix unquoted HTTP address braille-specs/no.yaml (causing mingw64 test failures)

### DIFF
--- a/tests/braille-specs/no.yaml
+++ b/tests/braille-specs/no.yaml
@@ -1662,7 +1662,7 @@ tests:
   - [Utakk er verdens lønn., ⠠⠥⠞⠅ ⠱ ⠧⠑⠗⠙⠣⠎ ⠇⠪⠝⠝⠄]
   - [på'n igjen, ⠏⠐⠰⠝ ⠊⠛⠚⠣, xfail: {backward: true}]
   - [b/c- og/eller c-forkorting, ⠰⠃⠌⠰⠉⠤ ⠉⠌⠑ ⠰⠉⠤⠫⠅⠕⠗⠞⠊⠝⠛, xfail: {backward: true}]
-  - [https://punktskriftutvalget.no, ⠓⠞⠞⠏⠎⠒⠌⠌⠏⠥⠝⠅⠞⠎⠅⠗⠊⠋⠞⠥⠞⠧⠁⠇⠛⠑⠞⠄⠝⠕]
+  - ["https://punktskriftutvalget.no", ⠓⠞⠞⠏⠎⠒⠌⠌⠏⠥⠝⠅⠞⠎⠅⠗⠊⠋⠞⠥⠞⠧⠁⠇⠛⠑⠞⠄⠝⠕]
   - [tips@dn.no, ⠞⠊⠏⠎⠈⠙⠝⠄⠝⠕]
   - [m, ⠰⠍]
   - [km, ⠰⠅⠍]


### PR DESCRIPTION
Quote the URL "https://punktskriftutvalget.no" in a YAML flow sequence to fix a parse error with libyaml 0.1.4.

The unquoted colon in "https://" causes libyaml 0.1.4 to report "found unexpected ':'" because that older parser incorrectly treats it as a mapping indicator inside a flow sequence. Newer versions (0.2.x) handle this correctly per the YAML spec.

This was introduced in commit 6e214fe5 ("Reworked grade two translation for level 2", 2025-10-11) and merged to master via f903fcee on 2025-12-01. The mingw64 CI build has been failing since then. The failure only occurs in the mingw64 cross-compile workflow because it builds against libyaml 0.1.4, while native Linux builds use the system libyaml (typically 0.2.x) which parses this correctly.