### PR TITLE
Adapt AUTHORS based on git log

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,25 +32,32 @@ Former maintainers:
 
 Considerable coding was done by:
 
+  Anthony Tibbs <anthony@tibbs.ca>
   Bue Vester-Andersen <bue@vester-andersen.dk>
   Dave Mielke <dave@mielke.cc>
   Davy Kager <mail@davykager.nl>
   Eitan Isaacson <eitan@ascender.com>
   James Teh <jamie@jantrid.net>
+  Leonard de Ruijter <alderuijter@gmail.com>
   Michael Curran <mick@kulgan.net>
   Michael Whapples <mwhapples@aim.com>
   Mike Gray <mgray@aph.org>
   Reiner Dolp <hallo@reinerdolp.com>
+  Samuel Thibault <samuel.thibault@labri.fr>
 
 Patches were provided by:
 
+  André-Abush Clause <dev@andreabc.net>
   Arend Arends <arend.arends@hccnet.nl>
+  Camsyn <2742046922@qq.com>
   Chris Brannon
   Jeremy Roman <jbroman@google.com>
   Ken Perry <kperry@aph.org>
+  Marsman1996 <lqliuyuwei@outlook.com>
+  Martin Gieseking <martin.gieseking@uos.de>
   Martin Michlmayr <tbm@cyrius.com>
   Matt Wenn
-  Mike Gorse
+  Mike Gorse <mgorse@suse.com>
   Milan Zamazal <pdm@brailcom.org>
   Peter Nilsson Lundblad <plundblad@google.com>
   Simon Aittamaa, Index Braille <simon.aittamaa@indexbraille.com>
@@ -86,7 +93,6 @@ Other contributors:
   Nikhil Nair <nn201@cus.cam.ac.uk>
   Oscar Fernandez <ofa@once.es>
   Per Lejontand <pele@acc.umu.se>
-  Samuel Thibault <samuel.thibault@labri.fr>
   Sébastien Hinderer <sebastien.hinderer@libertysurf.fr>
   Stephane Dalton <sdalton@videotron.ca>
   Wolfgang Astleitner <wolfgang.astleitner@liwest.at>
@@ -104,9 +110,7 @@ TABLE AND TEST CONTRIBUTORS
   Ali-Riza Ciftcioglu <Aliminator83@gmail.com>
   Allan R. Mesoga <allan.mesoga@deped.gov.ph>
   Ammar Usama <ammar.usama@nlb.no>
-  André-Abush Clause <dev@andreabc.net>
   Andrey Yakuboy <braille@yakuboy.ru>
-  Anthony Tibbs
   Artis Raugulis
   Ashoka Bandula Weerawardhana
   Babbage B.V. <www.babbage.com>
@@ -186,7 +190,6 @@ TABLE AND TEST CONTRIBUTORS
   Luisterpuntbibliotheek <https://www.luisterpuntbibliotheek.be>
   Leon Ungier <Leon.Ungier@ViewPlus.com> from ViewPlus Technologies, Inc. <www.viewplus.com>
   Leona Holloway <Leona.Holloway@visionaustralia.org> from Vision Australia
-  Leonard de Ruijter <alderuijter@gmail.com>
   Ludovic Oger <oger.ludovic@gmail.com>
   Łukasz Golonka <lukasz.golonka@mailbox.org>
   Mariam Mikiashvili


### PR DESCRIPTION
Use git shortlog -sne -- *.c *.h to see a list of authors with counts per author. Then use that to update the AUTHORS file.

Only authors with more than two commits are considered
