### PR TITLE
Add Norwegian braille table for Spanish text

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -143,6 +143,7 @@ jobs:
           - Es-Es-G0.utb
           - es-g1.ctb
           - es-g2.ctb
+          - es-no.utb
           - et.ctb
           - et-6dot.utb
           - et-g0.utb

--- a/extra/generate-display-names/display-names
+++ b/extra/generate-display-names/display-names
@@ -77,6 +77,7 @@
 * ../../tables/es.tbl                               Spanish, uncontracted                              Spanish uncontracted braille
 * ../../tables/es-g2.ctb                            Spanish, contracted                                Spanish contracted braille
 * ../../tables/Es-Es-G0.utb                         Spanish, computer                                  Spanish computer braille
+  ../../tables/es-no.utb                            Spanish, Norway                                    Norwegian braille for Spanish text
 * ../../tables/et.tbl                               Estonian, computer                                 Estonian computer braille
 * ../../tables/et-6dot.utb                          Estonian                                           Estonian braille
 * ../../tables/fi.utb                               Finnish                                            Finnish braille

--- a/tables/Makefile.am
+++ b/tables/Makefile.am
@@ -146,6 +146,7 @@ table_files = \
 	Es-Es-G0.utb \
 	es-g1.ctb \
 	es-g2.ctb \
+	es-no.utb \
 	es-new.dis \
 	es-old.dis \
 	es.tbl \

--- a/tables/es-no.utb
+++ b/tables/es-no.utb
@@ -1,0 +1,79 @@
+#
+#  Copyright (C) 2026 Bert Frees
+#  Copyright (C) 2026 Statped, Department Teaching Materials Visual Impairment <https://www.statped.no>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# -------------------------------------------------------------------------------
+
+#-copyright: 2026, Bert Frees
+#-copyright: 2026, Statped, Department Teaching Materials Visual Impairment <https://www.statped.no>
+#-license: lgpl-2.1
+#-author: Bert Frees
+
+# This is a table for Spanish text, based on the Norwegian braille
+# standard. The rules are specified in «Håndbok i litterær
+# punktskrift» in «Appendiks: 7 Spansk» (see
+# https://liblouis.io/braille-specs/norwegian). The accented letters
+# are listed in the beginning under «Bokstaver med diakritiske tegn»
+# (Letters with diacritical marks). The inverted question mark and
+# inverted exclamation mark are the first characters listed under
+# «Tegn» (characters).
+#
+# All other punctuation is handled according to the generic rules of
+# Norwegian braille, and so are braille indicators.
+#
+# Statped is probably the only organisation in Norway that produces
+# Spanish this way. This is because of the age group they supply
+# for. For higher education and for fiction, it makes more sense to
+# use the Spanish braille code.
+
+#-display-name: Norwegian braille for Spanish Text index-name:
+#-Spanish, Norway
+
+#+locale: es
+#+region: no
+#+type: literary
+#+dots: 6
+#+contraction: no
+#+direction: both
+
+# Spanish punctuation
+noback punctuation ¿ 26
+noback punctuation ¡ 235
+prepunc ¿ 26
+prepunc ¡ 235
+
+# Accented letters that should be mapped differently for Spanish text
+letter é 2346
+letter í 34
+letter ó 346
+letter ú 23456
+letter ñ 12456
+
+base uppercase É é
+base uppercase Í í
+base uppercase Ó ó
+base uppercase Ú ú
+base uppercase Ñ ñ
+
+# Accented letters that are mapped the same as in Norwegian text, but should be prioritized in back-translation
+letter á 12356
+letter ü 1256
+
+# other characters punctuation as in Norwegian uncontracted braille
+include no-no-g0.utb

