### PR TITLE
fix segv in _lou_compileTranslationRule

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5464,6 +5464,7 @@ int EXPORT_CALL
 _lou_compileTranslationRule(const char *tableList, const char *inString) {
 	TranslationTableHeader *table;
 	getTable(tableList, NULL, &table, NULL);
+	if (!table) return 0;
 	return compileString(inString, &table, NULL);
 }
 
@@ -5471,6 +5472,7 @@ int EXPORT_CALL
 _lou_compileDisplayRule(const char *tableList, const char *inString) {
 	DisplayTableHeader *table;
 	getTable(NULL, tableList, NULL, &table);
+	if (!table) return 0;
 	return compileString(inString, NULL, &table);
 }
 


### PR DESCRIPTION


`_lou_compileTranslationRule` and `_lou_compileDisplayRule` do not check whether `getTable()` returns a NULL table before calling `compileString()`, causing a NULL pointer dereference (SEGV at offset 0x4) when table loading fails. This patch adds `if (!table) return 0` after each `getTable()` call, consistent with the existing guard in `lou_compileString()`.

I tested this patch. With it, the bug in https://github.com/liblouis/liblouis/issues/1978 disappeared.