### PR TITLE
Migrate docker files image from debian:bullseye to debian:bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN ./autogen.sh && ./configure --enable-ucs4 && make && make install && ldconfi
 
 # install python bindings
 WORKDIR /usr/src/liblouis/python
-RUN pip install .
+RUN pip install --break-system-packages .
 
 # clean up
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     python3-setuptools \
+    python3-venv \
     texinfo \
    && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +23,10 @@ ADD . /usr/src/liblouis
 WORKDIR /usr/src/liblouis
 RUN ./autogen.sh && ./configure --enable-ucs4 && make && make install && ldconfig
 
-# install python bindings
+# install python bindings into an isolated venv, so we don't need to touch
+# Debian's externally-managed system Python environment
+RUN python3 -m venv /opt/liblouis-venv
+ENV PATH="/opt/liblouis-venv/bin:$PATH"
 WORKDIR /usr/src/liblouis/python
 RUN pip install .
 

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637 AS builder
+FROM debian:bookworm@sha256:8738a0fdc7a61feebbeb625c41b405443639ea0a04ecc0d481d92b4720fd8566 AS builder
 
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
@@ -59,7 +59,7 @@ RUN ./autogen.sh && \
 # Now we have all we really need namely the cross-compiled liblouis
 # packaged neatly in a zip. But just to be extra sure we test the
 # cross-compiled liblouis in a separate docker image with wine
-FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637
+FROM debian:bookworm@sha256:8738a0fdc7a61feebbeb625c41b405443639ea0a04ecc0d481d92b4720fd8566
 
 # install wine for 32-bit architecture
 RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get install -y \

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89 AS builder
+FROM debian:bookworm@sha256:8738a0fdc7a61feebbeb625c41b405443639ea0a04ecc0d481d92b4720fd8566 AS builder
 
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
@@ -59,7 +59,7 @@ RUN ./autogen.sh && \
 # Now we have all we really need namely the cross-compiled liblouis
 # packaged neatly in a zip. But just to be extra sure we test the
 # cross-compiled liblouis in a separate docker image with wine
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bookworm@sha256:8738a0fdc7a61feebbeb625c41b405443639ea0a04ecc0d481d92b4720fd8566
 
 # install wine for 32-bit architecture
 RUN apt-get update && dpkg --add-architecture i386 && apt-get update && apt-get install -y \

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637 AS builder
+FROM debian:bookworm@sha256:b5fd0730c71f88a75e9d95dc6d812e8c34db679b3f009903d917be8f0300ba13 AS builder
 
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
@@ -50,7 +50,7 @@ RUN ./autogen.sh && \
 # Now we have all we really need namely the cross-compiled liblouis
 # packaged neatly in a zip. But just to be extra sure we test the
 # cross-compiled liblouis in a separate docker image with wine
-FROM debian:bullseye@sha256:2c407480ad7c98bdc551dbb38b92acb674dc130c8298f2e0fa2ad34da9078637
+FROM debian:bookworm@sha256:b5fd0730c71f88a75e9d95dc6d812e8c34db679b3f009903d917be8f0300ba13
 
 # install wine
 RUN apt-get update && apt-get install -y \
@@ -66,4 +66,4 @@ RUN unzip liblouis.zip
 
 # just run any old self-contained yaml test that doesn't need any env setup
 ADD tests/yaml/letterDefTest_harness.yaml .
-RUN wine64 bin/lou_checkyaml.exe letterDefTest_harness.yaml
+RUN wine bin/lou_checkyaml.exe letterDefTest_harness.yaml

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -1,4 +1,4 @@
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89 AS builder
+FROM debian:bookworm@sha256:b5fd0730c71f88a75e9d95dc6d812e8c34db679b3f009903d917be8f0300ba13 AS builder
 
 LABEL maintainer="Liblouis Maintainers <liblouis-liblouisxml@freelists.org>"
 
@@ -50,7 +50,7 @@ RUN ./autogen.sh && \
 # Now we have all we really need namely the cross-compiled liblouis
 # packaged neatly in a zip. But just to be extra sure we test the
 # cross-compiled liblouis in a separate docker image with wine
-FROM debian:bullseye@sha256:e7100042ddfd3c1fb9d4a5bf15acbdb1058d7bb3340142916d3413a5c001fc89
+FROM debian:bookworm@sha256:b5fd0730c71f88a75e9d95dc6d812e8c34db679b3f009903d917be8f0300ba13
 
 # install wine
 RUN apt-get update && apt-get install -y \
@@ -66,4 +66,4 @@ RUN unzip liblouis.zip
 
 # just run any old self-contained yaml test that doesn't need any env setup
 ADD tests/yaml/letterDefTest_harness.yaml .
-RUN wine64 bin/lou_checkyaml.exe letterDefTest_harness.yaml
+RUN wine bin/lou_checkyaml.exe letterDefTest_harness.yaml


### PR DESCRIPTION
## Description
Based with #1961 discussion, I opening proper pull request to Dockerfile, Dockerfile.win32, and Dockerfile.win64 related.
Dockerfile I fixed only the pip command related line, when I tested the docker build -f Dockerfile -t liblouis . command, because the build ran really a Debian 12 image, need use in dockerfile the --break-system-packages option with pip command.

In Dockerfile.win32, Dockerfile.win64 I changed image from DEbian:bullseye to Debian:bookworm actual sha256 version.

Describe what this pull request changes and why. If it fixes a bug,
describe the observed behavior and the expected behavior. Include any
information that helps reviewing this change: links to specs, issues,
or prior discussions.
#1961 document everithing change and why need this change. Bullseye support will be eol in 2026 august 30, and in Liblouis 3.39.0 release publication date not absolute sure guaranteed will be awailable the Bullseye image or not into the Docker hub, and will be functional the Bullseye apt repositoryes. Bookworm supported until 2028. june 30, so we have more time future migrate final to Debian 13 Trixie the entire cross-compilation process.
This is not possible yet, because Docker cross-compilation in debian:latest actual Debian 13 version produce possible Gnulib errors.

## Checklist
* I Checked normal Dockerfile build with docker build -f Dockerfile -t liblouis . Command, after pip command related commit the build process ran successfull. When I run docker run -it liblouis command, for example lou_translate --version command in terminal right presents version number, lou_translate hu-hu-g1.ctb command right translated a hungarian text to braille.
* Make distwin command right generated both liblouis-3.37.0-win32.zip and liblouis-3.37.0-win64.zip.
* Both two architecture versions when I unzipped the proper zip file, in wine right ran lou_translate.exe --version command, right translated lou_translate.exe with a normal text to braille with hu-hu-g1.ctb command, and lou_checkyaml.exe right ran Liblouis larger hungarian grade1 harness test file. Me have only Linux operating system with all computers, so have possibility only testing the Windows cross-compiled binaries into Wine emulator.

### Tests
Based with the previous check list, all check list documented tests are passed.
See the #1961 with my Dockerfiles.win32 and Dockerfile.win64 related last comments.
