### PR TITLE
Hebrew: only produce dots 346 for a genuine shuruq

### DIFF
--- a/tables/hbo-common-rules.uti
+++ b/tables/hbo-common-rules.uti
@@ -82,8 +82,14 @@ noback pass3 [@2456-135a]~ @246
 noback pass3 [@135a-2456]%hebLetter @246
 
 ## Shuruq and consonantal waw
+## A dagesh+waw that is followed by a vowel is a consonantal waw with
+## dagesh, not a shuruq. We distinguish the two up front, on the Hebrew
+## "ּו" sequence itself, so that the bare dot pattern 346 is only ever
+## produced for a genuine shuruq. This avoids a later pass rule matching
+## the naked 346 cell, which would also match identical cells produced by
+## other languages when this table is combined with them.
+noback context ["ּו"]$x @5a-2456
 noback context "ּו" @346
-noback pass2 [@346]$xy @5a-2456
 
 ## Hiriq Yod
 noback pass3 @24a-245 @35 Hiriq-yod

--- a/tests/braille-specs/hbo.yaml
+++ b/tests/braille-specs/hbo.yaml
@@ -44,6 +44,9 @@ tests:
   - ['וַיֹּ֣אמְרוּ לָ֔הּ', '⠺⠉⠐⠚⠕⠁⠍⠄⠗⠬ ⠇⠣⠘⠓⠂']
 
 ## Tests of shuruq and dagesh waw
+# Consonantal waw with dagesh forte followed by a vowel: חַוָּה (Eve),
+# Genesis 3:20. The waw is a doubled consonant, not a shuruq (⠬).
+  - ['חַוָּ֑ה', '⠭⠉⠐⠺⠣⠓⠆']
   - ['צִוָּ֥ה', '⠮⠊⠐⠺⠣⠓']
   - ['צִוִּיתִ֔ים', '⠮⠊⠐⠺⠔⠹⠔⠍⠂']
   - ['מִֽי־יָשׂ֣וּם אִלֵּ֔ם א֣וֹ חֵרֵ֔שׁ א֥וֹ פִקֵּ֖חַ א֣וֹ עִוֵּ֑ר', '⠍⠔⠤⠚⠣⠱⠬⠍ ⠁⠊⠐⠇⠌⠍⠂ ⠁⠪ ⠭⠌⠗⠌⠩⠂ ⠁⠪ ⠋⠊⠐⠟⠌⠭⠉ ⠁⠪ ⠫⠊⠐⠺⠌⠗⠆']
@@ -253,6 +256,7 @@ tests:
   - ['וַיֹּ֣אמְרוּ לָ֔הּ', '⠺⠉⠐⠚⠕⠨⠥⠁⠍⠄⠗⠬ ⠇⠣⠂⠘⠓']
 
 ## Tests of shuruq and dagesh waw
+  - ['חַוָּ֑ה', '⠭⠉⠐⠺⠣⠆⠓']
   - ['צִוָּ֥ה', '⠮⠊⠐⠺⠣⠨⠍⠓']
   - ['צִוִּיתִ֔ים', '⠮⠊⠐⠺⠔⠹⠂⠔⠍']
   - ['מִֽי־יָשׂ֣וּם אִלֵּ֔ם א֣וֹ חֵרֵ֔שׁ א֥וֹ פִקֵּ֖חַ א֣וֹ עִוֵּ֑ר', '⠍⠈⠔⠤⠚⠣⠱⠨⠥⠬⠍ ⠁⠊⠐⠇⠌⠂⠍ ⠁⠨⠥⠪ ⠭⠌⠗⠌⠂⠩ ⠁⠨⠍⠪ ⠋⠊⠐⠟⠌⠨⠞⠭⠉ ⠁⠨⠥⠪ ⠫⠊⠐⠺⠌⠆⠗']
@@ -321,6 +325,7 @@ tests:
   - ['וַיֹּ֣אמְרוּ לָ֔הּ', '⠺⠉⠚⠕⠁⠍⠗⠬ ⠇⠣⠓']
 
 ## Tests of shuruq and dagesh waw
