### PR TITLE
 Fix infinite loop in isEmphasizable caused if characters mistakenly reference one another

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4385,6 +4385,7 @@ finalizeCharacter(TranslationTableHeader *table, TranslationTableOffset characte
 		int detect_loop) {
 	TranslationTableCharacter *character =
 			(TranslationTableCharacter *)&table->ruleArea[characterOffset];
+	if (character->finalized) return character;
 	if (character->basechar) {
 		TranslationTableOffset basecharOffset = 0;
 		TranslationTableCharacter *basechar = character;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -231,6 +231,7 @@ dist_yaml_TESTS =				\
 	yaml/emphasis.yaml			\
 	yaml/example_test.yaml			\
 	yaml/face-with-tears-of-joy.yaml        \
+	yaml/issue-1863-basechar-finalize.yaml	\
 	yaml/hyphenation.yaml			\
 	yaml/hyphenation_nocross_harness.yaml	\
 	yaml/inpos_outpos.yaml			\

--- a/tests/yaml/issue-1863-basechar-finalize.yaml
+++ b/tests/yaml/issue-1863-basechar-finalize.yaml
@@ -1,0 +1,30 @@
+# Regression test for https://github.com/liblouis/liblouis/issues/1863
+#
+# A basechar chain (A→B→a) where the hash iteration order causes a
+# character to be visited after it was already recursively finalized
+# used to result in a cycle in the linked list, making
+# isEmphasizable() spin forever.
+
+table: |
+  include tables/spaces.uti
+  include tables/braille-patterns.cti
+  lowercase a 1
+  lowercase b 12
+  lowercase c 14
+  # Chain: B is based on a (uppercase), A is based on B (custom attr).
+  # Because hash(A)=65 < hash(B)=66, the outer loop in finalizeTable
+  # visits A first, recursively finalizing B.  Without the early-return
+  # guard in finalizeCharacter(), B would be finalized a second time
+  # when the loop reaches it, creating a cycle in a's linked list.
+  base uppercase B a
+  base myattr A B
+  # Caps indicators activate the emphasis code path that traverses the
+  # linked list inside isEmphasizable().
+  begcapsword 6-6
+  endcapsword 6-3
+
+flags: {testmode: forward}
+tests:
+  # Translating any text exercises isEmphasizable on every character.
+  # Before the fix this would hang forever.
+  - ["a b c", "⠁ ⠃ ⠉"]


### PR DESCRIPTION
A malformed table could cause `finalizeCharacter()` to process the same character twice, inserting it into the linked list a second time and creating a cycle. The `while(chardef->linked)` loop in `isEmphasizable()` then runs forever. Guard against this by returning early when the character is already finalized.

Fixes #1863