### PR TITLE
Fix three table-triggered OOB writes in translation/back-translation

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -565,10 +565,14 @@ findEmphasisClass(const TranslationTableHeader *table, const TranslationTableRul
 static int
 handleMultind(const TranslationTableHeader *table, int *currentDotslen,
 		TranslationTableOpcode *currentOpcode, const TranslationTableRule **currentRule,
-		int *doingMultind, const TranslationTableRule *multindRule) {
+		int *doingMultind, const TranslationTableRule *multindRule, int remainingLen) {
 	/* Handle multille braille indicators */
 	int found = 0;
 	if (!*doingMultind) return 0;
+	if (*doingMultind > multindRule->charslen) {
+		*doingMultind = 0;
+		return 0;
+	}
 	switch (multindRule->charsdots[multindRule->charslen - *doingMultind]) {
 	case CTO_CapsLetter:  // FIXME: make sure this works
 		found = findBrailleIndicatorRule(table->emphRules[MAX_EMPH_CLASSES][letterOffset],
@@ -619,6 +623,10 @@ handleMultind(const TranslationTableHeader *table, int *currentDotslen,
 	default:
 		found = 0;
 		break;
+	}
+	if (found && *currentDotslen > remainingLen) {
+		*doingMultind = 0;
+		return 0;
 	}
 	(*doingMultind)--;
 	return found;
@@ -688,14 +696,15 @@ back_selectRule(const TranslationTableHeader *table, int pos, int mode,
 		const widechar **passInstructions, int *passIC, PassRuleMatch *patternMatch,
 		int hasTypebuf) {
 	/* check for valid back-translations */
-	int length = input->length - pos;
+	int remainingLen = input->length - pos;
+	int length = remainingLen;
 	TranslationTableOffset ruleOffset = 0;
 	static TranslationTableRule pseudoRule = { 0 };
 	unsigned long int makeHash = 0;
 	const TranslationTableCharacter *dots = getDots(input->chars[pos], table);
 	int tryThis;
 	if (handleMultind(table, currentDotslen, currentOpcode, currentRule, doingMultind,
-				*multindRule))
+				*multindRule, remainingLen))
 		return;
 	for (tryThis = 0; tryThis < 3; tryThis++) {
 		switch (tryThis) {
@@ -801,7 +810,7 @@ back_selectRule(const TranslationTableHeader *table, int pos, int mode,
 						*doingMultind = *currentDotslen;
 						*multindRule = *currentRule;
 						if (handleMultind(table, currentDotslen, currentOpcode,
-									currentRule, doingMultind, *multindRule))
+									currentRule, doingMultind, *multindRule, remainingLen))
 							return;
 						break;
 					case CTO_LargeSign:

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -810,7 +810,8 @@ back_selectRule(const TranslationTableHeader *table, int pos, int mode,
 						*doingMultind = *currentDotslen;
 						*multindRule = *currentRule;
 						if (handleMultind(table, currentDotslen, currentOpcode,
-									currentRule, doingMultind, *multindRule, remainingLen))
+									currentRule, doingMultind, *multindRule,
+									remainingLen))
 							return;
 						break;
 					case CTO_LargeSign:

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3814,7 +3814,7 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 
 		switch (transOpcode) {
 		case CTO_EndNum:
-			if (table->letterSign && checkCharAttr(input->chars[pos], CTC_Letter, table))
+			if (table->letterSign && output->length > 0 && checkCharAttr(input->chars[pos], CTC_Letter, table))
 				output->length--;
 			break;
 		case CTO_Repeated:

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -544,6 +544,7 @@ replaceGrouping(const TranslationTableHeader *table, const InString **input,
 			replaceStart = replaceRule->charsdots[2];
 			replaceEnd = replaceRule->charsdots[3];
 		}
+		if ((output->length + 1) > output->maxlength) return 0;
 		output->chars[output->length] = replaceEnd;
 		for (p = output->length - 1; p >= 0; p--) {
 			if (output->chars[p] == endCharDots) level--;
@@ -978,6 +979,7 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 			ruleOffset =
 					(passInstructions[passIC + 1] << 16) | passInstructions[passIC + 2];
 			rule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
+			if ((output->length + 1) > output->maxlength) return 0;
 			posMapping[output->length] = match.startMatch;
 			output->chars[output->length++] = rule->charsdots[2 * passCharDots];
 			passIC += 3;
@@ -986,6 +988,7 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 			ruleOffset =
 					(passInstructions[passIC + 1] << 16) | passInstructions[passIC + 2];
 			rule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
+			if ((output->length + 1) > output->maxlength) return 0;
 			posMapping[output->length] = match.startMatch;
 			output->chars[output->length++] = rule->charsdots[2 * passCharDots + 1];
 			passIC += 3;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3817,7 +3817,8 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 
 		switch (transOpcode) {
 		case CTO_EndNum:
-			if (table->letterSign && output->length > 0 && checkCharAttr(input->chars[pos], CTC_Letter, table))
+			if (table->letterSign && output->length > 0 &&
+					checkCharAttr(input->chars[pos], CTC_Letter, table))
 				output->length--;
 			break;
 		case CTO_Repeated:


### PR DESCRIPTION
## Description

This pull request fixes three table-triggered memory corruption bugs in liblouis translation/back-translation.

Observed behavior (before):
- A crafted translation table can cause `output->length` to underflow in the `endnum` handler, leading to a write before the start of `posMapping`.
- A crafted table using `multind` + an oversized `numsign` indicator can make back-translation write past the end of `posMapping`.
- Grouping/pass actions (`pass_group*` / `replaceGrouping`) could append beyond `output->maxlength`, later causing an out-of-bounds write into the caller-provided output buffer.

Expected behavior:
- Translation/back-translation should not write out of bounds but fail safely or stop applying the invalid indicator/action.

What changed:
- Guard the `CTO_EndNum` decrement so `output->length` cannot underflow.
- Add bounds checks before appending grouping markers and grouping replacements to the output buffer.
- In back-translation multind handling, validate the multind state and ensure the selected indicator length does not exceed the remaining input.

---

**If this pull request contains changes that are not covered by tests, explain why**: These changes add bounds checks. Changes were validated by building and running `make check` locally.