### PR TITLE
Avoid crash when table resolver is NULL

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4849,6 +4849,10 @@ copyStringArray(char **array) {
 
 char **EXPORT_CALL
 _lou_resolveTable(const char *tableList, const char *base) {
+	if (!tableResolver) {
+		_lou_logMessage(LOU_LOG_ERROR, "Table resolver is not set");
+		return NULL;
+	}
 	char **tableFiles = (*tableResolver)(tableList, base);
 	char **result = copyStringArray(tableFiles);
 	if (tableResolver == &_lou_defaultTableResolver) lou_freeTableFiles(tableFiles);
@@ -4864,6 +4868,10 @@ _lou_resolveTable(const char *tableList, const char *base) {
 void EXPORT_CALL
 lou_registerTableResolver(
 		char **(EXPORT_CALL *resolver)(const char *tableList, const char *base)) {
+	if (!resolver) {
+		_lou_logMessage(LOU_LOG_ERROR, "Cannot register a NULL table resolver");
+		return;
+	}
 	tableResolver = resolver;
 }
 


### PR DESCRIPTION
- Add NULL guard in `_lou_resolveTable()` to prevent inadvertent null pointer deref if the table resolver has been set to NULL or not set at all
- Explicitly reject attempts to call `lou_registerTableResolver()` with a NULL resolver
- All existing callers of `_lou_resolveTable()` already handle NULL returns, so no downstream changes needed

Fixes #1865