### PR TITLE
Add the lou_translate help text to the documentation

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2733,6 +2733,8 @@ over any display table specified as part of the table files.
 
 If no options are given forward translation is assumed.
 
+@subsection Examples
+
 Use the following command to do a forward translation of English text
 to grade 2 contracted braille according to the U.S. braille standard.
 
@@ -2740,11 +2742,27 @@ to grade 2 contracted braille according to the U.S. braille standard.
 lou_translate --display-table unicode.dis language:en grade:2 region:en-US < input.txt
 @end example
 
-Use the following command to do a forward translation with translation
-table @file{en-us-g2.ctb}.
+Do the same forward translation but with a specific ASCII braille
+encoding instead of Unicode braille.
 
 @example
-lou_translate --forward en-us-g2.ctb < input.txt
+lou_translate -d en-us-brf.dis language:en grade:2 region:en-US < input.txt
+@end example
+
+Do a forward translation with table @file{en-us-g2.ctb} and Unicode
+braille encoding.
+
+@example
+lou_translate -d unicode.dis en-us-g2.ctb < input.txt
+@end example
+
+Do a backward translation with the English grade 2 table. Note that
+the ASCII braille input (as shown here) must match the specified
+display table (North American Braille Computer Code in this
+case).
+
+@example
+echo ",! qk br@{n fox" | lou_translate -b -d text_nabcc.dis language:en grade:2 region:en-US
 @end example
 
 When you specify the table as a query, the braille encoding is always

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2735,59 +2735,20 @@ If no options are given forward translation is assumed.
 
 @subsection Examples
 
-Use the following command to do a forward translation of English text
-to grade 2 contracted braille according to the U.S. braille standard.
-
-@example
-lou_translate --display-table unicode.dis language:en grade:2 region:en-US < input.txt
-@end example
-
-Do the same forward translation but with a specific ASCII braille
-encoding instead of Unicode braille.
-
-@example
-lou_translate -d en-us-brf.dis language:en grade:2 region:en-US < input.txt
-@end example
-
-Do a forward translation with table @file{en-us-g2.ctb} and Unicode
-braille encoding.
-
-@example
-lou_translate -d unicode.dis en-us-g2.ctb < input.txt
-@end example
-
-Do a backward translation with the English grade 2 table. Note that
-the ASCII braille input (as shown here) must match the specified
-display table (North American Braille Computer Code in this
-case).
-
-@example
-echo ",! qk br@{n fox" | lou_translate -b -d text_nabcc.dis language:en grade:2 region:en-US
-@end example
-
-When you specify the table as a query, the braille encoding is always
-Unicode dot patterns, unless you specify a display table with the
-@option{display-table} option.
-
-When you specify the table as a file list, the encoding of the
-resulting braille depends on the character definitions in the given
-table. It is recommended to use a display table, as in the following
-example, if you require a specific braille encoding.
-
-The next example illustrates a forward translation with translation
+The following example does a forward translation with translation
 table @file{en-us-g2.ctb} and display table @file{unicode.dis}. The
 resulting braille is encoded as Unicode dot patterns (as defined in
 @file{unicode.dis}).
 
 @example
-lou_translate --forward unicode.dis,en-us-g2.ctb < input.txt
+lou_translate -f -d unicode.dis en-us-g2.ctb < input.txt
 @end example
 
 Use a pipe if you would rather just pass some given text to the
 translator.
 
 @example
-echo "The quick brown fox jumps over the lazy dog" | lou_translate -f unicode.dis,en-us-g2.ctb
+echo "The quick brown fox jumps over the lazy dog" | lou_translate -f -d unicode.dis en-us-g2.ctb
 @end example
 
 The result will be written to standard output:
@@ -2808,16 +2769,45 @@ which results in
 The quick brown fox jumps over the lazy dog
 @end example
 
-You can also do a backward translation using Unicode dot patterns
+You can also do a backward translation using Unicode dot patterns:
 
 @example
