### PR TITLE
Fix second unquoted URL in braille-specs/no.yaml for mingw64 CI

### DIFF
--- a/tests/braille-specs/no.yaml
+++ b/tests/braille-specs/no.yaml
@@ -1684,7 +1684,7 @@ flags: {testmode: forward}
 
 tests:
   - [<tips@dn.no>, ⠣⠞⠊⠏⠎⠈⠙⠝⠄⠝⠕⠜]
-  - [<https://bt.no>, ⠣⠓⠞⠞⠏⠎⠒⠌⠌⠃⠞⠄⠝⠕⠜]
+  - ["<https://bt.no>", ⠣⠓⠞⠞⠏⠎⠒⠌⠌⠃⠞⠄⠝⠕⠜]
 
 
 flags: {testmode: backward}


### PR DESCRIPTION
Quote "<https://bt.no>" in a YAML flow sequence to prevent a libyaml 0.1.4 parse error. Follow-up to (what turned out to be an incomplete) fix in #1931.