--- a/tables/es-no.utb
+++ b/tables/es-no.utb
@@ -1,0 +1,79 @@
+#
+#  Copyright (C) 2026 Bert Frees
+#  Copyright (C) 2026 Statped, Department Teaching Materials Visual Impairment <https://www.statped.no>
+#
+#  This file is part of liblouis.
+#
+#  liblouis is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as
+#  published by the Free Software Foundation, either version 2.1 of the
+#  License, or (at your option) any later version.
+#
+#  liblouis is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with liblouis. If not, see
+#  <http://www.gnu.org/licenses/>.
+#
+# -------------------------------------------------------------------------------
+
+#-copyright: 2026, Bert Frees
+#-copyright: 2026, Statped, Department Teaching Materials Visual Impairment <https://www.statped.no>
+#-license: lgpl-2.1
+#-author: Bert Frees
+
+# This is a table for Spanish text, based on the Norwegian braille
+# standard. The rules are specified in «Håndbok i litterær
+# punktskrift» in «Appendiks: 7 Spansk» (see
+# https://liblouis.io/braille-specs/norwegian). The accented letters
+# are listed in the beginning under «Bokstaver med diakritiske tegn»
+# (Letters with diacritical marks). The inverted question mark and
+# inverted exclamation mark are the first characters listed under
+# «Tegn» (characters).
+#
+# All other punctuation is handled according to the generic rules of
+# Norwegian braille, and so are braille indicators.
+#
+# Statped is probably the only organisation in Norway that produces
+# Spanish this way. This is because of the age group they supply
+# for. For higher education and for fiction, it makes more sense to
+# use the Spanish braille code.
+
+#-display-name: Norwegian braille for Spanish text
+#-index-name: Spanish, Norway
+
+#+locale: es
+#+region: no
+#+type: literary
+#+dots: 6
+#+contraction: no
+#+direction: both
+
+# Spanish punctuation
+noback punctuation ¿ 26
+noback punctuation ¡ 235
+prepunc ¿ 26
+prepunc ¡ 235
+
+# Accented letters that should be mapped differently for Spanish text
+letter é 2346
+letter í 34
+letter ó 346
+letter ú 23456
+letter ñ 12456
+
+base uppercase É é
+base uppercase Í í
+base uppercase Ó ó
+base uppercase Ú ú
+base uppercase Ñ ñ
+
+# Accented letters that are mapped the same as in Norwegian text, but should be prioritized in back-translation
+letter á 12356
+letter ü 1256
+
+# other characters punctuation as in Norwegian uncontracted braille
+include no-no-g0.utb

--- a/tests/braille-specs/no.yaml
+++ b/tests/braille-specs/no.yaml
@@ -1,8 +1,9 @@
 # Tests for Norwegian braille
 #
 # Copyright © 2009-2010, 2012-2013, 2017, 2019, 2021-2022, 2025-2026 Lars Bjørndal <lars@lamasti.net>
-# Copyright © 2015,2021 NLB Norwegian library of talking books and braille, http://www.nlb.no/
-# Copyright © 2020 by Bert Frees
+# Copyright © 2015,2021 NLB Norwegian library of talking books and braille <http://www.nlb.no>
+# Copyright © 2020,2026 Bert Frees
+# Copyright © 2026 Statped, Department Teaching Materials Visual Impairment <https://www.statped.no>
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -1452,6 +1453,20 @@ tests:
         underline: '    +++++++++++++++       '
         bold:      '    +++++++++++++++       '
       xfail: indicators in wrong order
+
+# Spanish text
+table:
+  language: es
+  region: no
+  grade: 0
+  dots: 6
+flags: {testmode: bothDirections}
+tests:
+  - ["¡Claro que sí!", "⠖⠠⠉⠇⠁⠗⠕ ⠟⠥⠑ ⠎⠌⠖"]
+  - ["¿Quién habla español?", "⠢⠠⠟⠥⠊⠮⠝ ⠓⠁⠃⠇⠁ ⠑⠎⠏⠁⠻⠕⠇⠢"]
+  - ["¿Cómo estás hoy?", "⠢⠠⠉⠬⠍⠕ ⠑⠎⠞⠷⠎ ⠓⠕⠽⠢"]
+  - ["Ronaldo juega al fútbol.", "⠠⠗⠕⠝⠁⠇⠙⠕ ⠚⠥⠑⠛⠁ ⠁⠇ ⠋⠾⠞⠃⠕⠇⠄"]
+  - ["Ella dibuja una cigüeña.", "⠠⠑⠇⠇⠁ ⠙⠊⠃⠥⠚⠁ ⠥⠝⠁ ⠉⠊⠛⠳⠑⠻⠁⠄"]
 
 # Spaces
 display: |


### PR DESCRIPTION
This is a variant of the Norwegian uncontracted braille table, with different mappings of some accented letters.

To do:

- [x] Table metadata and documentation is complete and up to date
- [x] The table has links to the official specification of the implemented braille code, if available