-echo "⠠⠮ ⠟⠅ ⠃⠗⠪⠝ ⠋⠕⠭" | lou_translate --backward unicode.dis,en-us-g2.ctb
+echo "⠠⠮ ⠟⠅ ⠃⠗⠪⠝ ⠋⠕⠭" | lou_translate -b -d unicode.dis en-us-g2.ctb
 @end example
 
 resulting in
 
 @example
 The quick brown fox
+@end example
+
+Note that with file-based tables the braille encoding depends on the
+character definitions in the table, which is why the examples above
+use @option{-d} to specify an explicit display table. With query-based
+tables the encoding is always Unicode dot patterns unless you override
+it with @option{-d}.
+
+Use the following command to do a forward translation of English text
+to grade 2 contracted braille according to the U.S. braille standard.
+
+@example
+lou_translate --display-table unicode.dis language:en grade:2 region:en-US < input.txt
+@end example
+
+Do the same forward translation but with a specific ASCII braille
+encoding instead of Unicode braille.
+
+@example
+lou_translate -d en-us-brf.dis language:en grade:2 region:en-US < input.txt
+@end example
+
+Do a backward translation with the English grade 2 table. Note that
+the ASCII braille input (as shown here) must match the specified
+display table (North American Braille Computer Code in this
+case).
+
+@example
+echo ",! qk br@{n fox" | lou_translate -b -d text_nabcc.dis language:en grade:2 region:en-US
 @end example
 
 @node lou_checkhyphens

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -2735,6 +2735,35 @@ If no options are given forward translation is assumed.
 
 @subsection Examples
 
+Use the following command to do a forward translation of English text
+to grade 2 contracted braille according to the U.S. braille standard.
+
+@example
+lou_translate --display-table unicode.dis language:en grade:2 region:en-US < input.txt
+@end example
+
+Do the same forward translation but with a specific ASCII braille
+encoding instead of Unicode braille.
+
+@example
+lou_translate -d en-us-brf.dis language:en grade:2 region:en-US < input.txt
+@end example
+
+Do a backward translation with the English grade 2 table. Note that
+the ASCII braille input (as shown here) must match the specified
+display table (North American Braille Computer Code in this
+case).
+
+@example
+echo ",! qk br@{n fox" | lou_translate -b -d text_nabcc.dis language:en grade:2 region:en-US
+@end example
+
+Note that with query-based tables the braille encoding is always
+Unicode dot patterns unless you override it with @option{-d}. With
+file-based tables the braille encoding depends on the character
+definitions in the table, so the examples below use @option{-d} to
+specify an explicit display table.
+
 The following example does a forward translation with translation
 table @file{en-us-g2.ctb} and display table @file{unicode.dis}. The
 resulting braille is encoded as Unicode dot patterns (as defined in
@@ -2779,35 +2808,6 @@ resulting in
 
 @example
 The quick brown fox
-@end example
-
-Note that with file-based tables the braille encoding depends on the
-character definitions in the table, which is why the examples above
-use @option{-d} to specify an explicit display table. With query-based
-tables the encoding is always Unicode dot patterns unless you override
-it with @option{-d}.
-
-Use the following command to do a forward translation of English text
-to grade 2 contracted braille according to the U.S. braille standard.
-
-@example
-lou_translate --display-table unicode.dis language:en grade:2 region:en-US < input.txt
-@end example
-
-Do the same forward translation but with a specific ASCII braille
-encoding instead of Unicode braille.
-
-@example
-lou_translate -d en-us-brf.dis language:en grade:2 region:en-US < input.txt
-@end example
-
-Do a backward translation with the English grade 2 table. Note that
-the ASCII braille input (as shown here) must match the specified
-display table (North American Braille Computer Code in this
-case).
-
-@example
-echo ",! qk br@{n fox" | lou_translate -b -d text_nabcc.dis language:en grade:2 region:en-US
 @end example
 
 @node lou_checkhyphens


### PR DESCRIPTION
Add examples from `lou_translate --help` order them logically and drop the use of display tables within the table list