### PR TITLE
Fix some back-translation issues in Portuguese grade 1

### DIFF
--- a/tables/pt-pt-g1.utb
+++ b/tables/pt-pt-g1.utb
@@ -219,11 +219,10 @@ endnum \x00BA 135
 numsign 3456
 midnum , 2
 midnum . 3
-midnum + 235-3456
-midnum - 36-3456
-midnum / 6-2-3456
-midnum : 25-3456
-
+nofor context _$D[@235]@3456$D "+"
+nofor context _$D[@36]@3456$D  "-"
+nofor context _$D[@6-2]@3456$D "/"
+nofor context _$D[@25]@3456$D  ":"
 endnum # 56-3456
 
 repeated ... 3-3-3		points de suite

--- a/tests/braille-specs/pt.yaml
+++ b/tests/braille-specs/pt.yaml
@@ -189,18 +189,12 @@ tests:
     xfail: {backward: "back-translates as letters after , (no letsign defined)"}]
   - ["123.456", "⠼⠁⠃⠉⠄⠙⠑⠋",
     xfail: {backward: "back-translates as letters after . (no letsign defined)"}]
-  - ["1+2", "⠼⠁⠖⠼⠃",
-    xfail: {backward: "Letters after +"}]
-  - ["4+47", "⠼⠙⠖⠼⠙⠛",
-    xfail: {backward: "back-translates to '4+dg' (see https://github.com/liblouis/liblouis/issues/1818)"}]
-  - ["4+4", "⠼⠙⠖⠼⠙",
-    xfail: {backward: "back-translates to '4+d' (see https://github.com/liblouis/liblouis/issues/1818)"}]
-  - ["1-2", "⠼⠁⠤⠼⠃",
-    xfail: {backward: "Letters after -"}]
-  - ["1/2", "⠼⠁⠠⠂⠼⠃",
-    xfail: {backward: "Letters after /"}]
-  - ["12:34", "⠼⠁⠃⠒⠼⠉⠙",
-    xfail: {backward: "Letters after :"}]
+  - ["1+2", "⠼⠁⠖⠼⠃"]
+  - ["4+47", "⠼⠙⠖⠼⠙⠛"]
+  - ["4+4", "⠼⠙⠖⠼⠙"]
+  - ["1-2", "⠼⠁⠤⠼⠃"]
+  - ["1/2", "⠼⠁⠠⠂⠼⠃"]
+  - ["12:34", "⠼⠁⠃⠒⠼⠉⠙"]
   - ["123#", "⠼⠁⠃⠉⠰⠼"]
   - [" -- ", "⠤⠤"]
   - ["√81", "⠫⠱⠼⠓⠁"]


### PR DESCRIPTION
@tiago-casal This change to the Portuguese grade 1 table fixes some back-translation issues. See https://github.com/liblouis/liblouis/issues/1818 / https://bugs.debian.org/1109681. It is not quite the same as what you suggested. I'm hoping my fix is better. Would it be possible for you to run some tests on it?