### PR TITLE
Fix building with clang/MSVC on Windows (fixes #1889)

### DIFF
--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -36,6 +36,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include "liblouis.h"
 
@@ -51,6 +52,7 @@ extern "C" {
 
 #ifdef _MSC_VER
 #define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #endif
 
 #define NUMVAR 50

--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -27,7 +27,9 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
+#ifndef _MSC_VER
+#include <strings.h> /* for strcasecmp/strncasecmp; on MSVC these are shimmed in internal.h */
+#endif
 #if defined(_MSC_VER) || defined(_WIN32)
 #include <windows.h>
 #else


### PR DESCRIPTION
## Summary

Makes the Windows `nmake`/clang-cl build compile again. Fixes #1889.

The Windows `nmake` build uses a minimal hand-written `windows/include/config.h` instead of the gnulib-generated one, so it doesn't get the portability replacements the autotools build relies on. Once the C sources started using C99 `bool` and the POSIX `<strings.h>` header, `clang-cl` stopped being able to build it. There are two independent blockers:

1. **`bool` / `true` / `false` — unknown type (the error reported in #1889).**
   `compileTranslationTable.c` uses `bool` but no header pulls in `<stdbool.h>`. Fixed by including `<stdbool.h>` from the shared `internal.h`, so every translation unit gets it.

2. **`<strings.h>` not found / `strncasecmp` undefined on MSVC.**
   `metadata.c` includes POSIX `<strings.h>` and calls `strncasecmp`, neither of which exist under MSVC/clang-cl. `internal.h` already shims `strcasecmp` → `_stricmp` for `_MSC_VER`; this adds the matching `strncasecmp` → `_strnicmp` shim and guards the `<strings.h>` include out for `_MSC_VER` (MinGW keeps it), mirroring the existing `_MSC_VER` handling already in that file.

With both applied, `nmake /f Makefile.nmake` completes with clang-cl and produces a working `liblouis.dll` (verified with a UCS-4/x64 build: translate / back-translate / chars↔dots all round-trip correctly).

## Changes

- `liblouis/internal.h`: include `<stdbool.h>`; add `strncasecmp` → `_strnicmp` shim under `_MSC_VER`.
- `liblouis/metadata.c`: guard the POSIX `<strings.h>` include for non-MSVC.

Both changes are no-ops on the autotools (Linux/macOS) and MinGW builds.
