### PR TITLE
Also generate single-page HTML documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ TAGS
 /doc/version.texi
 /doc/stamp-vti
 /doc/liblouis.html
+/doc/liblouis-single.html
 /doc/liblouis.info
 /doc/liblouis.txt
 /doc/liblouis.pdf

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -5,3 +5,11 @@ SUFFIXES                = .txt
 
 .texi.txt:
 	$(MAKEINFO) --plaintext $< -o $@
+
+# Generate single-page HTML in addition to the default multi-page
+html-local: liblouis-single.html
+
+liblouis-single.html: liblouis.texi
+	$(MAKEINFO) --html --no-headers --no-split -I $(srcdir) -o $@ $<
+
+CLEANFILES = liblouis-single.html


### PR DESCRIPTION
## Summary

Adds an `html-local` rule to `doc/Makefile.am` so that `make html` produces both the multi-page directory (`doc/liblouis.html/`) and a single-page file (`doc/liblouis-single.html`).

The website links to both formats from `documentation/index.md`, but the single-page version stopped being updated when the `AM_MAKEINFOHTMLFLAGS = --no-headers --no-split` flag was removed in 008a0116 (June 5). The release helper can then be updated to copy both to the website.

Closes #2016

🤖 Generated with [Claude Code](https://claude.ai/code)