### PR TITLE
Optimize TranslationTableRule memory usage

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -836,13 +836,15 @@ addForwardRuleWithSingleChar(const FileInfo *file, TranslationTableOffset ruleOf
 								->ruleArea[character->definitionRule];
 				char *prevOpcodeName = strdup(_lou_findOpcodeName(prevRule->opcode));
 				char *newOpcodeName = strdup(_lou_findOpcodeName((*rule)->opcode));
+#if ENABLE_RULE_DEBUG_INFO
 				_lou_logMessage(LOU_LOG_DEBUG,
-						"%s:%d: Character already defined (%s). The existing %s rule "
-						"will take precedence over the new %s rule.",
-						file->fileName, file->lineNumber,
-						printSource(file->sourceFile, prevRule->sourceFile,
-								prevRule->sourceLine),
-						prevOpcodeName, newOpcodeName);
+					"%s:%d: Character already defined (%s). The existing %s rule "
+					"will take precedence over the new %s rule.",
+					file->fileName, file->lineNumber,
+					printSource(file->sourceFile, prevRule->sourceFile,
+						prevRule->sourceLine),
+					prevOpcodeName, newOpcodeName);
+#endif
 				free(prevOpcodeName);
 				free(newOpcodeName);
 			} else {
@@ -1006,15 +1008,18 @@ addRule(const FileInfo *file, TranslationTableOpcode opcode, const CharsString *
 	/* Add a rule to the table, using the hash function to find the start of
 	 * chains and chaining both the chars and dots strings */
 	TranslationTableOffset offset;
-	int ruleSize = sizeof(TranslationTableRule) - (DEFAULTRULESIZE * CHARSIZE);
+	int ruleSize = sizeof(TranslationTableRule);
 	if (ruleChars) ruleSize += CHARSIZE * ruleChars->length;
 	if (ruleDots) ruleSize += CHARSIZE * ruleDots->length;
 	if (!allocateSpaceInTranslationTable(file, &offset, ruleSize, table)) return 0;
 	TranslationTableRule *r = (TranslationTableRule *)&(*table)->ruleArea[offset];
 	if (rule) *rule = r;
 	if (ruleOffset) *ruleOffset = offset;
-	r->sourceFile = file->sourceFile;
-	r->sourceLine = file->lineNumber;
+#if ENABLE_RULE_DEBUG_INFO
+    r->sourceFile = file->sourceFile;
+    r->sourceLine = file->lineNumber;
+#endif
+
 	r->index = (*table)->ruleCounter++;
 	r->opcode = opcode;
 	r->after = after;
@@ -4439,22 +4444,27 @@ finalizeCharacter(TranslationTableHeader *table, TranslationTableOffset characte
 				if (defRule->index < character->ruleIndex) {
 					// character definition rule was defined before base rule; ignore base
 					// rule
+#if ENABLE_RULE_DEBUG_INFO
 					_lou_logMessage(LOU_LOG_DEBUG,
-							"%s:%d: Character already defined (%s). The existing %s rule "
-							"will take precedence over the new base rule.",
-							character->sourceFile, character->sourceLine,
-							printSource(character->sourceFile, defRule->sourceFile,
-									defRule->sourceLine),
-							defOpcodeName);
+						"%s:%d: Character already defined (%s). The existing %s rule "
+						"will take precedence over the new base rule.",
+						character->sourceFile, character->sourceLine,
+						printSource(character->sourceFile, defRule->sourceFile,
+							defRule->sourceLine),
+						defOpcodeName);
+#endif
 					free(defOpcodeName);
 					character->basechar = 0;
 					character->mode = 0;
+#if ENABLE_RULE_DEBUG_INFO
 					character->sourceFile = defRule->sourceFile;
 					character->sourceLine = defRule->sourceLine;
+#endif
 					character->ruleIndex = defRule->index;
 					character->finalized = 1;
 					return character;
 				} else {
+#if ENABLE_RULE_DEBUG_INFO
 					_lou_logMessage(LOU_LOG_DEBUG,
 							"%s:%d: A base rule already exists for this character (%s). "
 							"The "
@@ -4464,6 +4474,7 @@ finalizeCharacter(TranslationTableHeader *table, TranslationTableOffset characte
 							printSource(defRule->sourceFile, character->sourceFile,
 									character->sourceLine),
 							defOpcodeName);
+#endif
 					free(defOpcodeName);
 					character->definitionRule = 0;
 				}

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -65,6 +65,9 @@ extern "C" {
 #define CHARSIZE sizeof(widechar)
 #define DEFAULTRULESIZE 50
 
+/* Enable source file and line information in TranslationTableRule for debugging. */
+#define ENABLE_RULE_DEBUG_INFO 0
+
 typedef struct intCharTupple {
 	unsigned long long key;
 	char value;
@@ -81,7 +84,8 @@ typedef struct intCharTupple {
 #define MAX_SOURCE_FILES 100  // maximal number of files a table can consist of
 
 typedef unsigned int TranslationTableOffset;
-
+/* TranslationTableOpcode values currently fit within 8 bits. */
+typedef unsigned char TranslationTableOpcode;
 /* Basic type for translation table data, which carries all alignment
  * constraints that fields contained in translation table may have.
  * Notably TranslationTableCharacterAttributes is unsigned long long, so we need
@@ -356,22 +360,24 @@ typedef enum { /* Op codes */
 	CTO_EndCapsPhraseAfter,
 
 	CTO_All
-} TranslationTableOpcode;
+} TranslationTableOpcodes;
 
 typedef struct {
+	TranslationTableCharacterAttributes after; /** character types which must follow */
+	TranslationTableCharacterAttributes before; /** character types which must precede */
+#if ENABLE_RULE_DEBUG_INFO
 	const char *sourceFile;
 	int sourceLine;
+#endif
 	int index;								   /** sequence number of rule within table */
 	TranslationTableOffset charsnext;		   /** next chars entry */
 	TranslationTableOffset dotsnext;		   /** next dots entry */
-	TranslationTableCharacterAttributes after; /** character types which must follow */
-	TranslationTableCharacterAttributes before; /** character types which must precede */
 	TranslationTableOffset patterns;			/** before and after patterns */
-	TranslationTableOpcode opcode; /** rule for testing validity of replacement */
-	char nocross;
 	short charslen;						 /** length of string to be replaced */
 	short dotslen;						 /** length of replacement string */
-	widechar charsdots[DEFAULTRULESIZE]; /** find and replacement strings */
+	TranslationTableOpcode opcode; 		/** Rule opcode (stored as an unsigned char). */
+	char nocross;
+	widechar charsdots[]; /** Flexible array member allocated according to the rule size. */ /** find and replacement strings */
 } TranslationTableRule;
 
 typedef struct /* state transition */


### PR DESCRIPTION
## Summary

This pull request optimizes the memory footprint of TranslationTableRule by reducing the size of frequently allocated rule objects without changing their behavior.

## Changes

- Reduce the storage size of `TranslationTableOpcode` from an enum to an 8-bit type, since all current opcode values fit within one byte.
- Make `sourceFile` and `sourceLine` in `TranslationTableRule` optional through a compile-time flag (`ENABLE_RULE_DEBUG_INFO`).
- Used a flexible array member (charsdots[]) with dynamic allocation based on the rule size.
- Preserve debug information when required while allowing production builds to omit it.
- Improve comments and documentation related to the optimized structures.

## Benefits

- Reduces the size of each `TranslationTableRule`.
- Lowers the overall memory usage of compiled translation tables.
- No functional changes to translation behavior.
- Debug information can still be enabled when needed.

## Testing

The changes were tested on Windows using Visual Studio with a custom application that uses the Liblouis library.
The following were verified:
-	Successful compilation.
-	Translation results remain unchanged compared to the original implementation.
-	No functional regressions were observed during testing.
-	Memory usage of the compiled translation table was reduced.
