### PR TITLE
en-ueb-g2: fix missing apostrophe in whereabouts's back-translation rule

### DIFF
--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -4198,7 +4198,7 @@ nofor word wouldn't's  2456-145-1345-3-2345-3-234
 nofor word wouldn't've's  2456-145-1345-3-2345-3-1236-15-3-234
 nofor word wouldst's  2456-145-34-3-234
 
-nofor word whereabouts's  5-156-1-12-234-234
+nofor word whereabouts's  5-156-1-12-234-3-234
 
 contraction abface      aboutface
 contraction abturn      aboutturn

--- a/tests/braille-specs/en-ueb-g2-dictionary_harness.yaml
+++ b/tests/braille-specs/en-ueb-g2-dictionary_harness.yaml
@@ -104776,7 +104776,7 @@ tests:
   - [whereabout, ⠐⠱⠁⠃]
   - [whereabout's, ⠐⠱⠁⠃⠄⠎]
   - [whereabouts, ⠐⠱⠁⠃⠎]
-  - [whereabouts's, ⠐⠱⠁⠃⠎⠄⠎, xfail: {backward: true}]
+  - [whereabouts's, ⠐⠱⠁⠃⠎⠄⠎]
   - [whereafter, ⠐⠱⠁⠋]
   - [whereafter's, ⠐⠱⠁⠋⠄⠎]
   - [whereafters, ⠐⠱⠁⠋⠎]


### PR DESCRIPTION
The UEB Grade 2 table contains:

```
nofor word whereabouts's  5-156-1-12-234-234
```

The dots end `-234-234` (s, s) — the dot-3 apostrophe between them is missing; they should end `-234-3-234`. Because forward translation of `whereabouts's` produces `5-156-1-12-234-3-234` (⠐⠱⠁⠃⠎⠄⠎), this back-only rule could never match the braille the table itself generates, and back-translating ⠐⠱⠁⠃⠎⠄⠎ fell through to the generic rules instead.

The dictionary harness has had this marked `xfail: {backward: true}` since b75ba9fa (#1487), when backward testing was first enabled and all failures at the time were bulk-annotated — so the xfail recorded the symptom of this typo rather than an expected lossy round trip. This PR corrects the dots and removes the xfail, turning that entry into a passing regression test.