### PR TITLE
Fix heap-buffer-overflow in back_passDoAction

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1766,7 +1766,7 @@ back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
 			int count = destStartReplace - destStartMatch;
 			if (count > 0) {
 				memmove(&output->chars[destStartMatch], &output->chars[destStartReplace],
-						count * sizeof(*output->chars));
+						(output->length - destStartReplace) * sizeof(*output->chars));
 				output->length -= count;
 				destStartReplace = destStartMatch;
 			}

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1767,7 +1767,7 @@ back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
 			int count = destStartReplace - destStartMatch;
 			if (count > 0) {
 				memmove(&output->chars[destStartMatch], &output->chars[destStartReplace],
-						count * sizeof(*output->chars));
+						(output->length - destStartReplace) * sizeof(*output->chars));
 				output->length -= count;
 				destStartReplace = destStartMatch;
 			}

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1013,9 +1013,8 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 		case pass_copy: {
 			int count = destStartReplace - destStartMatch;
 			if (count > 0) {
-				if (destStartReplace + count > output->maxlength) return 0;
 				memmove(&output->chars[destStartMatch], &output->chars[destStartReplace],
-						count * sizeof(*output->chars));
+						(output->length - destStartReplace) * sizeof(*output->chars));
 				output->length -= count;
 				destStartReplace = destStartMatch;
 			}


### PR DESCRIPTION
OSSFuzz initially reported [liblouis:fuzz_backtranslate: Heap-buffer-overflow in back_passDoAction
](https://issues.oss-fuzz.com/issues/471456889#comment1) late last year. The disclosure deadline for that particular report has passed and as such I figured I'd post [the report](https://issues.oss-fuzz.com/issues/471456889#comment1) again as well as a patch (this PR).

AI DISCLAIMER: We ran CodeMender against the report in an agent+fuzzer feedback loop until we arrived at this simple patch which was then reviewed by several humans here at Google. If this patch 1) doesn't meet liblouis' coding standards or 2) is not actually correct then please let me know and I (human) will fix it :)

---

The `pass_copy` case in `back_passDoAction` contained a logic error in a `memmove` call, leading to a heap-buffer-overflow when shifting data to close a gap in the output buffer.

The code incorrectly used the size of the replaced segment (`count = destStartReplace - destStartMatch`) as the number of elements to move. However, `memmove` should shift the data *following* the replaced segment (the suffix) into the new position.

In the reproduction case, `destStartReplace` was equal to `output->length`, meaning the suffix size was zero. The original code attempted to read `count` (576) widechars from the end of the buffer, resulting in an out-of-bounds read.

This patch corrects the `memmove` size argument to use the actual number of remaining characters: `output->length - destStartReplace`.


Reviewed-by: Bill Wendling <morbo@google.com>
Reviewed-by: Meder Kydyraliev <meder@google.com>
Fixes: https://issues.oss-fuzz.com/issues/471456889