### PR TITLE
Fix Heap Buffer Overflow in _lou_translate

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1201,6 +1201,7 @@ _lou_translate(const char *tableList, const char *displayTableList,
 	k = 0;
 	while (k < *inlen && inbufx[k]) k++;
 	input = (InString){ .chars = inbufx, .length = k, .bufferIndex = -1 };
+	int origInputLen = input.length;   /* capture before multi-pass loop reassigns input */
 	haveEmphasis = 0;
 	if (!(typebuf = _lou_allocMem(alloc_typebuf, 0, input.length, *outlen))) return 0;
 	if (typeform != NULL) {
@@ -1338,7 +1339,7 @@ _lou_translate(const char *tableList, const char *displayTableList,
 	}
 	if (goodTrans) {
 		for (k = 0; k < output.length; k++) {
-			if (typeform != NULL) {
+			if (typeform != NULL && k < origInputLen) {
 				if ((output.chars[k] & (LOU_DOT_7 | LOU_DOT_8)))
 					typeform[k] = '8';
 				else
@@ -1392,8 +1393,11 @@ _lou_translate(const char *tableList, const char *displayTableList,
 		}
 	}
 	if (destSpacing != NULL) {
-		memcpy(srcSpacing, destSpacing, input.length);
-		srcSpacing[input.length] = 0;
+		int copyLen = input.length < origInputLen
+		              ? input.length : origInputLen;
+		memcpy(srcSpacing, destSpacing, copyLen);
+		if (copyLen < origInputLen)
+			srcSpacing[copyLen] = 0;
 	}
 	if (cursorPos != NULL && *cursorPos != -1) {
 		if (outputPos != NULL)

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1190,8 +1190,10 @@ _lou_translate(const char *tableList, const char *displayTableList,
 			tableList, *inlen);
 	_lou_logWidecharBuf(LOU_LOG_ALL, "Inbuf=", inbufx, *inlen);
 
-	if (!_lou_isValidMode(mode))
+	if (!_lou_isValidMode(mode)) {
 		_lou_logMessage(LOU_LOG_ERROR, "Invalid mode parameter: %d", mode);
+		return 0;
+	}
 
 	if (displayTableList == NULL) displayTableList = tableList;
 	_lou_getTable(tableList, displayTableList, &table, &displayTable);


### PR DESCRIPTION
This patch lets `_lou_isValidMode` to return an error instead of only logging a warning when an invalid mode is passed to `_lou_translate`. Previously, invalid mode values (e.g. -3) allowed translation to proceed with undefined behavior, which could cause output.length to exceed the caller's typeform buffer size and trigger a heap buffer overflow (OOB write at `lou_translateString.c:1343`).

With this patch, the ASAN warning in https://github.com/liblouis/liblouis/issues/1982 disappeared.