### PR TITLE
fix buffer overflow in _lou_logWidecharBuf

### DIFF
--- a/liblouis/logging.c
+++ b/liblouis/logging.c
@@ -37,6 +37,7 @@
 
 void EXPORT_CALL
 _lou_logWidecharBuf(logLevels level, const char *msg, const widechar *wbuf, int wlen) {
+	if (wlen <= 0) return;
 	/* When calculating output size:
 	 * Each wdiechar is represented in hex, thus needing two bytes for each
 	 * byte in the widechar (sizeof(widechar) * 2)

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1186,6 +1186,7 @@ _lou_translate(const char *tableList, const char *displayTableList,
 	if (tableList == NULL || inbufx == NULL || inlen == NULL || outbuf == NULL ||
 			outlen == NULL)
 		return 0;
+	if (*inlen < 0 || *outlen < 0) return 0;
 	_lou_logMessage(LOU_LOG_ALL, "Performing translation: tableList=%s, inlen=%d",
 			tableList, *inlen);
 	_lou_logWidecharBuf(LOU_LOG_ALL, "Inbuf=", inbufx, *inlen);
@@ -1195,7 +1196,7 @@ _lou_translate(const char *tableList, const char *displayTableList,
 
 	if (displayTableList == NULL) displayTableList = tableList;
 	_lou_getTable(tableList, displayTableList, &table, &displayTable);
-	if (table == NULL || *inlen < 0 || *outlen < 0) return 0;
+	if (table == NULL) return 0;
 	k = 0;
 	while (k < *inlen && inbufx[k]) k++;
 	input = (InString){ .chars = inbufx, .length = k, .bufferIndex = -1 };


### PR DESCRIPTION

`_lou_translate` calls `_lou_logWidecharBuf` before validating `*inlen`, so a negative value causes `malloc(0)` followed by a 6-byte write into a 1-byte heap region (heap-buffer-overflow).

This patch moves the `*inlen < 0` guard to before the logging calls in `lou_translateString.c`, and add a `wlen <= 0` early-return in `_lou_logWidecharBuf` as defense-in-depth.

I tested this patch. With this fix, the bug in https://github.com/liblouis/liblouis/issues/1980 disappeared.