+  - ['חַוָּ֑ה', '⠭⠉⠺⠣⠓⠆']
   - ['צִוָּ֥ה', '⠮⠊⠺⠣⠓']
   - ['צִוִּיתִ֔ים', '⠮⠊⠺⠔⠹⠔⠍']
   - ['מִֽי־יָשׂ֣וּם אִלֵּ֔ם א֣וֹ חֵרֵ֔שׁ א֥וֹ פִקֵּ֖חַ א֣וֹ עִוֵּ֑ר', '⠍⠔⠤⠚⠣⠱⠬⠍ ⠁⠊⠇⠌⠍ ⠁⠪ ⠭⠌⠗⠌⠩ ⠁⠪ ⠋⠊⠟⠌⠭⠉ ⠁⠪ ⠫⠊⠺⠌⠗⠆']
@@ -378,3 +383,15 @@ tests:
   - ["הָיְתָה", "⠓⠣⠚⠄⠹⠣⠓"]
   - ["וְהָאָרֶץ", "⠺⠄⠓⠣⠁⠣⠗⠑⠮"]
   - ["הַמָּיִם", "⠓⠉⠐⠍⠣⠚⠊⠍"]
+
+# Regression test for the shuruq / consonantal-waw rule in
+# hbo-common-rules.uti. A shuruq (⠬, dots 346) must only be produced from
+# the Hebrew "ּו" sequence. When the Hebrew rules are combined with another
+# language, a cell that merely happens to be dots 346 must not be rewritten
+# into dagesh+waw (⠐⠺) just because the next cell carries the Hebrew "vowel"
+# attribute. Here digit 0 = dots 346 and digit 2 = dots 126 (as Hebrew
+# qamats), so "02" must stay ⠬⠣ and not become ⠐⠺⠣.
+table: hbo-ihbc-rules.uti,digits6DotsPlusDot6.uti,braille-patterns.cti
+flags: { testmode: forward }
+tests:
+  - ['02', '⠬⠣']

--- a/tests/braille-specs/hbo.yaml
+++ b/tests/braille-specs/hbo.yaml
@@ -48,6 +48,9 @@ tests:
   - ['וַיֹּ֣אמְרוּ לָ֔הּ', '⠺⠉⠐⠚⠕⠁⠍⠄⠗⠬ ⠇⠣⠘⠓⠂']
 
 ## Tests of shuruq and dagesh waw
+# Consonantal waw with dagesh forte followed by a vowel: חַוָּה (Eve),
+# Genesis 3:20. The waw is a doubled consonant, not a shuruq (⠬).
+  - ['חַוָּ֑ה', '⠭⠉⠐⠺⠣⠓⠆']
   - ['צִוָּ֥ה', '⠮⠊⠐⠺⠣⠓']
   - ['צִוִּיתִ֔ים', '⠮⠊⠐⠺⠔⠹⠔⠍⠂']
   - ['מִֽי־יָשׂ֣וּם אִלֵּ֔ם א֣וֹ חֵרֵ֔שׁ א֥וֹ פִקֵּ֖חַ א֣וֹ עִוֵּ֑ר', '⠍⠔⠤⠚⠣⠱⠬⠍ ⠁⠊⠐⠇⠌⠍⠂ ⠁⠪ ⠭⠌⠗⠌⠩⠂ ⠁⠪ ⠋⠊⠐⠟⠌⠭⠉ ⠁⠪ ⠫⠊⠐⠺⠌⠗⠆']
@@ -403,6 +406,7 @@ tests:
   - ['וַיֹּ֣אמְרוּ לָ֔הּ', '⠺⠉⠐⠚⠕⠨⠥⠁⠍⠄⠗⠬ ⠇⠣⠂⠘⠓']
 
 ## Tests of shuruq and dagesh waw
+  - ['חַוָּ֑ה', '⠭⠉⠐⠺⠣⠆⠓']
   - ['צִוָּ֥ה', '⠮⠊⠐⠺⠣⠨⠍⠓']
   - ['צִוִּיתִ֔ים', '⠮⠊⠐⠺⠔⠹⠂⠔⠍']
   - ['מִֽי־יָשׂ֣וּם אִלֵּ֔ם א֣וֹ חֵרֵ֔שׁ א֥וֹ פִקֵּ֖חַ א֣וֹ עִוֵּ֑ר', '⠍⠈⠔⠤⠚⠣⠱⠨⠥⠬⠍ ⠁⠊⠐⠇⠌⠂⠍ ⠁⠨⠥⠪ ⠭⠌⠗⠌⠂⠩ ⠁⠨⠍⠪ ⠋⠊⠐⠟⠌⠨⠞⠭⠉ ⠁⠨⠥⠪ ⠫⠊⠐⠺⠌⠆⠗']
