### PR TITLE
Fix emphasis end marker placement for non-emphasizable characters

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2772,8 +2772,17 @@ resolveEmphasisWords(EmphasisInfo *buffer, const EmphasisClass *class,
 						 * word, also mark the end point */
 						buffer[word_start].word |= class->value;
 						if (wordBuffer[i] & WORD_CHAR) {
-							buffer[i].end |= class->value;
-							buffer[i].word |= class->value;
+							/* If non-emphasizable characters (e.g. chr47, chr45) precede
+							 * position i within the same word, place the end indicator
+							 * before them so that emphasis terminators appear in the
+							 * output before those characters rather than after them. */
+							int end_pos = i;
+							while (end_pos > word_start &&
+									!isEmphasizable(
+											input->chars[end_pos - 1], table, class))
+								end_pos--;
+							buffer[end_pos].end |= class->value;
+							buffer[end_pos].word |= class->value;
 						}
 					}
 				}
@@ -2876,7 +2885,12 @@ resolveEmphasisWords(EmphasisInfo *buffer, const EmphasisClass *class,
 				wordBuffer[i] |= WORD_WHOLE;
 		} else if (buffer[i].word & class->value) {
 			if (buffer[i].end & class->value) {
-				if (word_start >= 0 && wordBuffer[i] & WORD_CHAR)
+				/* Only remove WORD_WHOLE if the emphasis ends at an emphasizable
+				 * character (e.g. a lowercase letter directly after uppercase).
+				 * If the end is at a non-emphasizable character (e.g. '/', '-'),
+				 * the capitalized portion before it is still a whole word. */
+				if (word_start >= 0 && wordBuffer[i] & WORD_CHAR &&
+						isEmphasizable(input->chars[i], table, class))
 					wordBuffer[word_start] &= ~WORD_WHOLE;
 				word_start = -1;
 			} else {

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -1251,10 +1251,10 @@ tests:
 - - VIIb
   - ',,vii,''b'
 
-#- - INITIALS OF WRITER/initials of secretary
-#  - ,,,9itials ( writ},'_/9itials ( secret>y
-#  - typeform:
-#      passage_break: '                  +'
+- - INITIALS OF WRITER/initials of secretary
+  - ,,,9itials ( writ},'_/9itials ( secret>y
+  - typeform:
+      passage_break: '                  +'
 
 - - The two CEOs met in our CEO's office.
   - ',! two ,,ceo,''s met 9 |r ,,ceo''s (fice4'


### PR DESCRIPTION

Found in Brailleblaster and reported to dev's Incorrect translation of: 

`INITIALS OF WRITER/initials of secretary`

The first part should be a passage but was treated as capital words.

This commit fixes caps/emphasis terminator placement when a capitalized word ends immediately before a non-emphasizable character (e.g. `/`, `-`) in `resolveEmphasisWords`

(`liblouis/lou_translateString.c`).

Two related bugs existed in `resolveEmphasisWords`:

1. **End marker placed at the wrong position** — when emphasis (caps) ended at a non-emphasizable character like `/`, the end marker was placed *after* the character instead of *before* it.

2. **`WORD_WHOLE` flag incorrectly removed** — when an emphasis end occurred at a non-emphasizable character mid-word, the `WORD_WHOLE` flag was removed from the last caps word, preventing the passage detector from counting it correctly.

Changes

liblouis/lou_translateString.c

Fix 1:

around the `WORD_WHOLE` removal logic:
Added an `isEmphasizable()`
check before removing `WORD_WHOLE`. If caps ends at a non-emphasizable character (e.g. `/`), `WORD_WHOLE` is now preserved so the passage detector counts the word correctly.

Fix 2

end/word marker placement:
Before setting the `end`/`word` marker,
walk backwards through any trailing non-emphasizable characters to find the correct insertion position, ensuring the caps terminator appears in the output before those characters rather than after them.

tests/braille-specs/en-ueb.yaml

Uncommented the previously disabled regression test case at Line 1254

INITIALS OF WRITER/initials of secretary in en-ueb.yaml → ,,,9itials ( writ},'_/9itials ( secret>y

This test verifies that caps passage indicators are placed correctly around words separated by `/`.

Testing:

The regression test in `en-ueb.yaml` (line 1254) now passes. It had been commented out because the bug caused an incorrect translation output; with these fixes the expected braille output is produced correctly.
