### PR TITLE
fix segv in lou_compileString

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -2882,8 +2882,9 @@ doOpcode:
 			(eqasc2uni((unsigned char *)"ISO", token.chars, 3) ||
 					eqasc2uni((unsigned char *)"UTF-8", token.chars, 5))) {
 		if (file->in == NULL)
-			/* When compileRule is invokded by compileString, it leaves file->in a NULL pointer.
-		     * Add a check to avoid dereferencing the NULL pointer in compileHyphenation*/
+			/* When compileRule is invokded by compileString, it leaves file->in a NULL
+			 * pointer. Add a check to avoid dereferencing the NULL pointer in
+			 * compileHyphenation*/
 			return 0;
 		if (table)
 			compileHyphenation(file, &token, table);

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -2881,6 +2881,10 @@ doOpcode:
 	if (file->lineNumber == 1 &&
 			(eqasc2uni((unsigned char *)"ISO", token.chars, 3) ||
 					eqasc2uni((unsigned char *)"UTF-8", token.chars, 5))) {
+		if (file->in == NULL)
+			/* When compileRule is invokded by compileString, it leaves file->in a NULL pointer.
+		     * Add a check to avoid dereferencing the NULL pointer in compileHyphenation*/
+			return 0;
 		if (table)
 			compileHyphenation(file, &token, table);
 		else


### PR DESCRIPTION
`compileString` initializes a `FileInfo` via `memset`, leaving `file->in = NULL` (string mode has no file descriptor). When `compileRule` detects a `"UTF-8"` or `"ISO"` token on line 1, it unconditionally calls compileHyphenation, which eventually calls `fgetc(file->in)` — crashing with SIGSEGV on the null `FILE*`.

This fix adds a `file->in == NULL` guard before entering the hyphenation dispatch path. In string mode, the function now returns `0` (compile error) instead of dereferencing a null pointer.

I tested this fix, with this patch, the SEGV bug disappeared.

Fix: https://github.com/liblouis/liblouis/issues/1976