@@ -471,6 +475,7 @@ tests:
   - ['וַיֹּ֣אמְרוּ לָ֔הּ', '⠺⠉⠚⠕⠁⠍⠗⠬ ⠇⠣⠓']
 
 ## Tests of shuruq and dagesh waw
+  - ['חַוָּ֑ה', '⠭⠉⠺⠣⠓⠆']
   - ['צִוָּ֥ה', '⠮⠊⠺⠣⠓']
   - ['צִוִּיתִ֔ים', '⠮⠊⠺⠔⠹⠔⠍']
   - ['מִֽי־יָשׂ֣וּם אִלֵּ֔ם א֣וֹ חֵרֵ֔שׁ א֥וֹ פִקֵּ֖חַ א֣וֹ עִוֵּ֑ר', '⠍⠔⠤⠚⠣⠱⠬⠍ ⠁⠊⠇⠌⠍ ⠁⠪ ⠭⠌⠗⠌⠩ ⠁⠪ ⠋⠊⠟⠌⠭⠉ ⠁⠪ ⠫⠊⠺⠌⠗⠆']
@@ -528,3 +533,15 @@ tests:
   - ["הָיְתָה", "⠓⠣⠚⠄⠹⠣⠓"]
   - ["וְהָאָרֶץ", "⠺⠄⠓⠣⠁⠣⠗⠑⠮"]
   - ["הַמָּיִם", "⠓⠉⠐⠍⠣⠚⠊⠍"]
+
+# Regression test for the shuruq / consonantal-waw rule in
+# hbo-common-rules.uti. A shuruq (⠬, dots 346) must only be produced from
+# the Hebrew "ּו" sequence. When the Hebrew rules are combined with another
+# language, a cell that merely happens to be dots 346 must not be rewritten
+# into dagesh+waw (⠐⠺) just because the next cell carries the Hebrew "vowel"
+# attribute. Here digit 0 = dots 346 and digit 2 = dots 126 (as Hebrew
+# qamats), so "02" must stay ⠬⠣ and not become ⠐⠺⠣.
+table: hbo-ihbc-rules.uti,digits6DotsPlusDot6.uti,braille-patterns.cti
+flags: { testmode: forward }
+tests:
+  - ['02', '⠬⠣']


### PR DESCRIPTION
Follow-up to #1820, which swapped the shuruq / consonantal waw behaviour so that shuruq is assumed by default and rewritten to a consonantal waw with dagesh when a vowel follows. That rewrite is a multipass rule on the bare dot pattern 346 (`noback pass2 [@346]$xy @5a-2456`). Because `attribute vowel` also tags the single-cell dot counterparts of the vowels (e.g. qamats = dots 126), the rule fires on any 346 cell followed by such a cell when the Hebrew rules are combined with another language, corrupting an unrelated ⠬ into dagesh+waw (⠐⠺). For example, combining `hbo-ihbc-rules.uti` with `digits6DotsPlusDot6.uti` (digit 0 = dots 346, digit 2 = dots 126) turns `02` into ⠐⠺⠣ instead of ⠬⠣.

This pr therefore does the following:

- Move the shuruq / consonantal waw distinction up front, onto the Hebrew `ּו` sequence itself, in the context pass. A dagesh+waw followed by a vowel is emitted directly as a consonantal waw with dagesh; otherwise it is a shuruq. The bare 346 cell is now only ever produced for a genuine shuruq, so no later pass rule matches it and the leak is gone.
- Use `$x` (vowel) rather than `$xy` as the disambiguator: at the context pass, cantillation marks are still adjacent to the waw and must not trigger the consonantal reading. This is also why the distinction can't simply stay in pass2 with a virtual dot on 346 — an unregistered dot pattern like `346a` defaults to the space attribute and breaks the Etnahta/Zaqef Qatan reordering.
- Add חַוָּה (Eve, Genesis 3:20) as a verse-anchored test of a consonantal waw with dagesh forte in all three systems.
- Add a cross-language regression test (`02` → ⠬⠣) combining the Hebrew rules with `digits6DotsPlusDot6.uti`.

Would appreciate another look from @EricJHarvey, since this touches the shuruq handling flagged in #1820.