### PR TITLE
Fix heap-buffer-overflow in back_passDoAction

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -1766,7 +1766,7 @@ back_passDoAction(const TranslationTableHeader *table, int *pos, int mode,
 			int count = destStartReplace - destStartMatch;
 			if (count > 0) {
 				memmove(&output->chars[destStartMatch], &output->chars[destStartReplace],
-						count * sizeof(*output->chars));
+						(output->length - destStartReplace) * sizeof(*output->chars));
 				output->length -= count;
 				destStartReplace = destStartMatch;
 			}


### PR DESCRIPTION
In `lou_backTranslateString.c`, the `pass_copy` case of `back_passDoAction` contained a logic error in a `memmove` call used to shift data and close a gap after a replacement.

The code incorrectly used `count` (the length of the segment being removed) as the number of elements to move. The correct behavior for shifting the trailing data (the suffix) to the new offset is to move the number of elements remaining in the buffer *after* the replaced segment.

In cases where the replacement occurred at the end of the buffer (`destStartReplace == output->length`), the suffix size is zero. The previous code would instead attempt to read `count` elements from beyond the buffer boundary, leading to a heap-buffer-overflow.

This patch updates the `memmove` call to use the correct suffix length: `(output->length - destStartReplace)`.

Fixes: https://issues.oss-fuzz.com/issues/471456889
Co-authored-by: CodeMender <codemender-patching@google.com>
Signed-off-by: Bill Wendling <morbo@google.com>
