### PR TITLE
Remove dead CTO_Contraction case from back_selectRule()

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -732,7 +732,6 @@ back_selectRule(const TranslationTableHeader *table, int pos, int mode,
 					case CTO_WholeWord:
 						if (mode & partialTrans) break;
 						if (ctx.itsALetter || ctx.itsANumber) break;
-					case CTO_Contraction:
 						if ((beforeAttributes & (CTC_Space | CTC_Punctuation)) &&
 								((afterAttributes & CTC_Space) ||
 										isEndWord(table, pos, mode, input,


### PR DESCRIPTION
PR removes the `CTO_Contraction` case label in `back_selectRule()` for clarity since `CTO_Contraction` is never actually added into the compiled backtranslation table.

Functionally, however, this is a no-op and this removes the label solely to avoid confusion about why it is there at all.  The code that was in that label is retained because `CTO_WholeWord` processing fell through into this block in any event.

