### PR TITLE
fix missing length validation in _lou_backTranslate

### DIFF
--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -215,6 +215,7 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 	if (displayTableList == NULL) displayTableList = tableList;
 	_lou_getTable(tableList, displayTableList, &table, &displayTable);
 	if (table == NULL) return 0;
+	if (*inlen < 0 || *outlen < 0) return 0;
 
 	if (!_lou_isValidMode(mode))
 		_lou_logMessage(LOU_LOG_ERROR, "Invalid mode parameter: %d", mode);


### PR DESCRIPTION
`_lou_backTranslate` did not validate that `*inlen` and `*outlen` are non-negative before use, unlike the symmetric `_lou_translate` which already guards against this (`lou_translateString.c:1198`). A negative `*outlen` passed unchecked to `memset(typebuf, 0, *outlen * sizeof(formtype))` (line 257) causes an AddressSanitizer negative-size-param abort and potential memory corruption in getStringBuffer().

This patch adds the missing guard to `_lou_backTranslate`, making it consistent with `_lou_translate`

Fix: https://github.com/liblouis/liblouis/issues/1984

With this patch, the ASAN warning disappeared.