### PR TITLE
Document input format considerations for back-translation when using lou_translate

### DIFF
--- a/tools/lou_translate.c
+++ b/tools/lou_translate.c
@@ -111,13 +111,15 @@ Options:\n\
   -b, --backward       backward translation using the given table\n\
                        If neither -f nor -b are specified forward translation\n\
                        is assumed\n\
-  -d, --display-table  use the given display table for the translation. This\n\
-                       is useful when you are specifying the table as a query.\n\
-                       This option takes precedence over any display table\n\
-                       specified as part of the table file list.\n\
-                       Note: for backward translation, the display table\n\
-                       determines how ASCII input characters are mapped to\n\
-                       braille dot patterns.\n",
+  -d, --display-table  use the given display table for the translation. The\n\
+                       display table determines how braille dot patterns are\n\
+                       encoded as text (decoded in case of backward\n\
+                       translation). Without a display table, the braille\n\
+                       encoding is determined by the translation table, when\n\
+                       it is specified as a file list, or Unicode braille when\n\
+                       the table is specified as a query. For clarity and\n\
+                       reliability, it is recommended to always make the\n\
+                       display table explicit.\n",
 			stdout);
 	fputs("\
 Examples:\n\
@@ -126,31 +128,20 @@ Examples:\n\
   Do a forward translation of English text to grade 2 contracted braille\n\
   according to the U.S. braille standard.\n\
   \n\
-  lou_translate --forward en-us-g2.ctb < input.txt\n\
+  lou_translate -d en-us-brf.dis language:en grade:2 region:en-US < input.txt\n\
   \n\
-  Do a forward translation with table en-us-g2.ctb.\n\
+  Here we do the same forward translation but with a specific ASCII braille\n\
+  encoding instead of Unicode braille.\n\
   \n\
-  lou_translate unicode.dis,en-us-g2.ctb < input.txt\n\
+  lou_translate -d unicode.dis en-us-g2.ctb < input.txt\n\
   \n\
-  If you require a specific braille encoding use a display table. Here we do a\n\
-  forward translation with table en-us-g2.ctb and a display table for Unicode\n\
-  braille. The resulting braille is encoded as Unicode dot patterns.\n\
+  Do a forward translation with table en-us-g2.ctb and Unicode braille encoding.\n\
   \n\
-  lou_translate -d unicode.dis language:en grade:2 region:en-US < input.txt\n\
+  echo \",! qk br{n fox\" | lou_translate -b -d text_nabcc.dis language:en grade:2 region:en-US\n\
   \n\
-  Using a query and a specific display table you can achieve basically the same\n\
-  translation as above.\n\
-  \n\
-  echo \",! qk br{n fox\" | lou_translate --backward en-us-g2.ctb\n\
-  \n\
-  Do a backward translation with table en-us-g2.ctb. Note that braille-ASCII\n\
-  input (as shown here) only works reliably with tables whose character\n\
-  definitions match the North American Braille Computer Code (NABCC), such as\n\
-  English tables. For other tables, use Unicode braille input instead:\n\
-  \n\
-  echo '\\x2810\\x2801' | lou_translate --backward sk-g1.ctb\n\
-  \n\
-  Do a backward translation of Unicode braille with a Slovak table.\n",
+  Do a backward translation with the English grade 2 table. Note that the ASCII\n\
+  braille input (as shown here) must match the specified display table\n\
+  (North American Braille Computer Code in this case).\n",
 			stdout);
 	printf("\n");
 	printf("Report bugs to %s.\n", PACKAGE_BUGREPORT);


### PR DESCRIPTION
Clarified the help text on `lou_translate` to explain that braille-ASCII back-translation input is table-specific (relying on NABCC-compatible character definitions) and add an example showing Unicode braille input for non-English tables.

_Also_: Fixed `-d` short option for selecting a display table, as this did not actually work (as it was not included in the `getopt_long()` call - originally added in PR #1679).

Fixes #1905