### PR TITLE
Use native Windows directory API under MinGW too

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
 #include <windows.h>
 #else
 #include <dirent.h>
@@ -972,7 +972,7 @@ _lou_freeTableIndex(void) {
  *
  * Must be freed by the caller, using list_free.
  */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(_WIN32)
 static List *
 listDir(List *list, char *dirName) {
 	static char glob[MAXSTRING];


### PR DESCRIPTION
On MinGW the build fails because `metadata.c` only uses the native
Windows directory code (`windows.h` / `FindFirstFile`) when `_MSC_VER`
is set. MinGW defines `_WIN32` but not `_MSC_VER`, so it falls back to
`<dirent.h>`, which clashes with gnulib's `dirent.h`.

Changed the two guards to `#if defined(_MSC_VER) || defined(_WIN32)`
so MinGW uses the native API too. MSVC is unaffected. Built and tested
locally with MinGW-w64 (UCRT64).
