### PR TITLE
en-ueb-g2: replace redundant shortform match rules with bidirectional word rules

### DIFF
--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -1676,6 +1676,12 @@ match %[_~^]%<* letter (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 123-1235   10.9.3
 match %[_~^]%<* little (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 123-123   10.9.3
 match %[_~^]%<* quick (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 12345-13   10.9.3
 
+#   The word rules below consume a word-final "s", bypassing the
+#   "noback endword s\x2019 234-3" rule in en-ueb-chardefs.uti. Keep a
+#   trailing U+2019 after a word-final s an apostrophe rather than a
+#   closing quote (the dogs\x2019 bones, the friends\x2019 interference).
+noback match [sS] \x2019 %>*%[_~^] 3
+
 #TODO:  backmatch should be able to merge these
 word about  1-12
 word above  1-12-1236

--- a/tables/en-ueb-g2.ctb
+++ b/tables/en-ueb-g2.ctb
@@ -1665,234 +1665,169 @@ always mention 134-26-56-1345 TION has priority
 
 attribute 2 BCDFGHJKLMNPQRSTVWXZbcdfghjklmnpqrstvwxz  no vowels (except w) and 2.6.4
 
-match %[_~^]%<* about ([Ss]|['’][Ss])?%>*%[_~^] 1-12
-match %[_~^]%<* above ([Ss]|['’][Ss])?%>*%[_~^] 1-12-1236
-match %[_~^]%<* according ([Ss]|['’][Ss])?%>*%[_~^] 1-14
-match %[_~^]%<* across ([Ss]|['’][Ss])?%>*%[_~^] 1-14-1235
-match %[_~^]%<* after ([Ss]|['’][Ss])?%>*%[_~^] 1-124
-match %[_~^]%<* afternoon ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1345
-match %[_~^]%<* afterward ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2456
-match %[_~^]%<* again ([Ss]|['’][Ss])?%>*%[_~^] 1-1245
-match %[_~^]%<* against ([Ss]|['’][Ss])?%>*%[_~^] 1-1245-34
-match %[_~^]%<* almost ([Ss]|['’][Ss])?%>*%[_~^] 1-123-134
-match %[_~^]%<* already ([Ss]|['’][Ss])?%>*%[_~^] 1-123-1235
-match %[_~^]%<* also ([Ss]|['’][Ss])?%>*%[_~^] 1-123
-match %[_~^]%<* although ([Ss]|['’][Ss])?%>*%[_~^] 1-123-1456
-match %[_~^]%<* altogether ([Ss]|['’][Ss])?%>*%[_~^] 1-123-2345
-match %[_~^]%<* always ([Ss]|['’][Ss])?%>*%[_~^] 1-123-2456
-match %[_~^]%<* because ([Ss]|['’][Ss])?%>*%[_~^] 23-14
-match %[_~^]%<* before ([Ss]|['’][Ss])?%>*%[_~^] 23-124
-match %[_~^]%<* behind ([Ss]|['’][Ss])?%>*%[_~^] 23-125
-match %[_~^]%<* below ([Ss]|['’][Ss])?%>*%[_~^] 23-123
-match %[_~^]%<* beneath ([Ss]|['’][Ss])?%>*%[_~^] 23-1345
-match %[_~^]%<* beside ([Ss]|['’][Ss])?%>*%[_~^] 23-234
-match %[_~^]%<* between ([Ss]|['’][Ss])?%>*%[_~^] 23-2345
-match %[_~^]%<* beyond ([Ss]|['’][Ss])?%>*%[_~^] 23-13456
 match %[_~^]%<* blind (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 12-123   appendix 1.4
 match %[_~^]%<*%a* braille %a*([Ss]|['’][Ss])?%>*%[_~^] 12-1235-123   10.9.3
 match %[_~^]%<*%a* children (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 16-1345   10.9.3
-match %[_~^]%<* conceive ([Ss]|['’][Ss])?%>*%[_~^] 25-14-1236
-match %[_~^]%<* conceiving ([Ss]|['’][Ss])?%>*%[_~^] 25-14-1236-1245
-match %[_~^]%<* could ([Ss]|['’][Ss])?%>*%[_~^] 14-145
-match %[_~^]%<* deceive ([Ss]|['’][Ss])?%>*%[_~^] 145-14-1236
-match %[_~^]%<* deceiving ([Ss]|['’][Ss])?%>*%[_~^] 145-14-1236-1245
-match %[_~^]%<* declare ([Ss]|['’][Ss])?%>*%[_~^] 145-14-123
-match %[_~^]%<* declaring ([Ss]|['’][Ss])?%>*%[_~^] 145-14-123-1245
-match %[_~^]%<* either ([Ss]|['’][Ss])?%>*%[_~^] 15-24
 match %[_~^]%<* first (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 124-34   10.9.3
 match %[_~^]%<* friend (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 124-1235   appendix 1.4
 match %[_~^]%<* good (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 1245-145   10.9.3
 match %[_~^]%<*%a* great %a*([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345   10.9.3
-match %[_~^]%<* herself ([Ss]|['’][Ss])?%>*%[_~^] 125-12456-124
-match %[_~^]%<* him ([Ss]|['’][Ss])?%>*%[_~^] 125-134
-match %[_~^]%<* himself ([Ss]|['’][Ss])?%>*%[_~^] 125-134-124
-match %[_~^]%<* immediate ([Ss]|['’][Ss])?%>*%[_~^] 24-134-134
-match %[_~^]%<* its ([Ss]|['’][Ss])?%>*%[_~^] 1346-234
-match %[_~^]%<* itself ([Ss]|['’][Ss])?%>*%[_~^] 1346-124
 match %[_~^]%<* letter (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 123-1235   10.9.3
 match %[_~^]%<* little (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 123-123   10.9.3
-match %[_~^]%<* much ([Ss]|['’][Ss])?%>*%[_~^] 134-16
-match %[_~^]%<* must ([Ss]|['’][Ss])?%>*%[_~^] 134-34
-match %[_~^]%<* myself ([Ss]|['’][Ss])?%>*%[_~^] 134-13456-124
-match %[_~^]%<* necessary ([Ss]|['’][Ss])?%>*%[_~^] 1345-15-14
-match %[_~^]%<* neither ([Ss]|['’][Ss])?%>*%[_~^] 1345-15-24
-match %[_~^]%<* oneself ([Ss]|['’][Ss])?%>*%[_~^] 5-135-124
-match %[_~^]%<* ourselves ([Ss]|['’][Ss])?%>*%[_~^] 1256-1235-1236-234
-match %[_~^]%<* paid ([Ss]|['’][Ss])?%>*%[_~^] 1234-145
-match %[_~^]%<* perceive ([Ss]|['’][Ss])?%>*%[_~^] 1234-12456-14-1236
-match %[_~^]%<* perceiving ([Ss]|['’][Ss])?%>*%[_~^] 1234-12456-14-1236-1245
-match %[_~^]%<* perhaps ([Ss]|['’][Ss])?%>*%[_~^] 1234-12456-125
 match %[_~^]%<* quick (%2%a*)?([Ss]|['’][Ss])?%>*%[_~^] 12345-13   10.9.3
-match %[_~^]%<* receive ([Ss]|['’][Ss])?%>*%[_~^] 1235-14-1236
-match %[_~^]%<* receiving ([Ss]|['’][Ss])?%>*%[_~^] 1235-14-1236-1245
-match %[_~^]%<* rejoice ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14
-match %[_~^]%<* rejoicing ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-1245
-match %[_~^]%<* said ([Ss]|['’][Ss])?%>*%[_~^] 234-145
-match %[_~^]%<* should ([Ss]|['’][Ss])?%>*%[_~^] 146-145
-match %[_~^]%<* such ([Ss]|['’][Ss])?%>*%[_~^] 234-16
-match %[_~^]%<* themselves ([Ss]|['’][Ss])?%>*%[_~^] 2346-134-1236-234
-match %[_~^]%<* thyself ([Ss]|['’][Ss])?%>*%[_~^] 1456-13456-124
-match %[_~^]%<* today ([Ss]|['’][Ss])?%>*%[_~^] 2345-145
-match %[_~^]%<* together ([Ss]|['’][Ss])?%>*%[_~^] 2345-1245-1235
-match %[_~^]%<* tomorrow ([Ss]|['’][Ss])?%>*%[_~^] 2345-134
-match %[_~^]%<* tonight ([Ss]|['’][Ss])?%>*%[_~^] 2345-1345
-match %[_~^]%<* would ([Ss]|['’][Ss])?%>*%[_~^] 2456-145
-match %[_~^]%<* your ([Ss]|['’][Ss])?%>*%[_~^] 13456-1235
-match %[_~^]%<* yourself ([Ss]|['’][Ss])?%>*%[_~^] 13456-1235-124
-match %[_~^]%<* yourselves ([Ss]|['’][Ss])?%>*%[_~^] 13456-1235-1236-234
 
 #TODO:  backmatch should be able to merge these
-nofor word about  1-12
-nofor word above  1-12-1236
-nofor word according  1-14
-nofor word across  1-14-1235
-nofor word after  1-124   appendix 1.4
-nofor word afternoon  1-124-1345
-nofor word afterward  1-124-2456
-nofor word again  1-1245
-nofor word against  1-1245-34
-nofor word almost  1-123-134
-nofor word already  1-123-1235
-nofor word also  1-123
-nofor word although  1-123-1456
-nofor word altogether  1-123-2345
-nofor word always  1-123-2456
-nofor word because  23-14
-nofor word before  23-124
-nofor word behind  23-125
-nofor word below  23-123
-nofor word beneath  23-1345
-nofor word beside  23-234
-nofor word between  23-2345
-nofor word beyond  23-13456
-nofor word blind  12-123   appendix 1.4
-nofor word braille  12-1235-123   10.9.3
-nofor word children  16-1345   10.9.3
-nofor word conceive  25-14-1236
-nofor word conceiving  25-14-1236-1245
-nofor word could  14-145
-nofor word deceive  145-14-1236
-nofor word deceiving  145-14-1236-1245
-nofor word declare  145-14-123
-nofor word declaring  145-14-123-1245
-nofor word either  15-24
-nofor word first  124-34   10.9.3
-nofor word friend  124-1235   appendix 1.4
-nofor word good  1245-145   10.9.3
-nofor word great  1245-1235-2345   10.9.3
-nofor word herself  125-12456-124
-nofor word him  125-134
-nofor word himself  125-134-124
-nofor word immediate  24-134-134
-nofor word its  1346-234
-nofor word itself  1346-124
-nofor word letter  123-1235   10.9.3
-nofor word little  123-123   10.9.3
-nofor word much  134-16
-nofor word must  134-34
-nofor word myself  134-13456-124
-nofor word necessary  1345-15-14
-nofor word neither  1345-15-24
-nofor word oneself  5-135-124
-nofor word ourselves  1256-1235-1236-234
-nofor word paid  1234-145
-nofor word perceive  1234-12456-14-1236
-nofor word perceiving  1234-12456-14-1236-1245
-nofor word perhaps  1234-12456-125
-nofor word quick 12345-13   10.9.3
-nofor word receive  1235-14-1236
-nofor word receiving  1235-14-1236-1245
-nofor word rejoice  1235-245-14
-nofor word rejoicing  1235-245-14-1245
-nofor word said  234-145
-nofor word should  146-145
-nofor word such  234-16
-nofor word themselves  2346-134-1236-234
-nofor word thyself  1456-13456-124
-nofor word today  2345-145
-nofor word together  2345-1245-1235
-nofor word tomorrow  2345-134
-nofor word tonight  2345-1345
-nofor word would  2456-145
-nofor word your  13456-1235
-nofor word yourself  13456-1235-124
-nofor word yourselves  13456-1235-1236-234
+word about  1-12
+word above  1-12-1236
+word according  1-14
+word across  1-14-1235
+word after  1-124   appendix 1.4
+word afternoon  1-124-1345
+word afterward  1-124-2456
+word again  1-1245
+word against  1-1245-34
+word almost  1-123-134
+word already  1-123-1235
+word also  1-123
+word although  1-123-1456
+word altogether  1-123-2345
+word always  1-123-2456
+word because  23-14
+word before  23-124
+word behind  23-125
+word below  23-123
+word beneath  23-1345
+word beside  23-234
+word between  23-2345
+word beyond  23-13456
+word blind  12-123   appendix 1.4
+word braille  12-1235-123   10.9.3
+word children  16-1345   10.9.3
+word conceive  25-14-1236
+word conceiving  25-14-1236-1245
+word could  14-145
+word deceive  145-14-1236
+word deceiving  145-14-1236-1245
+word declare  145-14-123
+word declaring  145-14-123-1245
+word either  15-24
+word first  124-34   10.9.3
+word friend  124-1235   appendix 1.4
+word good  1245-145   10.9.3
+word great  1245-1235-2345   10.9.3
+word herself  125-12456-124
+word him  125-134
+word himself  125-134-124
+word immediate  24-134-134
+word its  1346-234
+word itself  1346-124
+word letter  123-1235   10.9.3
+word little  123-123   10.9.3
+word much  134-16
+word must  134-34
+word myself  134-13456-124
+word necessary  1345-15-14
+word neither  1345-15-24
+word oneself  5-135-124
+word ourselves  1256-1235-1236-234
+word paid  1234-145
+word perceive  1234-12456-14-1236
+word perceiving  1234-12456-14-1236-1245
+word perhaps  1234-12456-125
+word quick 12345-13   10.9.3
+word receive  1235-14-1236
+word receiving  1235-14-1236-1245
+word rejoice  1235-245-14
+word rejoicing  1235-245-14-1245
+word said  234-145
+word should  146-145
+word such  234-16
+word themselves  2346-134-1236-234
+word thyself  1456-13456-124
+word today  2345-145
+word together  2345-1245-1235
+word tomorrow  2345-134
+word tonight  2345-1345
+word would  2456-145
+word your  13456-1235
+word yourself  13456-1235-124
+word yourselves  13456-1235-1236-234
 
 #nofor word abouts  1-12-234   appendix 1
-nofor word aboves  1-12-1236-234
-nofor word accordings  1-14-234
-nofor word acrosss  1-14-1235-234
-nofor word afters  1-124-234   appendix 1.4
-nofor word afternoons  1-124-1345-234
-nofor word afterwards  1-124-2456-234
-nofor word agains  1-1245-234
-nofor word againsts  1-1245-34-234
+word aboves  1-12-1236-234
+word accordings  1-14-234
+word acrosss  1-14-1235-234
+word afters  1-124-234   appendix 1.4
+word afternoons  1-124-1345-234
+word afterwards  1-124-2456-234
+word agains  1-1245-234
+word againsts  1-1245-34-234
 #nofor word almosts  1-123-134-234   appendix 1
-nofor word alreadys  1-123-1235-234
-nofor word alsos  1-123-234
-nofor word althoughs  1-123-1456-234
-nofor word altogethers  1-123-2345-234
-nofor word alwayss  1-123-2456-234
-nofor word becauses  23-14-234
-nofor word befores  23-124-234
-nofor word behinds  23-125-234
-nofor word belows  23-123-234
-nofor word beneaths  23-1345-234
-nofor word besides  23-234-234
-nofor word betweens  23-2345-234
-nofor word beyonds  23-13456-234
-nofor word blinds  12-123-234   appendix 1.4
-nofor word brailles  12-1235-123-234   10.9.3
-nofor word childrens  16-1345-234   10.9.3
-nofor word conceives  25-14-1236-234
-nofor word conceivings  25-14-1236-1245-234
-nofor word coulds  14-145-234
-nofor word deceives  145-14-1236-234
-nofor word deceivings  145-14-1236-1245-234
-nofor word declares  145-14-123-234
-nofor word declarings  145-14-123-1245-234
-nofor word eithers  15-24-234
-nofor word firsts  124-34-234   10.9.3
-nofor word friends  124-1235-234   appendix 1.4
-nofor word goods  1245-145-234   10.9.3
-nofor word greats  1245-1235-2345-234   10.9.3
-nofor word herselfs  125-12456-124-234
+word alreadys  1-123-1235-234
+word alsos  1-123-234
+word althoughs  1-123-1456-234
+word altogethers  1-123-2345-234
+word alwayss  1-123-2456-234
+word becauses  23-14-234
+word befores  23-124-234
+word behinds  23-125-234
+word belows  23-123-234
+word beneaths  23-1345-234
+word besides  23-234-234
+word betweens  23-2345-234
+word beyonds  23-13456-234
+word blinds  12-123-234   appendix 1.4
+word brailles  12-1235-123-234   10.9.3
+word childrens  16-1345-234   10.9.3
+word conceives  25-14-1236-234
+word conceivings  25-14-1236-1245-234
+word coulds  14-145-234
+word deceives  145-14-1236-234
+word deceivings  145-14-1236-1245-234
+word declares  145-14-123-234
+word declarings  145-14-123-1245-234
+word eithers  15-24-234
+word firsts  124-34-234   10.9.3
+word friends  124-1235-234   appendix 1.4
+word goods  1245-145-234   10.9.3
+word greats  1245-1235-2345-234   10.9.3
+word herselfs  125-12456-124-234
 #nofor word hims  125-134-234   appendix 1
-nofor word himselfs  125-134-124-234
-nofor word immediates  24-134-134-234
-nofor word itss  1346-234-234
-nofor word itselfs  1346-124-234
-nofor word letters  123-1235-234   10.9.3
-nofor word littles  123-123-234   10.9.3
-nofor word muchs  134-16-234
-nofor word musts  134-34-234
-nofor word myselfs  134-13456-124-234
-nofor word necessarys  1345-15-14-234
-nofor word neithers  1345-15-24-234
-nofor word oneselfs  5-135-124-234
-nofor word ourselvess  1256-1235-1236-234-234
-nofor word paids  1234-145-234
-nofor word perceives  1234-12456-14-1236-234
-nofor word perceivings  1234-12456-14-1236-1245-234
-nofor word perhapss  1234-12456-125-234
-nofor word quicks  12345-13-234   10.9.3
-nofor word receives  1235-14-1236-234
-nofor word receivings  1235-14-1236-1245-234
-nofor word rejoices  1235-245-14-234
-nofor word rejoicings  1235-245-14-1245-234
-nofor word saids  234-145-234
-nofor word shoulds  146-145-234
-nofor word suchs  234-16-234
-nofor word themselvess  2346-134-1236-234-234
-nofor word thyselfs  1456-13456-124-234
-nofor word todays  2345-145-234
-nofor word togethers  2345-1245-1235-234
-nofor word tomorrows  2345-134-234
-nofor word tonights  2345-1345-234
-nofor word woulds  2456-145-234
-nofor word yours  13456-1235-234
-nofor word yourselfs  13456-1235-124-234
-nofor word yourselvess  13456-1235-1236-234-234
+word himselfs  125-134-124-234
+word immediates  24-134-134-234
+word itss  1346-234-234
+word itselfs  1346-124-234
+word letters  123-1235-234   10.9.3
+word littles  123-123-234   10.9.3
+word muchs  134-16-234
+word musts  134-34-234
+word myselfs  134-13456-124-234
+word necessarys  1345-15-14-234
+word neithers  1345-15-24-234
+word oneselfs  5-135-124-234
+word ourselvess  1256-1235-1236-234-234
+word paids  1234-145-234
+word perceives  1234-12456-14-1236-234
+word perceivings  1234-12456-14-1236-1245-234
+word perhapss  1234-12456-125-234
+word quicks  12345-13-234   10.9.3
+word receives  1235-14-1236-234
+word receivings  1235-14-1236-1245-234
+word rejoices  1235-245-14-234
+word rejoicings  1235-245-14-1245-234
+word saids  234-145-234
+word shoulds  146-145-234
+word suchs  234-16-234
+word themselvess  2346-134-1236-234-234
+word thyselfs  1456-13456-124-234
+word todays  2345-145-234
+word togethers  2345-1245-1235-234
+word tomorrows  2345-134-234
+word tonights  2345-1345-234
+word woulds  2456-145-234
+word yours  13456-1235-234
+word yourselfs  13456-1235-124-234
+word yourselvess  13456-1235-1236-234-234
 
 nofor word about's  1-12-3-234
 nofor word above's  1-12-1236-3-234
@@ -2081,1585 +2016,1032 @@ word abouts 1-12-1256-2345-234
 word almosts 1-123-134-135-34-234
 word hims 125-24-134-234
 
-nofor word alms 1-123-134-234
+word alms 1-123-134-234
 
 #   don't mix ’ with ' together
-match %[_~^]%<* ’twould ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145
-match %[_~^]%<* 'twould ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145
-match %[_~^]%<* ’twould’ve ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-3-1236-15
-match %[_~^]%<* 'twould've ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-3-1236-15
-match %[_~^]%<* ’twoulda ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-1
-match %[_~^]%<* 'twoulda ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-1
-match %[_~^]%<* ’twouldn’t ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-1345-3-2345
-match %[_~^]%<* 'twouldn't ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-1345-3-2345
-match %[_~^]%<* ’twouldn’t’ve ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-1345-3-2345-3-1236-15
-match %[_~^]%<* 'twouldn't've ([Ss]|['’][Ss])?%>*%[_~^] 3-2345-2456-145-1345-3-2345-3-1236-15
-match %[_~^]%<* aboutface ([Ss]|['’][Ss])?%>*%[_~^] 1-12-124-1-14-15
-match %[_~^]%<* aboutfaced ([Ss]|['’][Ss])?%>*%[_~^] 1-12-124-1-14-1246
-match %[_~^]%<* aboutfacer ([Ss]|['’][Ss])?%>*%[_~^] 1-12-124-1-14-12456
-match %[_~^]%<* aboutfacing ([Ss]|['’][Ss])?%>*%[_~^] 1-12-124-1-14-346
-match %[_~^]%<* aboutturn ([Ss]|['’][Ss])?%>*%[_~^] 1-12-2345-136-1235-1345
-match %[_~^]%<* aboutturned ([Ss]|['’][Ss])?%>*%[_~^] 1-12-2345-136-1235-1345-1246
-match %[_~^]%<* aboveboard ([Ss]|['’][Ss])?%>*%[_~^] 1-12-1236-12-135-345-145
-match %[_~^]%<* aboveground ([Ss]|['’][Ss])?%>*%[_~^] 1-12-1236-1245-1235-46-145
-match %[_~^]%<* abovementioned ([Ss]|['’][Ss])?%>*%[_~^] 1-12-1236-134-26-56-1345-1246
-match %[_~^]%<* accordingly ([Ss]|['’][Ss])?%>*%[_~^] 1-14-123-13456
-match %[_~^]%<* aforesaid ([Ss]|['’][Ss])?%>*%[_~^] 1-123456-15-234-145
-match %[_~^]%<* afterbattle ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-1-2345-2345-123-15
-match %[_~^]%<* afterbirth ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-24-1235-1456
-match %[_~^]%<* afterbreakfast ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-1235-2-13-124-1-34
-match %[_~^]%<* afterburn ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-136-1235-1345
-match %[_~^]%<* afterburned ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-136-1235-1345-1246
-match %[_~^]%<* afterburner ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-136-1235-1345-12456
-match %[_~^]%<* afterburning ([Ss]|['’][Ss])?%>*%[_~^] 1-124-12-136-1235-1345-346
-match %[_~^]%<* aftercare ([Ss]|['’][Ss])?%>*%[_~^] 1-124-14-345-15
-match %[_~^]%<* afterclap ([Ss]|['’][Ss])?%>*%[_~^] 1-124-14-123-1-1234
-match %[_~^]%<* aftercoffee ([Ss]|['’][Ss])?%>*%[_~^] 1-124-14-12356-124-15-15
-match %[_~^]%<* afterdamp ([Ss]|['’][Ss])?%>*%[_~^] 1-124-145-1-134-1234
-match %[_~^]%<* afterdark ([Ss]|['’][Ss])?%>*%[_~^] 1-124-145-345-13
-match %[_~^]%<* afterdeck ([Ss]|['’][Ss])?%>*%[_~^] 1-124-145-15-14-13
-match %[_~^]%<* afterdinner ([Ss]|['’][Ss])?%>*%[_~^] 1-124-145-35-1345-12456
-match %[_~^]%<* afterflow ([Ss]|['’][Ss])?%>*%[_~^] 1-124-124-123-246
-match %[_~^]%<* aftergame ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1245-1-134-15
-match %[_~^]%<* afterglow ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1245-123-246
-match %[_~^]%<* afterguard ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1245-136-345-145
-match %[_~^]%<* afterhatch ([Ss]|['’][Ss])?%>*%[_~^] 1-124-125-1-2345-16
-match %[_~^]%<* afterhatches ([Ss]|['’][Ss])?%>*%[_~^] 1-124-125-1-2345-16-15-234
-match %[_~^]%<* afterhour ([Ss]|['’][Ss])?%>*%[_~^] 1-124-125-1256-1235
-match %[_~^]%<* afterlife ([Ss]|['’][Ss])?%>*%[_~^] 1-124-123-24-124-15
-match %[_~^]%<* afterlight ([Ss]|['’][Ss])?%>*%[_~^] 1-124-123-24-126-2345
-match %[_~^]%<* afterlives ([Ss]|['’][Ss])?%>*%[_~^] 1-124-123-24-1236-15-234
-match %[_~^]%<* afterlunch ([Ss]|['’][Ss])?%>*%[_~^] 1-124-123-136-1345-16
-match %[_~^]%<* afterlunches ([Ss]|['’][Ss])?%>*%[_~^] 1-124-123-136-1345-16-15-234
-match %[_~^]%<* aftermarket ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-345-13-15-2345
-match %[_~^]%<* aftermatch ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-1-2345-16
-match %[_~^]%<* aftermatches ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-1-2345-16-15-234
-match %[_~^]%<* aftermath ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-1-1456
-match %[_~^]%<* aftermeeting ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-15-15-2345-346
-match %[_~^]%<* aftermentioned ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-26-56-1345-1246
-match %[_~^]%<* aftermidday ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-24-145-5-145
-match %[_~^]%<* aftermidnight ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-24-145-1345-24-126-2345
-match %[_~^]%<* aftermost ([Ss]|['’][Ss])?%>*%[_~^] 1-124-134-135-34
-match %[_~^]%<* afternoontea ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1345-2345-15-1
-match %[_~^]%<* afterpain ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1234-1-35
-match %[_~^]%<* afterparties ([Ss]|['’][Ss])?%>*%[_~^] 1-124-5-1234-24-15-234
-match %[_~^]%<* afterparty ([Ss]|['’][Ss])?%>*%[_~^] 1-124-5-1234-13456
-match %[_~^]%<* afterpiece ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1234-24-15-14-15
-match %[_~^]%<* afterplay ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1234-123-1-13456
-match %[_~^]%<* aftersale ([Ss]|['’][Ss])?%>*%[_~^] 1-124-234-1-123-15
-match %[_~^]%<* afterschool ([Ss]|['’][Ss])?%>*%[_~^] 1-124-234-16-135-135-123
-match %[_~^]%<* aftersensation ([Ss]|['’][Ss])?%>*%[_~^] 1-124-234-26-234-1-56-1345
-match %[_~^]%<* aftershave ([Ss]|['’][Ss])?%>*%[_~^] 1-124-146-1-1236-15
-match %[_~^]%<* aftershock ([Ss]|['’][Ss])?%>*%[_~^] 1-124-146-135-14-13
-match %[_~^]%<* aftershow ([Ss]|['’][Ss])?%>*%[_~^] 1-124-146-246
-match %[_~^]%<* aftershower ([Ss]|['’][Ss])?%>*%[_~^] 1-124-146-246-12456
-match %[_~^]%<* aftersupper ([Ss]|['’][Ss])?%>*%[_~^] 1-124-234-136-1234-1234-12456
-match %[_~^]%<* aftertaste ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2345-1-34-15
-match %[_~^]%<* aftertax ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2345-1-1346
-match %[_~^]%<* aftertaxes ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2345-1-1346-15-234
-match %[_~^]%<* aftertea ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2345-15-1
-match %[_~^]%<* aftertheater ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2346-1-2345-12456
-match %[_~^]%<* aftertheatre ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2346-1-2345-1235-15
-match %[_~^]%<* afterthought ([Ss]|['’][Ss])?%>*%[_~^] 1-124-1456-5-1256
-match %[_~^]%<* aftertime ([Ss]|['’][Ss])?%>*%[_~^] 1-124-5-2345
-match %[_~^]%<* aftertreatment ([Ss]|['’][Ss])?%>*%[_~^] 1-124-2345-1235-2-2345-56-2345
-match %[_~^]%<* afterword ([Ss]|['’][Ss])?%>*%[_~^] 1-124-45-2456
-match %[_~^]%<* afterwork ([Ss]|['’][Ss])?%>*%[_~^] 1-124-5-2456
-match %[_~^]%<* afterworld ([Ss]|['’][Ss])?%>*%[_~^] 1-124-456-2456
-match %[_~^]%<* apperceive ([Ss]|['’][Ss])?%>*%[_~^] 1-1234-1234-12456-14-1236
-match %[_~^]%<* apperceived ([Ss]|['’][Ss])?%>*%[_~^] 1-1234-1234-12456-14-1236-145
-match %[_~^]%<* apperceiver ([Ss]|['’][Ss])?%>*%[_~^] 1-1234-1234-12456-14-1236-1235
-match %[_~^]%<* apperceiving ([Ss]|['’][Ss])?%>*%[_~^] 1-1234-1234-12456-14-1236-1245
-match %[_~^]%<* archdeceiver ([Ss]|['’][Ss])?%>*%[_~^] 345-16-145-14-1236-1235
-match %[_~^]%<* beforehand ([Ss]|['’][Ss])?%>*%[_~^] 23-124-125-12346
-match %[_~^]%<* beforementioned ([Ss]|['’][Ss])?%>*%[_~^] 23-124-134-26-56-1345-1246
-match %[_~^]%<* befriend ([Ss]|['’][Ss])?%>*%[_~^] 23-124-1235
-match %[_~^]%<* behindhand ([Ss]|['’][Ss])?%>*%[_~^] 23-125-125-12346
-match %[_~^]%<* belittle ([Ss]|['’][Ss])?%>*%[_~^] 23-123-123
-match %[_~^]%<* belittled ([Ss]|['’][Ss])?%>*%[_~^] 23-123-123-145
-match %[_~^]%<* belittlement ([Ss]|['’][Ss])?%>*%[_~^] 23-123-123-56-2345
-match %[_~^]%<* belittler ([Ss]|['’][Ss])?%>*%[_~^] 23-123-123-1235
-match %[_~^]%<* belowdeck ([Ss]|['’][Ss])?%>*%[_~^] 23-123-145-15-14-13
-match %[_~^]%<* belowground ([Ss]|['’][Ss])?%>*%[_~^] 23-123-1245-1235-46-145
-match %[_~^]%<* belowmentioned ([Ss]|['’][Ss])?%>*%[_~^] 23-123-134-26-56-1345-1246
-match %[_~^]%<* beneathdeck ([Ss]|['’][Ss])?%>*%[_~^] 23-1345-145-15-14-13
-match %[_~^]%<* beneathground ([Ss]|['’][Ss])?%>*%[_~^] 23-1345-1245-1235-46-145
-match %[_~^]%<* betweendeck ([Ss]|['’][Ss])?%>*%[_~^] 23-2345-145-15-14-13
-match %[_~^]%<* betweentime ([Ss]|['’][Ss])?%>*%[_~^] 23-2345-5-2345
-match %[_~^]%<* betweenwhile ([Ss]|['’][Ss])?%>*%[_~^] 23-2345-156-24-123-15
-match %[_~^]%<* blindfish ([Ss]|['’][Ss])?%>*%[_~^] 12-123-124-24-146
-match %[_~^]%<* blindfishes ([Ss]|['’][Ss])?%>*%[_~^] 12-123-124-24-146-15-234
-match %[_~^]%<* blindfold ([Ss]|['’][Ss])?%>*%[_~^] 12-123-124-135-123-145
-match %[_~^]%<* blindfolded ([Ss]|['’][Ss])?%>*%[_~^] 12-123-124-135-123-145-1246
-match %[_~^]%<* blindfolder ([Ss]|['’][Ss])?%>*%[_~^] 12-123-124-135-123-145-12456
-match %[_~^]%<* blindfolding ([Ss]|['’][Ss])?%>*%[_~^] 12-123-124-135-123-145-346
-match %[_~^]%<* blindly ([Ss]|['’][Ss])?%>*%[_~^] 12-123-123-13456
-match %[_~^]%<* blindman ([Ss]|['’][Ss])?%>*%[_~^] 12-123-134-1-1345
-match %[_~^]%<* blindmen ([Ss]|['’][Ss])?%>*%[_~^] 12-123-134-26
-match %[_~^]%<* blindness ([Ss]|['’][Ss])?%>*%[_~^] 12-123-56-234
-match %[_~^]%<* blindnesses ([Ss]|['’][Ss])?%>*%[_~^] 12-123-56-234-15-234
-match %[_~^]%<* blindside ([Ss]|['’][Ss])?%>*%[_~^] 12-123-234-24-145-15
-match %[_~^]%<* blindsided ([Ss]|['’][Ss])?%>*%[_~^] 12-123-234-24-145-1246
-match %[_~^]%<* blindsider ([Ss]|['’][Ss])?%>*%[_~^] 12-123-234-24-145-12456
-match %[_~^]%<* blindsiding ([Ss]|['’][Ss])?%>*%[_~^] 12-123-234-24-145-346
-match %[_~^]%<* blindsight ([Ss]|['’][Ss])?%>*%[_~^] 12-123-234-24-126-2345
-match %[_~^]%<* blindstories ([Ss]|['’][Ss])?%>*%[_~^] 12-123-34-135-1235-24-15-234
-match %[_~^]%<* blindstory ([Ss]|['’][Ss])?%>*%[_~^] 12-123-34-135-1235-13456
-match %[_~^]%<* blindworm ([Ss]|['’][Ss])?%>*%[_~^] 12-123-2456-135-1235-134
-match %[_~^]%<* bloodletter ([Ss]|['’][Ss])?%>*%[_~^] 12-123-135-135-145-123-1235
-match %[_~^]%<* boyfriend ([Ss]|['’][Ss])?%>*%[_~^] 12-135-13456-124-1235
-match %[_~^]%<* brailled ([Ss]|['’][Ss])?%>*%[_~^] 12-1235-123-145
-match %[_~^]%<* brailler ([Ss]|['’][Ss])?%>*%[_~^] 12-1235-123-1235
-match %[_~^]%<* braillewriter ([Ss]|['’][Ss])?%>*%[_~^] 12-1235-123-2456-1235-24-2345-12456
-match %[_~^]%<* braillewriting ([Ss]|['’][Ss])?%>*%[_~^] 12-1235-123-2456-1235-24-2345-346
-match %[_~^]%<* brailley ([Ss]|['’][Ss])?%>*%[_~^] 12-1235-123-13456
-match %[_~^]%<* brainchildren ([Ss]|['’][Ss])?%>*%[_~^] 12-1235-1-35-16-1345
-match %[_~^]%<* chainletter ([Ss]|['’][Ss])?%>*%[_~^] 16-1-35-123-1235
-match %[_~^]%<* children’swear ([Ss]|['’][Ss])?%>*%[_~^] 16-1345-3-234-2456-15-345
-match %[_~^]%<* children'swear ([Ss]|['’][Ss])?%>*%[_~^] 16-1345-3-234-2456-15-345
-match %[_~^]%<* colorblind ([Ss]|['’][Ss])?%>*%[_~^] 14-135-123-135-1235-12-123
-match %[_~^]%<* colorblindness ([Ss]|['’][Ss])?%>*%[_~^] 14-135-123-135-1235-12-123-56-234
-match %[_~^]%<* colorblindnesses ([Ss]|['’][Ss])?%>*%[_~^] 14-135-123-135-1235-12-123-56-234-15-234
-match %[_~^]%<* colourblind ([Ss]|['’][Ss])?%>*%[_~^] 14-135-123-1256-1235-12-123
-match %[_~^]%<* colourblindness ([Ss]|['’][Ss])?%>*%[_~^] 14-135-123-1256-1235-12-123-56-234
-match %[_~^]%<* colourblindnesses ([Ss]|['’][Ss])?%>*%[_~^] 14-135-123-1256-1235-12-123-56-234-15-234
-match %[_~^]%<* conceived ([Ss]|['’][Ss])?%>*%[_~^] 25-14-1236-145
-match %[_~^]%<* conceiver ([Ss]|['’][Ss])?%>*%[_~^] 25-14-1236-1235
-match %[_~^]%<* could’ve ([Ss]|['’][Ss])?%>*%[_~^] 14-145-3-1236-15
-match %[_~^]%<* could've ([Ss]|['’][Ss])?%>*%[_~^] 14-145-3-1236-15
-match %[_~^]%<* coulda ([Ss]|['’][Ss])?%>*%[_~^] 14-145-1
-match %[_~^]%<* couldest ([Ss]|['’][Ss])?%>*%[_~^] 14-145-15-34
-match %[_~^]%<* couldn’t ([Ss]|['’][Ss])?%>*%[_~^] 14-145-1345-3-2345
-match %[_~^]%<* couldn't ([Ss]|['’][Ss])?%>*%[_~^] 14-145-1345-3-2345
-match %[_~^]%<* couldn’t’ve ([Ss]|['’][Ss])?%>*%[_~^] 14-145-1345-3-2345-3-1236-15
-match %[_~^]%<* couldn't've ([Ss]|['’][Ss])?%>*%[_~^] 14-145-1345-3-2345-3-1236-15
-match %[_~^]%<* couldst ([Ss]|['’][Ss])?%>*%[_~^] 14-145-34
-match %[_~^]%<* deafblind ([Ss]|['’][Ss])?%>*%[_~^] 145-2-124-12-123
-match %[_~^]%<* deafblindness ([Ss]|['’][Ss])?%>*%[_~^] 145-2-124-12-123-56-234
-match %[_~^]%<* deafblindnesses ([Ss]|['’][Ss])?%>*%[_~^] 145-2-124-12-123-56-234-15-234
-match %[_~^]%<* deceived ([Ss]|['’][Ss])?%>*%[_~^] 145-14-1236-145
-match %[_~^]%<* deceiver ([Ss]|['’][Ss])?%>*%[_~^] 145-14-1236-1235
-match %[_~^]%<* declared ([Ss]|['’][Ss])?%>*%[_~^] 145-14-123-145
-match %[_~^]%<* declarer ([Ss]|['’][Ss])?%>*%[_~^] 145-14-123-1235
-match %[_~^]%<* defriend ([Ss]|['’][Ss])?%>*%[_~^] 145-15-124-1235
-match %[_~^]%<* do-it-yourselfer ([Ss]|['’][Ss])?%>*%[_~^] 145-36-1346-36-13456-1235-124-12456
-match %[_~^]%<* doublequick ([Ss]|['’][Ss])?%>*%[_~^] 145-1256-12-123-15-12345-13
-match %[_~^]%<* eastabout ([Ss]|['’][Ss])?%>*%[_~^] 15-1-34-1-12
-match %[_~^]%<* feelgood ([Ss]|['’][Ss])?%>*%[_~^] 124-15-15-123-1245-145
-match %[_~^]%<* feetfirst ([Ss]|['’][Ss])?%>*%[_~^] 124-15-15-2345-124-34
-match %[_~^]%<* firstaid ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1-24-145
-match %[_~^]%<* firstaider ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1-24-145-12456
-match %[_~^]%<* firstborn ([Ss]|['’][Ss])?%>*%[_~^] 124-34-12-135-1235-1345
-match %[_~^]%<* firstclass ([Ss]|['’][Ss])?%>*%[_~^] 124-34-14-123-1-234-234
-match %[_~^]%<* firstclasses ([Ss]|['’][Ss])?%>*%[_~^] 124-34-14-123-1-234-234-15-234
-match %[_~^]%<* firstday ([Ss]|['’][Ss])?%>*%[_~^] 124-34-5-145
-match %[_~^]%<* firstdayer ([Ss]|['’][Ss])?%>*%[_~^] 124-34-5-145-12456
-match %[_~^]%<* firstfruit ([Ss]|['’][Ss])?%>*%[_~^] 124-34-124-1235-136-24-2345
-match %[_~^]%<* firstfruiting ([Ss]|['’][Ss])?%>*%[_~^] 124-34-124-1235-136-24-2345-346
-match %[_~^]%<* firstgeneration ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1245-26-12456-1-56-1345
-match %[_~^]%<* firsthand ([Ss]|['’][Ss])?%>*%[_~^] 124-34-125-12346
-match %[_~^]%<* firsthanded ([Ss]|['’][Ss])?%>*%[_~^] 124-34-125-12346-1246
-match %[_~^]%<* firstling ([Ss]|['’][Ss])?%>*%[_~^] 124-34-123-346
-match %[_~^]%<* firstly ([Ss]|['’][Ss])?%>*%[_~^] 124-34-123-13456
-match %[_~^]%<* firstness ([Ss]|['’][Ss])?%>*%[_~^] 124-34-56-234
-match %[_~^]%<* firstnight ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1345-24-126-2345
-match %[_~^]%<* firstnighter ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1345-24-126-2345-12456
-match %[_~^]%<* firstrate ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1235-1-2345-15
-match %[_~^]%<* firstrated ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1235-1-2345-1246
-match %[_~^]%<* firstrating ([Ss]|['’][Ss])?%>*%[_~^] 124-34-1235-1-2345-346
-match %[_~^]%<* firststring ([Ss]|['’][Ss])?%>*%[_~^] 124-34-34-1235-346
-match %[_~^]%<* forasmuch ([Ss]|['’][Ss])?%>*%[_~^] 123456-1-234-134-16
-match %[_~^]%<* foresaid ([Ss]|['’][Ss])?%>*%[_~^] 123456-15-234-145
-match %[_~^]%<* fosterchildren ([Ss]|['’][Ss])?%>*%[_~^] 124-135-34-12456-16-1345
-match %[_~^]%<* friendless ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-46-234
-match %[_~^]%<* friendlessness ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-46-234-56-234
-match %[_~^]%<* friendlessnesses ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-46-234-56-234-15-234
-match %[_~^]%<* friendlier ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-123-24-12456
-match %[_~^]%<* friendlies ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-123-24-15-234
-match %[_~^]%<* friendliest ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-123-24-15-34
-match %[_~^]%<* friendliness ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-123-24-56-234
-match %[_~^]%<* friendlinesses ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-123-24-56-234-15-234
-match %[_~^]%<* friendly ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-123-13456
-match %[_~^]%<* friendship ([Ss]|['’][Ss])?%>*%[_~^] 124-1235-146-24-1234
-match %[_~^]%<* gadabout ([Ss]|['’][Ss])?%>*%[_~^] 1245-1-145-1-12
-match %[_~^]%<* gainsaid ([Ss]|['’][Ss])?%>*%[_~^] 1245-1-35-234-145
-match %[_~^]%<* galfriend ([Ss]|['’][Ss])?%>*%[_~^] 1245-1-123-124-1235
-match %[_~^]%<* gentlemanfriend ([Ss]|['’][Ss])?%>*%[_~^] 1245-26-2345-123-15-134-1-1345-124-1235
-match %[_~^]%<* gentlemenfriends ([Ss]|['’][Ss])?%>*%[_~^] 1245-26-2345-123-15-134-26-124-1235-234
-match %[_~^]%<* girlfriend ([Ss]|['’][Ss])?%>*%[_~^] 1245-24-1235-123-124-1235
-match %[_~^]%<* godchildren ([Ss]|['’][Ss])?%>*%[_~^] 1245-135-145-16-1345
-match %[_~^]%<* goodafternoon ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-1-124-1345
-match %[_~^]%<* goodby ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-12-13456
-match %[_~^]%<* goodbye ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-12-13456-15
-match %[_~^]%<* goodbyeing ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-12-13456-15-346
-match %[_~^]%<* goodbying ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-12-13456-346
-match %[_~^]%<* goodday ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-5-145
-match %[_~^]%<* gooder ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-12456
-match %[_~^]%<* goodest ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-15-34
-match %[_~^]%<* goodevening ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-15-1236-26-346
-match %[_~^]%<* goodfellow ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-124-15-123-123-246
-match %[_~^]%<* goodfellowship ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-124-15-123-123-246-146-24-1234
-match %[_~^]%<* goodhearted ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-15-345-2345-1246
-match %[_~^]%<* goodheartedly ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-15-345-2345-1246-123-13456
-match %[_~^]%<* goodheartedness ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-15-345-2345-1246-56-234
-match %[_~^]%<* goodhumor ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-135-1235
-match %[_~^]%<* goodhumored ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-135-1235-1246
-match %[_~^]%<* goodhumoredly ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-135-1235-1246-123-13456
-match %[_~^]%<* goodhumoredness ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-135-1235-1246-56-234
-match %[_~^]%<* goodhumorednesses ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-135-1235-1246-56-234-15-234
-match %[_~^]%<* goodhumour ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-1256-1235
-match %[_~^]%<* goodhumoured ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-1256-1235-1246
-match %[_~^]%<* goodhumouredly ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-1256-1235-1246-123-13456
-match %[_~^]%<* goodhumouredness ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-1256-1235-1246-56-234
-match %[_~^]%<* goodhumourednesses ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-125-136-134-1256-1235-1246-56-234-15-234
-match %[_~^]%<* goodie ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-24-15
-match %[_~^]%<* goodish ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-24-146
-match %[_~^]%<* goodlier ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-24-12456
-match %[_~^]%<* goodliest ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-24-15-34
-match %[_~^]%<* goodliness ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-24-56-234
-match %[_~^]%<* goodlook ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-135-135-13
-match %[_~^]%<* goodlooker ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-135-135-13-12456
-match %[_~^]%<* goodlooking ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-135-135-13-346
-match %[_~^]%<* goodly ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-123-13456
-match %[_~^]%<* goodman ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-134-1-1345
-match %[_~^]%<* goodmen ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-134-26
-match %[_~^]%<* goodmorning ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-134-135-1235-1345-346
-match %[_~^]%<* goodnature ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-1345-1-2345-136-1235-15
-match %[_~^]%<* goodnatured ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-1345-1-2345-136-1235-1246
-match %[_~^]%<* goodnaturedly ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-1345-1-2345-136-1235-1246-123-13456
-match %[_~^]%<* goodnaturedness ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-1345-1-2345-136-1235-1246-56-234
-match %[_~^]%<* goodness ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-56-234
-match %[_~^]%<* goodnesses ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-56-234-15-234
-match %[_~^]%<* goodnight ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-1345-24-126-2345
-match %[_~^]%<* goodsize ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-234-24-1356-15
-match %[_~^]%<* goodsized ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-234-24-1356-1246
-match %[_~^]%<* goodtempered ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-2345-15-134-1234-12456-1246
-match %[_~^]%<* goodtemperedly ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-2345-15-134-1234-12456-1246-123-13456
-match %[_~^]%<* goodtime ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-5-2345
-match %[_~^]%<* goodun ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-136-1345
-match %[_~^]%<* goodwife ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-2456-24-124-15
-match %[_~^]%<* goodwill ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-2456-24-123-123
-match %[_~^]%<* goodwilled ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-2456-24-123-123-1246
-match %[_~^]%<* goodwives ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-2456-24-1236-15-234
-match %[_~^]%<* goody ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-13456
-match %[_~^]%<* goodyear ([Ss]|['’][Ss])?%>*%[_~^] 1245-145-13456-15-345
-match %[_~^]%<* grandchildren ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-12346-16-1345
-match %[_~^]%<* greataunt ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1-136-1345-2345
-match %[_~^]%<* greatbatch ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-12-1-2345-16
-match %[_~^]%<* greatcircle ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-14-24-1235-14-123-15
-match %[_~^]%<* greatcoat ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-14-135-1-2345
-match %[_~^]%<* greaten ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-26
-match %[_~^]%<* greatened ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-26-1246
-match %[_~^]%<* greatener ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-26-12456
-match %[_~^]%<* greatening ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-26-346
-match %[_~^]%<* greater ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-12456
-match %[_~^]%<* greatest ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-15-34
-match %[_~^]%<* greatgrandaunt ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-1-136-1345-2345
-match %[_~^]%<* greatgrandchild ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-16-24-123-145
-match %[_~^]%<* greatgrandchildren ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-16-1345
-match %[_~^]%<* greatgranddad ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-145-1-145
-match %[_~^]%<* greatgranddaughter ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-145-1-136-126-2345-12456
-match %[_~^]%<* greatgrandfather ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-5-124
-match %[_~^]%<* greatgrandfatherhood ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-5-124-125-135-135-145
-match %[_~^]%<* greatgrandma ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-134-1
-match %[_~^]%<* greatgrandmother ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-5-134
-match %[_~^]%<* greatgrandmotherhood ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-5-134-125-135-135-145
-match %[_~^]%<* greatgrandnephew ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-1345-15-1234-125-15-2456
-match %[_~^]%<* greatgrandniece ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-1345-24-15-14-15
-match %[_~^]%<* greatgrandpa ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-1234-1
-match %[_~^]%<* greatgrandparent ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-1234-345-26-2345
-match %[_~^]%<* greatgrandparenthood ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-1234-345-26-2345-125-135-135-145
-match %[_~^]%<* greatgrandson ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-234-135-1345
-match %[_~^]%<* greatgranduncle ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1245-1235-12346-136-1345-14-123-15
-match %[_~^]%<* greathearted ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-125-15-345-2345-1246
-match %[_~^]%<* greatheartedly ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-125-15-345-2345-1246-123-13456
-match %[_~^]%<* greatheartedness ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-125-15-345-2345-1246-56-234
-match %[_~^]%<* greatheartednesses ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-125-15-345-2345-1246-56-234-15-234
-match %[_~^]%<* greatly ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-123-13456
-match %[_~^]%<* greatnephew ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1345-15-1234-125-15-2456
-match %[_~^]%<* greatness ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-56-234
-match %[_~^]%<* greatnesses ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-56-234-15-234
-match %[_~^]%<* greatniece ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-1345-24-15-14-15
-match %[_~^]%<* greatsword ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-234-45-2456
-match %[_~^]%<* greatuncle ([Ss]|['’][Ss])?%>*%[_~^] 1245-1235-2345-136-1345-14-123-15
-match %[_~^]%<* guyfriend ([Ss]|['’][Ss])?%>*%[_~^] 1245-136-13456-124-1235
-match %[_~^]%<* hateletter ([Ss]|['’][Ss])?%>*%[_~^] 125-1-2345-15-123-1235
-match %[_~^]%<* headfirst ([Ss]|['’][Ss])?%>*%[_~^] 125-2-145-124-34
-match %[_~^]%<* hereabout ([Ss]|['’][Ss])?%>*%[_~^] 5-125-1-12
-match %[_~^]%<* hereafter ([Ss]|['’][Ss])?%>*%[_~^] 5-125-1-124
-match %[_~^]%<* hereagain ([Ss]|['’][Ss])?%>*%[_~^] 5-125-1-1245
-match %[_~^]%<* hereagainst ([Ss]|['’][Ss])?%>*%[_~^] 5-125-1-1245-34
-match %[_~^]%<* hereinabove ([Ss]|['’][Ss])?%>*%[_~^] 5-125-35-1-12-1236
-match %[_~^]%<* hereinafter ([Ss]|['’][Ss])?%>*%[_~^] 5-125-35-1-124
-match %[_~^]%<* hereinagain ([Ss]|['’][Ss])?%>*%[_~^] 5-125-35-1-1245
-match %[_~^]%<* highlypaid ([Ss]|['’][Ss])?%>*%[_~^] 125-24-126-123-13456-1234-145
-match %[_~^]%<* himbo ([Ss]|['’][Ss])?%>*%[_~^] 125-134-12-135
-match %[_~^]%<* himboes ([Ss]|['’][Ss])?%>*%[_~^] 125-134-12-135-15-234
-match %[_~^]%<* illpaid ([Ss]|['’][Ss])?%>*%[_~^] 24-123-123-1234-145
-match %[_~^]%<* immediately ([Ss]|['’][Ss])?%>*%[_~^] 24-134-134-123-13456
-match %[_~^]%<* immediateness ([Ss]|['’][Ss])?%>*%[_~^] 24-134-134-56-234
-match %[_~^]%<* inasmuch ([Ss]|['’][Ss])?%>*%[_~^] 35-1-234-134-16
-match %[_~^]%<* insomuch ([Ss]|['’][Ss])?%>*%[_~^] 35-234-135-134-16
-match %[_~^]%<* knockabout ([Ss]|['’][Ss])?%>*%[_~^] 13-1345-135-14-13-1-12
-match %[_~^]%<* ladyfriend ([Ss]|['’][Ss])?%>*%[_~^] 123-1-145-13456-124-1235
-match %[_~^]%<* layabout ([Ss]|['’][Ss])?%>*%[_~^] 123-1-13456-1-12
-match %[_~^]%<* letterbodies ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-145-24-15-234
-match %[_~^]%<* letterbody ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-145-13456
-match %[_~^]%<* letterbomb ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-134-12
-match %[_~^]%<* letterbombed ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-134-12-1246
-match %[_~^]%<* letterbomber ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-134-12-12456
-match %[_~^]%<* letterbombing ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-134-12-346
-match %[_~^]%<* letterbox ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-1346
-match %[_~^]%<* letterboxed ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-1346-1246
-match %[_~^]%<* letterboxer ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-1346-12456
-match %[_~^]%<* letterboxes ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-1346-15-234
-match %[_~^]%<* letterboxing ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12-135-1346-346
-match %[_~^]%<* lettered ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-1246
-match %[_~^]%<* letterer ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12456
-match %[_~^]%<* letterform ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-123456-134
-match %[_~^]%<* letterhead ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-125-2-145
-match %[_~^]%<* letterheading ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-125-2-145-346
-match %[_~^]%<* lettering ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-346
-match %[_~^]%<* letterman ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-134-1-1345
-match %[_~^]%<* lettermen ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-134-26
-match %[_~^]%<* letteropener ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-135-1234-26-12456
-match %[_~^]%<* letterperfect ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-1234-12456-124-15-14-2345
-match %[_~^]%<* letterpress ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-1234-1235-15-234-234
-match %[_~^]%<* letterpressed ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-1234-1235-15-234-234-1246
-match %[_~^]%<* letterpresses ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-1234-1235-15-234-234-15-234
-match %[_~^]%<* letterpressing ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-1234-1235-15-234-234-346
-match %[_~^]%<* letterquality ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-12345-136-1-123-56-13456
-match %[_~^]%<* letterspace ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-234-1234-1-14-15
-match %[_~^]%<* letterspaced ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-234-1234-1-14-1246
-match %[_~^]%<* letterspacing ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-234-1234-1-14-346
-match %[_~^]%<* lettertext ([Ss]|['’][Ss])?%>*%[_~^] 123-1235-2345-15-1346-2345
-match %[_~^]%<* littled ([Ss]|['’][Ss])?%>*%[_~^] 123-123-145
-match %[_~^]%<* littleneck ([Ss]|['’][Ss])?%>*%[_~^] 123-123-1345-15-14-13
-match %[_~^]%<* littleness ([Ss]|['’][Ss])?%>*%[_~^] 123-123-56-234
-match %[_~^]%<* littlenesses ([Ss]|['’][Ss])?%>*%[_~^] 123-123-56-234-15-234
-match %[_~^]%<* littler ([Ss]|['’][Ss])?%>*%[_~^] 123-123-1235
-match %[_~^]%<* littlest ([Ss]|['’][Ss])?%>*%[_~^] 123-123-34
-match %[_~^]%<* lovechildren ([Ss]|['’][Ss])?%>*%[_~^] 123-135-1236-15-16-1345
-match %[_~^]%<* loveletter ([Ss]|['’][Ss])?%>*%[_~^] 123-135-1236-15-123-1235
-match %[_~^]%<* lowlypaid ([Ss]|['’][Ss])?%>*%[_~^] 123-246-123-13456-1234-145
-match %[_~^]%<* manfriend ([Ss]|['’][Ss])?%>*%[_~^] 134-1-1345-124-1235
-match %[_~^]%<* menfriends ([Ss]|['’][Ss])?%>*%[_~^] 134-26-124-1235-234
-match %[_~^]%<* midafternoon ([Ss]|['’][Ss])?%>*%[_~^] 134-24-145-1-124-1345
-match %[_~^]%<* misbraille ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-12-1235-123
-match %[_~^]%<* misbrailled ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-12-1235-123-145
-match %[_~^]%<* misperceive ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-1234-12456-14-1236
-match %[_~^]%<* misperceived ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-1234-12456-14-1236-145
-match %[_~^]%<* misperceiver ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-1234-12456-14-1236-1235
-match %[_~^]%<* misperceiving ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-1234-12456-14-1236-1245
-match %[_~^]%<* missaid ([Ss]|['’][Ss])?%>*%[_~^] 134-24-234-234-145
-match %[_~^]%<* morningafter ([Ss]|['’][Ss])?%>*%[_~^] 134-135-1235-1345-346-1-124
-match %[_~^]%<* muchly ([Ss]|['’][Ss])?%>*%[_~^] 134-16-123-13456
-match %[_~^]%<* muchness ([Ss]|['’][Ss])?%>*%[_~^] 134-16-56-234
-match %[_~^]%<* must’ve ([Ss]|['’][Ss])?%>*%[_~^] 134-34-3-1236-15
-match %[_~^]%<* must've ([Ss]|['’][Ss])?%>*%[_~^] 134-34-3-1236-15
-match %[_~^]%<* musta ([Ss]|['’][Ss])?%>*%[_~^] 134-34-1
-match %[_~^]%<* mustard ([Ss]|['’][Ss])?%>*%[_~^] 134-34-345-145
-match %[_~^]%<* mustardy ([Ss]|['’][Ss])?%>*%[_~^] 134-34-345-145-13456
-match %[_~^]%<* mustier ([Ss]|['’][Ss])?%>*%[_~^] 134-34-24-12456
-match %[_~^]%<* mustiest ([Ss]|['’][Ss])?%>*%[_~^] 134-34-24-15-34
-match %[_~^]%<* mustily ([Ss]|['’][Ss])?%>*%[_~^] 134-34-24-123-13456
-match %[_~^]%<* mustiness ([Ss]|['’][Ss])?%>*%[_~^] 134-34-24-56-234
-match %[_~^]%<* mustn’t ([Ss]|['’][Ss])?%>*%[_~^] 134-34-1345-3-2345
-match %[_~^]%<* mustn't ([Ss]|['’][Ss])?%>*%[_~^] 134-34-1345-3-2345
-match %[_~^]%<* mustn’t’ve ([Ss]|['’][Ss])?%>*%[_~^] 134-34-1345-3-2345-3-1236-15
-match %[_~^]%<* mustn't've ([Ss]|['’][Ss])?%>*%[_~^] 134-34-1345-3-2345-3-1236-15
-match %[_~^]%<* musty ([Ss]|['’][Ss])?%>*%[_~^] 134-34-13456
-match %[_~^]%<* newsletter ([Ss]|['’][Ss])?%>*%[_~^] 1345-15-2456-234-123-1235
-match %[_~^]%<* nonesuch ([Ss]|['’][Ss])?%>*%[_~^] 1345-5-135-234-16
-match %[_~^]%<* nonsuch ([Ss]|['’][Ss])?%>*%[_~^] 1345-135-1345-234-16
-match %[_~^]%<* northabout ([Ss]|['’][Ss])?%>*%[_~^] 1345-135-1235-1456-1-12
-match %[_~^]%<* overmuch ([Ss]|['’][Ss])?%>*%[_~^] 135-1236-12456-134-16
-match %[_~^]%<* overpaid ([Ss]|['’][Ss])?%>*%[_~^] 135-1236-12456-1234-145
-match %[_~^]%<* penfriend ([Ss]|['’][Ss])?%>*%[_~^] 1234-26-124-1235
-match %[_~^]%<* perceived ([Ss]|['’][Ss])?%>*%[_~^] 1234-12456-14-1236-145
-match %[_~^]%<* perceiver ([Ss]|['’][Ss])?%>*%[_~^] 1234-12456-14-1236-1235
-match %[_~^]%<* perhapses ([Ss]|['’][Ss])?%>*%[_~^] 1234-12456-125-15-234
-match %[_~^]%<* poorlypaid ([Ss]|['’][Ss])?%>*%[_~^] 1234-135-135-1235-123-13456-1234-145
-match %[_~^]%<* postpaid ([Ss]|['’][Ss])?%>*%[_~^] 1234-135-34-1234-145
-match %[_~^]%<* preceive ([Ss]|['’][Ss])?%>*%[_~^] 1234-1235-14-1236
-match %[_~^]%<* preceiver ([Ss]|['’][Ss])?%>*%[_~^] 1234-1235-14-1236-1235
-match %[_~^]%<* preceiving ([Ss]|['’][Ss])?%>*%[_~^] 1234-1235-14-1236-1245
-match %[_~^]%<* prepaid ([Ss]|['’][Ss])?%>*%[_~^] 1234-1235-15-1234-145
-match %[_~^]%<* purblind ([Ss]|['’][Ss])?%>*%[_~^] 1234-136-1235-12-123
-match %[_~^]%<* purblindly ([Ss]|['’][Ss])?%>*%[_~^] 1234-136-1235-12-123-123-13456
-match %[_~^]%<* purblindness ([Ss]|['’][Ss])?%>*%[_~^] 1234-136-1235-12-123-56-234
-match %[_~^]%<* purblindnesses ([Ss]|['’][Ss])?%>*%[_~^] 1234-136-1235-12-123-56-234-15-234
-match %[_~^]%<* quickdraw ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-145-1235-1-2456
-match %[_~^]%<* quicken ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-26
-match %[_~^]%<* quickened ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-26-1246
-match %[_~^]%<* quickener ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-26-12456
-match %[_~^]%<* quickening ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-26-346
-match %[_~^]%<* quicker ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-12456
-match %[_~^]%<* quickest ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-15-34
-match %[_~^]%<* quickfire ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-124-24-1235-15
-match %[_~^]%<* quickfiring ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-124-24-1235-346
-match %[_~^]%<* quickfreeze ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-124-1235-15-15-1356-15
-match %[_~^]%<* quickfreezing ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-124-1235-15-15-1356-346
-match %[_~^]%<* quickfroze ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-124-1235-135-1356-15
-match %[_~^]%<* quickfrozen ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-124-1235-135-1356-26
-match %[_~^]%<* quickie ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-24-15
-match %[_~^]%<* quickish ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-24-146
-match %[_~^]%<* quickishly ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-24-146-123-13456
-match %[_~^]%<* quicklime ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-123-24-134-15
-match %[_~^]%<* quickly ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-123-13456
-match %[_~^]%<* quickness ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-56-234
-match %[_~^]%<* quicknesses ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-56-234-15-234
-match %[_~^]%<* quicksand ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-234-12346
-match %[_~^]%<* quickset ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-234-15-2345
-match %[_~^]%<* quicksilver ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-234-24-123-1236-12456
-match %[_~^]%<* quicksilvered ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-234-24-123-1236-12456-1246
-match %[_~^]%<* quicksilvering ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-234-24-123-1236-12456-346
-match %[_~^]%<* quicksnap ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-234-1345-1-1234
-match %[_~^]%<* quickstep ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-34-15-1234
-match %[_~^]%<* quickstepped ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-34-15-1234-1234-1246
-match %[_~^]%<* quickstepper ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-34-15-1234-1234-12456
-match %[_~^]%<* quickstepping ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-34-15-1234-1234-346
-match %[_~^]%<* quicktempered ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-2345-15-134-1234-12456-1246
-match %[_~^]%<* quicktime ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-5-2345
-match %[_~^]%<* quickwitted ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-2456-24-2345-2345-1246
-match %[_~^]%<* quickwittedly ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-2456-24-2345-2345-1246-123-13456
-match %[_~^]%<* quickwittedness ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-2456-24-2345-2345-1246-56-234
-match %[_~^]%<* quicky ([Ss]|['’][Ss])?%>*%[_~^] 12345-13-13456
-match %[_~^]%<* readacross ([Ss]|['’][Ss])?%>*%[_~^] 1235-2-145-1-14-1235
-match %[_~^]%<* rebraille ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-12-1235-123
-match %[_~^]%<* rebrailled ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-12-1235-123-145
-match %[_~^]%<* rebrailler ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-12-1235-123-1235
-match %[_~^]%<* received ([Ss]|['’][Ss])?%>*%[_~^] 1235-14-1236-145
-match %[_~^]%<* receiver ([Ss]|['’][Ss])?%>*%[_~^] 1235-14-1236-1235
-match %[_~^]%<* receivership ([Ss]|['’][Ss])?%>*%[_~^] 1235-14-1236-1235-146-24-1234
-match %[_~^]%<* rejoiced ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-145
-match %[_~^]%<* rejoiceful ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-56-123
-match %[_~^]%<* rejoicefully ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-56-123-123-13456
-match %[_~^]%<* rejoicefulness ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-56-123-56-234
-match %[_~^]%<* rejoicer ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-1235
-match %[_~^]%<* rejoicingly ([Ss]|['’][Ss])?%>*%[_~^] 1235-245-14-1245-123-13456
-match %[_~^]%<* reletter ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-123-1235
-match %[_~^]%<* relettered ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-123-1235-1246
-match %[_~^]%<* relettering ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-123-1235-346
-match %[_~^]%<* repaid ([Ss]|['’][Ss])?%>*%[_~^] 1235-15-1234-145
-match %[_~^]%<* rightabout ([Ss]|['’][Ss])?%>*%[_~^] 5-1235-1-12
-match %[_~^]%<* roundabout ([Ss]|['’][Ss])?%>*%[_~^] 1235-46-145-1-12
-match %[_~^]%<* roustabout ([Ss]|['’][Ss])?%>*%[_~^] 1235-1256-34-1-12
-match %[_~^]%<* runabout ([Ss]|['’][Ss])?%>*%[_~^] 1235-136-1345-1-12
-match %[_~^]%<* saidest ([Ss]|['’][Ss])?%>*%[_~^] 234-145-15-34
-match %[_~^]%<* saidst ([Ss]|['’][Ss])?%>*%[_~^] 234-145-34
-match %[_~^]%<* scattergood ([Ss]|['’][Ss])?%>*%[_~^] 234-14-1-2345-2345-12456-1245-145
-match %[_~^]%<* schoolchildren ([Ss]|['’][Ss])?%>*%[_~^] 234-16-135-135-123-16-1345
-match %[_~^]%<* schoolfriend ([Ss]|['’][Ss])?%>*%[_~^] 234-16-135-135-123-124-1235
-match %[_~^]%<* should’ve ([Ss]|['’][Ss])?%>*%[_~^] 146-145-3-1236-15
-match %[_~^]%<* should've ([Ss]|['’][Ss])?%>*%[_~^] 146-145-3-1236-15
-match %[_~^]%<* shoulda ([Ss]|['’][Ss])?%>*%[_~^] 146-145-1
-match %[_~^]%<* shouldest ([Ss]|['’][Ss])?%>*%[_~^] 146-145-15-34
-match %[_~^]%<* shouldn’t ([Ss]|['’][Ss])?%>*%[_~^] 146-145-1345-3-2345
-match %[_~^]%<* shouldn't ([Ss]|['’][Ss])?%>*%[_~^] 146-145-1345-3-2345
-match %[_~^]%<* shouldn’t’ve ([Ss]|['’][Ss])?%>*%[_~^] 146-145-1345-3-2345-3-1236-15
-match %[_~^]%<* shouldn't've ([Ss]|['’][Ss])?%>*%[_~^] 146-145-1345-3-2345-3-1236-15
-match %[_~^]%<* shouldst ([Ss]|['’][Ss])?%>*%[_~^] 146-145-34
-match %[_~^]%<* snowblind ([Ss]|['’][Ss])?%>*%[_~^] 234-1345-246-12-123
-match %[_~^]%<* snowblindness ([Ss]|['’][Ss])?%>*%[_~^] 234-1345-246-12-123-56-234
-match %[_~^]%<* snowblindnesses ([Ss]|['’][Ss])?%>*%[_~^] 234-1345-246-12-123-56-234-15-234
-match %[_~^]%<* somesuch ([Ss]|['’][Ss])?%>*%[_~^] 5-234-234-16
-match %[_~^]%<* southabout ([Ss]|['’][Ss])?%>*%[_~^] 234-1256-1456-1-12
-match %[_~^]%<* stepchildren ([Ss]|['’][Ss])?%>*%[_~^] 34-15-1234-16-1345
-match %[_~^]%<* stirabout ([Ss]|['’][Ss])?%>*%[_~^] 34-24-1235-1-12
-match %[_~^]%<* suchlike ([Ss]|['’][Ss])?%>*%[_~^] 234-16-123-24-13-15
-match %[_~^]%<* supergood ([Ss]|['’][Ss])?%>*%[_~^] 234-136-1234-12456-1245-145
-match %[_~^]%<* superquick ([Ss]|['’][Ss])?%>*%[_~^] 234-136-1234-12456-12345-13
-match %[_~^]%<* tailfirst ([Ss]|['’][Ss])?%>*%[_~^] 2345-1-24-123-124-34
-match %[_~^]%<* thereabout ([Ss]|['’][Ss])?%>*%[_~^] 5-2346-1-12
-match %[_~^]%<* thereafter ([Ss]|['’][Ss])?%>*%[_~^] 5-2346-1-124
-match %[_~^]%<* thereagain ([Ss]|['’][Ss])?%>*%[_~^] 5-2346-1-1245
-match %[_~^]%<* thereagainst ([Ss]|['’][Ss])?%>*%[_~^] 5-2346-1-1245-34
-match %[_~^]%<* thereinafter ([Ss]|['’][Ss])?%>*%[_~^] 5-2346-35-1-124
-match %[_~^]%<* thereinagain ([Ss]|['’][Ss])?%>*%[_~^] 5-2346-35-1-1245
-match %[_~^]%<* togetherness ([Ss]|['’][Ss])?%>*%[_~^] 2345-1245-1235-56-234
-match %[_~^]%<* turnabout ([Ss]|['’][Ss])?%>*%[_~^] 2345-136-1235-1345-1-12
-match %[_~^]%<* unaccording ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1-14
-match %[_~^]%<* unaccordingly ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1-14-123-13456
-match %[_~^]%<* unblindfold ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-12-123-124-135-123-145
-match %[_~^]%<* unblindfolded ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-12-123-124-135-123-145-1246
-match %[_~^]%<* unblindfolding ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-12-123-124-135-123-145-346
-match %[_~^]%<* unbraille ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-12-1235-123
-match %[_~^]%<* unbrailled ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-12-1235-123-145
-match %[_~^]%<* undeceive ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-145-14-1236
-match %[_~^]%<* undeceived ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-145-14-1236-145
-match %[_~^]%<* undeceiver ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-145-14-1236-1235
-match %[_~^]%<* undeceiving ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-145-14-1236-1245
-match %[_~^]%<* undeclare ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-145-14-123
-match %[_~^]%<* undeclared ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-145-14-123-145
-match %[_~^]%<* underpaid ([Ss]|['’][Ss])?%>*%[_~^] 5-136-1234-145
-match %[_~^]%<* unfriend ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-124-1235
-match %[_~^]%<* unfriendlier ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-124-1235-123-24-12456
-match %[_~^]%<* unfriendliest ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-124-1235-123-24-15-34
-match %[_~^]%<* unfriendliness ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-124-1235-123-24-56-234
-match %[_~^]%<* unfriendlinesses ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-124-1235-123-24-56-234-15-234
-match %[_~^]%<* unfriendly ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-124-1235-123-13456
-match %[_~^]%<* unlettered ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-123-1235-1246
-match %[_~^]%<* unnecessary ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1345-15-14
-match %[_~^]%<* unpaid ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1234-145
-match %[_~^]%<* unperceive ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1234-12456-14-1236
-match %[_~^]%<* unperceived ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1234-12456-14-1236-145
-match %[_~^]%<* unperceiving ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1234-12456-14-1236-1245
-match %[_~^]%<* unquick ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-12345-13
-match %[_~^]%<* unreceived ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-14-1236-145
-match %[_~^]%<* unrejoice ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14
-match %[_~^]%<* unrejoiced ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-145
-match %[_~^]%<* unrejoiceful ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-56-123
-match %[_~^]%<* unrejoicefully ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-56-123-123-13456
-match %[_~^]%<* unrejoicefulness ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-56-123-56-234
-match %[_~^]%<* unrejoicer ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-1235
-match %[_~^]%<* unrejoicing ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-1245
-match %[_~^]%<* unrejoicingly ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-245-14-1245-123-13456
-match %[_~^]%<* unrepaid ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-1235-15-1234-145
-match %[_~^]%<* unsaid   ([Ss]|['’][Ss])?%>*%[_~^] 136-1345-234-145
-match %[_~^]%<* walkabout ([Ss]|['’][Ss])?%>*%[_~^] 2456-1-123-13-1-12
-match %[_~^]%<* wellpaid ([Ss]|['’][Ss])?%>*%[_~^] 2456-15-123-123-1234-145
-match %[_~^]%<* westabout ([Ss]|['’][Ss])?%>*%[_~^] 2456-15-34-1-12
-match %[_~^]%<* whereabout ([Ss]|['’][Ss])?%>*%[_~^] 5-156-1-12
-match %[_~^]%<* whereafter ([Ss]|['’][Ss])?%>*%[_~^] 5-156-1-124
-match %[_~^]%<* whereagain ([Ss]|['’][Ss])?%>*%[_~^] 5-156-1-1245
-match %[_~^]%<* whereagainst ([Ss]|['’][Ss])?%>*%[_~^] 5-156-1-1245-34
-match %[_~^]%<* whereinafter ([Ss]|['’][Ss])?%>*%[_~^] 5-156-35-1-124
-match %[_~^]%<* whereinagain ([Ss]|['’][Ss])?%>*%[_~^] 5-156-35-1-1245
-match %[_~^]%<* womanfriend ([Ss]|['’][Ss])?%>*%[_~^] 2456-135-134-1-1345-124-1235
-match %[_~^]%<* womenfriends ([Ss]|['’][Ss])?%>*%[_~^] 2456-135-134-26-124-1235-234
-match %[_~^]%<* would’ve ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-3-1236-15
-match %[_~^]%<* would've ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-3-1236-15
-match %[_~^]%<* woulda ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-1
-match %[_~^]%<* wouldest ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-15-34
-match %[_~^]%<* wouldn’t ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-1345-3-2345
-match %[_~^]%<* wouldn't ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-1345-3-2345
-match %[_~^]%<* wouldn’t’ve ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-1345-3-2345-3-1236-15
-match %[_~^]%<* wouldn't've ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-1345-3-2345-3-1236-15
-match %[_~^]%<* wouldst ([Ss]|['’][Ss])?%>*%[_~^] 2456-145-34
 
 match %[_~^]%<* whereabouts (['’][Ss])?%>*%[_~^] 5-156-1-12-234
 
-nofor word 'twould  3-2345-2456-145
-nofor word 'twould've  3-2345-2456-145-3-1236-15
-nofor word 'twoulda  3-2345-2456-145-1
-nofor word 'twouldn't  3-2345-2456-145-1345-3-2345
-nofor word 'twouldn't've  3-2345-2456-145-1345-3-2345-3-1236-15
-nofor word aboutface  1-12-124-1-14-15
-nofor word aboutfaced  1-12-124-1-14-1246
-nofor word aboutfacer  1-12-124-1-14-12456
-nofor word aboutfacing  1-12-124-1-14-346
-nofor word aboutturn  1-12-2345-136-1235-1345
-nofor word aboutturned  1-12-2345-136-1235-1345-1246
-nofor word aboveboard  1-12-1236-12-135-345-145
-nofor word aboveground  1-12-1236-1245-1235-46-145
-nofor word abovementioned  1-12-1236-134-26-56-1345-1246
-nofor word accordingly  1-14-123-13456
-nofor word aforesaid  1-123456-15-234-145
-nofor word afterbattle  1-124-12-1-2345-2345-123-15
-nofor word afterbirth  1-124-12-24-1235-1456
-nofor word afterbreakfast  1-124-12-1235-2-13-124-1-34
-nofor word afterburn  1-124-12-136-1235-1345
-nofor word afterburned  1-124-12-136-1235-1345-1246
-nofor word afterburner  1-124-12-136-1235-1345-12456
-nofor word afterburning  1-124-12-136-1235-1345-346
-nofor word aftercare  1-124-14-345-15
-nofor word afterclap  1-124-14-123-1-1234
-nofor word aftercoffee  1-124-14-12356-124-15-15
-nofor word afterdamp  1-124-145-1-134-1234
-nofor word afterdark  1-124-145-345-13
-nofor word afterdeck  1-124-145-15-14-13
-nofor word afterdinner  1-124-145-35-1345-12456
-nofor word afterflow  1-124-124-123-246
-nofor word aftergame  1-124-1245-1-134-15
-nofor word afterglow  1-124-1245-123-246
-nofor word afterguard  1-124-1245-136-345-145
-nofor word afterhatch  1-124-125-1-2345-16
-nofor word afterhatches  1-124-125-1-2345-16-15-234
-nofor word afterhour  1-124-125-1256-1235
-nofor word afterlife  1-124-123-24-124-15
-nofor word afterlight  1-124-123-24-126-2345
-nofor word afterlives  1-124-123-24-1236-15-234
-nofor word afterlunch  1-124-123-136-1345-16
-nofor word afterlunches  1-124-123-136-1345-16-15-234
-nofor word aftermarket  1-124-134-345-13-15-2345
-nofor word aftermatch 1-124-134-1-2345-16
-nofor word aftermatches  1-124-134-1-2345-16-15-234
-nofor word aftermath  1-124-134-1-1456
-nofor word aftermeeting  1-124-134-15-15-2345-346
-nofor word aftermentioned  1-124-134-26-56-1345-1246
-nofor word aftermidday  1-124-134-24-145-5-145
-nofor word aftermidnight  1-124-134-24-145-1345-24-126-2345
-nofor word aftermost  1-124-134-135-34
-nofor word afternoontea  1-124-1345-2345-15-1
-nofor word afterpain  1-124-1234-1-35
-nofor word afterparties  1-124-5-1234-24-15-234
-nofor word afterparty  1-124-5-1234-13456
-nofor word afterpiece  1-124-1234-24-15-14-15
-nofor word afterplay  1-124-1234-123-1-13456
-nofor word aftersale  1-124-234-1-123-15
-nofor word afterschool  1-124-234-16-135-135-123
-nofor word aftersensation  1-124-234-26-234-1-56-1345
-nofor word aftershave  1-124-146-1-1236-15
-nofor word aftershock  1-124-146-135-14-13
-nofor word aftershow  1-124-146-246
-nofor word aftershower  1-124-146-246-12456
-nofor word aftersupper  1-124-234-136-1234-1234-12456
-nofor word aftertaste  1-124-2345-1-34-15
-nofor word aftertax  1-124-2345-1-1346
-nofor word aftertaxes  1-124-2345-1-1346-15-234
-nofor word aftertea  1-124-2345-15-1
-nofor word aftertheater  1-124-2346-1-2345-12456
-nofor word aftertheatre  1-124-2346-1-2345-1235-15
-nofor word afterthought  1-124-1456-5-1256
-nofor word aftertime  1-124-5-2345
-nofor word aftertreatment  1-124-2345-1235-2-2345-56-2345
-nofor word afterword  1-124-45-2456
-nofor word afterwork  1-124-5-2456
-nofor word afterworld  1-124-456-2456
-nofor word apperceive  1-1234-1234-12456-14-1236
-nofor word apperceived  1-1234-1234-12456-14-1236-145
-nofor word apperceiver  1-1234-1234-12456-14-1236-1235
-nofor word apperceiving  1-1234-1234-12456-14-1236-1245
-nofor word archdeceiver  345-16-145-14-1236-1235
-nofor word beforehand  23-124-125-12346
-nofor word beforementioned  23-124-134-26-56-1345-1246
-nofor word befriend  23-124-1235
-nofor word behindhand  23-125-125-12346
-nofor word belittle  23-123-123
-nofor word belittled  23-123-123-145
-nofor word belittlement  23-123-123-56-2345
-nofor word belittler  23-123-123-1235
-nofor word belowdeck  23-123-145-15-14-13
-nofor word belowground  23-123-1245-1235-46-145
-nofor word belowmentioned  23-123-134-26-56-1345-1246
-nofor word beneathdeck  23-1345-145-15-14-13
-nofor word beneathground  23-1345-1245-1235-46-145
-nofor word betweendeck  23-2345-145-15-14-13
-nofor word betweentime  23-2345-5-2345
-nofor word betweenwhile  23-2345-156-24-123-15
-nofor word blindfish  12-123-124-24-146
-nofor word blindfishes  12-123-124-24-146-15-234
-nofor word blindfold  12-123-124-135-123-145
-nofor word blindfolded  12-123-124-135-123-145-1246
-nofor word blindfolder  12-123-124-135-123-145-12456
-nofor word blindfolding  12-123-124-135-123-145-346
-nofor word blindly  12-123-123-13456
-nofor word blindman  12-123-134-1-1345
-nofor word blindmen  12-123-134-26
-nofor word blindness  12-123-56-234
-nofor word blindnesses  12-123-56-234-15-234
-nofor word blindside  12-123-234-24-145-15
-nofor word blindsided  12-123-234-24-145-1246
-nofor word blindsider  12-123-234-24-145-12456
-nofor word blindsiding  12-123-234-24-145-346
-nofor word blindsight  12-123-234-24-126-2345
-nofor word blindstories  12-123-34-135-1235-24-15-234
-nofor word blindstory  12-123-34-135-1235-13456
-nofor word blindworm  12-123-2456-135-1235-134
-nofor word bloodletter  12-123-135-135-145-123-1235
-nofor word boyfriend  12-135-13456-124-1235
-nofor word brailled  12-1235-123-145
-nofor word brailler  12-1235-123-1235
-nofor word braillewriter  12-1235-123-2456-1235-24-2345-12456
-nofor word braillewriting  12-1235-123-2456-1235-24-2345-346
-nofor word brailley  12-1235-123-13456
-nofor word brainchildren  12-1235-1-35-16-1345
-nofor word chainletter  16-1-35-123-1235
-nofor word children'swear  16-1345-3-234-2456-15-345
-nofor word colorblind  14-135-123-135-1235-12-123
-nofor word colorblindness  14-135-123-135-1235-12-123-56-234
-nofor word colorblindnesses  14-135-123-135-1235-12-123-56-234-15-234
-nofor word colourblind  14-135-123-1256-1235-12-123
-nofor word colourblindness  14-135-123-1256-1235-12-123-56-234
-nofor word colourblindnesses  14-135-123-1256-1235-12-123-56-234-15-234
-nofor word conceived  25-14-1236-145
-nofor word conceiver  25-14-1236-1235
-nofor word could've  14-145-3-1236-15
-nofor word coulda  14-145-1
-nofor word couldest  14-145-15-34
-nofor word couldn't  14-145-1345-3-2345
-nofor word couldn't've  14-145-1345-3-2345-3-1236-15
-nofor word couldst  14-145-34
-nofor word deafblind  145-2-124-12-123
-nofor word deafblindness  145-2-124-12-123-56-234
-nofor word deafblindnesses  145-2-124-12-123-56-234-15-234
-nofor word deceived  145-14-1236-145
-nofor word deceiver  145-14-1236-1235
-nofor word declared  145-14-123-145
-nofor word declarer  145-14-123-1235
-nofor word defriend  145-15-124-1235
-nofor word do-it-yourselfer  145-36-1346-36-13456-1235-124-12456
-nofor word doublequick  145-1256-12-123-15-12345-13
-nofor word eastabout  15-1-34-1-12
-nofor word feelgood  124-15-15-123-1245-145
-nofor word feetfirst  124-15-15-2345-124-34
-nofor word firstaid  124-34-1-24-145
-nofor word firstaider  124-34-1-24-145-12456
-nofor word firstborn  124-34-12-135-1235-1345
-nofor word firstclass  124-34-14-123-1-234-234
-nofor word firstclasses  124-34-14-123-1-234-234-15-234
-nofor word firstday  124-34-5-145
-nofor word firstdayer  124-34-5-145-12456
-nofor word firstfruit  124-34-124-1235-136-24-2345
-nofor word firstfruiting  124-34-124-1235-136-24-2345-346
-nofor word firstgeneration  124-34-1245-26-12456-1-56-1345
-nofor word firsthand  124-34-125-12346
-nofor word firsthanded  124-34-125-12346-1246
-nofor word firstling  124-34-123-346
-nofor word firstly  124-34-123-13456
-nofor word firstness  124-34-56-234
-nofor word firstnight  124-34-1345-24-126-2345
-nofor word firstnighter  124-34-1345-24-126-2345-12456
-nofor word firstrate  124-34-1235-1-2345-15
-nofor word firstrated  124-34-1235-1-2345-1246
-nofor word firstrating  124-34-1235-1-2345-346
-nofor word firststring  124-34-34-1235-346
-nofor word forasmuch  123456-1-234-134-16
-nofor word foresaid  123456-15-234-145
-nofor word fosterchildren  124-135-34-12456-16-1345
-nofor word friendless  124-1235-46-234
-nofor word friendlessness  124-1235-46-234-56-234
-nofor word friendlessnesses  124-1235-46-234-56-234-15-234
-nofor word friendlier  124-1235-123-24-12456
-nofor word friendlies  124-1235-123-24-15-234
-nofor word friendliest  124-1235-123-24-15-34
-nofor word friendliness  124-1235-123-24-56-234
-nofor word friendlinesses  124-1235-123-24-56-234-15-234
-nofor word friendly  124-1235-123-13456
-nofor word friendship  124-1235-146-24-1234
-nofor word gadabout  1245-1-145-1-12
-nofor word gainsaid  1245-1-35-234-145
-nofor word galfriend  1245-1-123-124-1235
-nofor word gentlemanfriend  1245-26-2345-123-15-134-1-1345-124-1235
-nofor word gentlemenfriends  1245-26-2345-123-15-134-26-124-1235-234
-nofor word girlfriend  1245-24-1235-123-124-1235
-nofor word godchildren  1245-135-145-16-1345
-nofor word goodafternoon  1245-145-1-124-1345
-nofor word goodby  1245-145-12-13456
-nofor word goodbye  1245-145-12-13456-15
-nofor word goodbyeing  1245-145-12-13456-15-346
-nofor word goodbying  1245-145-12-13456-346
-nofor word goodday  1245-145-5-145
-nofor word gooder  1245-145-12456
-nofor word goodest  1245-145-15-34
-nofor word goodevening  1245-145-15-1236-26-346
-nofor word goodfellow  1245-145-124-15-123-123-246
-nofor word goodfellowship  1245-145-124-15-123-123-246-146-24-1234
-nofor word goodhearted  1245-145-125-15-345-2345-1246
-nofor word goodheartedly  1245-145-125-15-345-2345-1246-123-13456
-nofor word goodheartedness  1245-145-125-15-345-2345-1246-56-234
-nofor word goodhumor  1245-145-125-136-134-135-1235
-nofor word goodhumored  1245-145-125-136-134-135-1235-1246
-nofor word goodhumoredly  1245-145-125-136-134-135-1235-1246-123-13456
-nofor word goodhumoredness  1245-145-125-136-134-135-1235-1246-56-234
-nofor word goodhumorednesses  1245-145-125-136-134-135-1235-1246-56-234-15-234
-nofor word goodhumour  1245-145-125-136-134-1256-1235
-nofor word goodhumoured  1245-145-125-136-134-1256-1235-1246
-nofor word goodhumouredly  1245-145-125-136-134-1256-1235-1246-123-13456
-nofor word goodhumouredness  1245-145-125-136-134-1256-1235-1246-56-234
-nofor word goodhumourednesses  1245-145-125-136-134-1256-1235-1246-56-234-15-234
-nofor word goodie  1245-145-24-15
-nofor word goodish  1245-145-24-146
-nofor word goodlier  1245-145-123-24-12456
-nofor word goodliest  1245-145-123-24-15-34
-nofor word goodliness  1245-145-123-24-56-234
-nofor word goodlook  1245-145-123-135-135-13
-nofor word goodlooker  1245-145-123-135-135-13-12456
-nofor word goodlooking  1245-145-123-135-135-13-346
-nofor word goodly  1245-145-123-13456
-nofor word goodman  1245-145-134-1-1345
-nofor word goodmen  1245-145-134-26
-nofor word goodmorning  1245-145-134-135-1235-1345-346
-nofor word goodnature  1245-145-1345-1-2345-136-1235-15
-nofor word goodnatured  1245-145-1345-1-2345-136-1235-1246
-nofor word goodnaturedly  1245-145-1345-1-2345-136-1235-1246-123-13456
-nofor word goodnaturedness  1245-145-1345-1-2345-136-1235-1246-56-234
-nofor word goodness  1245-145-56-234
-nofor word goodnesses  1245-145-56-234-15-234
-nofor word goodnight  1245-145-1345-24-126-2345
-nofor word goodsize  1245-145-234-24-1356-15
-nofor word goodsized  1245-145-234-24-1356-1246
-nofor word goodtempered  1245-145-2345-15-134-1234-12456-1246
-nofor word goodtemperedly  1245-145-2345-15-134-1234-12456-1246-123-13456
-nofor word goodtime  1245-145-5-2345
-nofor word goodun  1245-145-136-1345
-nofor word goodwife  1245-145-2456-24-124-15
-nofor word goodwill  1245-145-2456-24-123-123
-nofor word goodwilled  1245-145-2456-24-123-123-1246
-nofor word goodwives  1245-145-2456-24-1236-15-234
-nofor word goody  1245-145-13456
-nofor word goodyear  1245-145-13456-15-345
-nofor word grandchildren  1245-1235-12346-16-1345
-nofor word greataunt  1245-1235-2345-1-136-1345-2345
-nofor word greatbatch  1245-1235-2345-12-1-2345-16
-nofor word greatcircle  1245-1235-2345-14-24-1235-14-123-15
-nofor word greatcoat  1245-1235-2345-14-135-1-2345
-nofor word greaten  1245-1235-2345-26
-nofor word greatened  1245-1235-2345-26-1246
-nofor word greatener  1245-1235-2345-26-12456
-nofor word greatening  1245-1235-2345-26-346
-nofor word greater  1245-1235-2345-12456
-nofor word greatest  1245-1235-2345-15-34
-nofor word greatgrandaunt  1245-1235-2345-1245-1235-12346-1-136-1345-2345
-nofor word greatgrandchild  1245-1235-2345-1245-1235-12346-16-24-123-145
-nofor word greatgrandchildren  1245-1235-2345-1245-1235-12346-16-1345
-nofor word greatgranddad  1245-1235-2345-1245-1235-12346-145-1-145
-nofor word greatgranddaughter  1245-1235-2345-1245-1235-12346-145-1-136-126-2345-12456
-nofor word greatgrandfather  1245-1235-2345-1245-1235-12346-5-124
-nofor word greatgrandfatherhood  1245-1235-2345-1245-1235-12346-5-124-125-135-135-145
-nofor word greatgrandma  1245-1235-2345-1245-1235-12346-134-1
-nofor word greatgrandmother  1245-1235-2345-1245-1235-12346-5-134
-nofor word greatgrandmotherhood  1245-1235-2345-1245-1235-12346-5-134-125-135-135-145
-nofor word greatgrandnephew  1245-1235-2345-1245-1235-12346-1345-15-1234-125-15-2456
-nofor word greatgrandniece  1245-1235-2345-1245-1235-12346-1345-24-15-14-15
-nofor word greatgrandpa  1245-1235-2345-1245-1235-12346-1234-1
-nofor word greatgrandparent  1245-1235-2345-1245-1235-12346-1234-345-26-2345
-nofor word greatgrandparenthood  1245-1235-2345-1245-1235-12346-1234-345-26-2345-125-135-135-145
-nofor word greatgrandson  1245-1235-2345-1245-1235-12346-234-135-1345
-nofor word greatgranduncle  1245-1235-2345-1245-1235-12346-136-1345-14-123-15
-nofor word greathearted  1245-1235-2345-125-15-345-2345-1246
-nofor word greatheartedly  1245-1235-2345-125-15-345-2345-1246-123-13456
-nofor word greatheartedness  1245-1235-2345-125-15-345-2345-1246-56-234
-nofor word greatheartednesses  1245-1235-2345-125-15-345-2345-1246-56-234-15-234
-nofor word greatly  1245-1235-2345-123-13456
-nofor word greatnephew  1245-1235-2345-1345-15-1234-125-15-2456
-nofor word greatness  1245-1235-2345-56-234
-nofor word greatnesses  1245-1235-2345-56-234-15-234
-nofor word greatniece  1245-1235-2345-1345-24-15-14-15
-nofor word greatsword  1245-1235-2345-234-45-2456
-nofor word greatuncle  1245-1235-2345-136-1345-14-123-15
-nofor word guyfriend  1245-136-13456-124-1235
-nofor word hateletter  125-1-2345-15-123-1235
-nofor word headfirst  125-2-145-124-34
-nofor word hereabout  5-125-1-12
-nofor word hereafter  5-125-1-124
-nofor word hereagain  5-125-1-1245
-nofor word hereagainst  5-125-1-1245-34
-nofor word hereinabove  5-125-35-1-12-1236
-nofor word hereinafter  5-125-35-1-124
-nofor word hereinagain  5-125-35-1-1245
-nofor word highlypaid  125-24-126-123-13456-1234-145
-nofor word himbo  125-134-12-135
-nofor word himboes  125-134-12-135-15-234
-nofor word illpaid  24-123-123-1234-145
-nofor word immediately  24-134-134-123-13456
-nofor word immediateness  24-134-134-56-234
-nofor word inasmuch  35-1-234-134-16
-nofor word insomuch  35-234-135-134-16
-nofor word knockabout  13-1345-135-14-13-1-12
-nofor word ladyfriend  123-1-145-13456-124-1235
-nofor word layabout  123-1-13456-1-12
-nofor word letterbodies  123-1235-12-135-145-24-15-234
-nofor word letterbody  123-1235-12-135-145-13456
-nofor word letterbomb  123-1235-12-135-134-12
-nofor word letterbombed  123-1235-12-135-134-12-1246
-nofor word letterbomber  123-1235-12-135-134-12-12456
-nofor word letterbombing  123-1235-12-135-134-12-346
-nofor word letterbox  123-1235-12-135-1346
-nofor word letterboxed  123-1235-12-135-1346-1246
-nofor word letterboxer  123-1235-12-135-1346-12456
-nofor word letterboxes  123-1235-12-135-1346-15-234
-nofor word letterboxing  123-1235-12-135-1346-346
-nofor word lettered  123-1235-1246
-nofor word letterer  123-1235-12456
-nofor word letterform  123-1235-123456-134
-nofor word letterhead  123-1235-125-2-145
-nofor word letterheading  123-1235-125-2-145-346
-nofor word lettering  123-1235-346
-nofor word letterman  123-1235-134-1-1345
-nofor word lettermen  123-1235-134-26
-nofor word letteropener  123-1235-135-1234-26-12456
-nofor word letterperfect  123-1235-1234-12456-124-15-14-2345
-nofor word letterpress  123-1235-1234-1235-15-234-234
-nofor word letterpressed  123-1235-1234-1235-15-234-234-1246
-nofor word letterpresses  123-1235-1234-1235-15-234-234-15-234
-nofor word letterpressing  123-1235-1234-1235-15-234-234-346
-nofor word letterquality  123-1235-12345-136-1-123-56-13456
-nofor word letterspace  123-1235-234-1234-1-14-15
-nofor word letterspaced  123-1235-234-1234-1-14-1246
-nofor word letterspacing  123-1235-234-1234-1-14-346
-nofor word lettertext  123-1235-2345-15-1346-2345
-nofor word littled  123-123-145
-nofor word littleneck  123-123-1345-15-14-13
-nofor word littleness  123-123-56-234
-nofor word littlenesses  123-123-56-234-15-234
-nofor word littler  123-123-1235
-nofor word littlest  123-123-34
-nofor word lovechildren  123-135-1236-15-16-1345
-nofor word loveletter  123-135-1236-15-123-1235
-nofor word lowlypaid  123-246-123-13456-1234-145
-nofor word manfriend  134-1-1345-124-1235
-nofor word menfriends  134-26-124-1235-234
-nofor word midafternoon  134-24-145-1-124-1345
-nofor word misbraille  134-24-234-12-1235-123
-nofor word misbrailled  134-24-234-12-1235-123-145
-nofor word misperceive  134-24-234-1234-12456-14-1236
-nofor word misperceived  134-24-234-1234-12456-14-1236-145
-nofor word misperceiver  134-24-234-1234-12456-14-1236-1235
-nofor word misperceiving  134-24-234-1234-12456-14-1236-1245
-nofor word missaid  134-24-234-234-145
-nofor word morningafter  134-135-1235-1345-346-1-124
-nofor word muchly  134-16-123-13456
-nofor word muchness  134-16-56-234
-nofor word must've  134-34-3-1236-15
-nofor word musta  134-34-1
-nofor word mustard  134-34-345-145
-nofor word mustardy  134-34-345-145-13456
-nofor word mustier  134-34-24-12456
-nofor word mustiest  134-34-24-15-34
-nofor word mustily  134-34-24-123-13456
-nofor word mustiness  134-34-24-56-234
-nofor word mustn't  134-34-1345-3-2345
-nofor word mustn't've  134-34-1345-3-2345-3-1236-15
-nofor word musty  134-34-13456
-nofor word newsletter  1345-15-2456-234-123-1235
-nofor word nonesuch  1345-5-135-234-16
-nofor word nonsuch  1345-135-1345-234-16
-nofor word northabout  1345-135-1235-1456-1-12
-nofor word overmuch  135-1236-12456-134-16
-nofor word overpaid  135-1236-12456-1234-145
-nofor word penfriend  1234-26-124-1235
-nofor word perceived  1234-12456-14-1236-145
-nofor word perceiver  1234-12456-14-1236-1235
-nofor word perhapses  1234-12456-125-15-234
-nofor word poorlypaid  1234-135-135-1235-123-13456-1234-145
-nofor word postpaid  1234-135-34-1234-145
-nofor word preceive  1234-1235-14-1236
-nofor word preceiver  1234-1235-14-1236-1235
-nofor word preceiving  1234-1235-14-1236-1245
-nofor word prepaid  1234-1235-15-1234-145
-nofor word purblind  1234-136-1235-12-123
-nofor word purblindly  1234-136-1235-12-123-123-13456
-nofor word purblindness  1234-136-1235-12-123-56-234
-nofor word purblindnesses  1234-136-1235-12-123-56-234-15-234
-nofor word quickdraw  12345-13-145-1235-1-2456
-nofor word quicken  12345-13-26
-nofor word quickened  12345-13-26-1246
-nofor word quickener  12345-13-26-12456
-nofor word quickening  12345-13-26-346
-nofor word quicker  12345-13-12456
-nofor word quickest  12345-13-15-34
-nofor word quickfire  12345-13-124-24-1235-15
-nofor word quickfiring  12345-13-124-24-1235-346
-nofor word quickfreeze  12345-13-124-1235-15-15-1356-15
-nofor word quickfreezing  12345-13-124-1235-15-15-1356-346
-nofor word quickfroze  12345-13-124-1235-135-1356-15
-nofor word quickfrozen  12345-13-124-1235-135-1356-26
-nofor word quickie  12345-13-24-15
-nofor word quickish  12345-13-24-146
-nofor word quickishly  12345-13-24-146-123-13456
-nofor word quicklime  12345-13-123-24-134-15
-nofor word quickly  12345-13-123-13456
-nofor word quickness  12345-13-56-234
-nofor word quicknesses  12345-13-56-234-15-234
-nofor word quicksand  12345-13-234-12346
-nofor word quickset  12345-13-234-15-2345
-nofor word quicksilver  12345-13-234-24-123-1236-12456
-nofor word quicksilvered  12345-13-234-24-123-1236-12456-1246
-nofor word quicksilvering  12345-13-234-24-123-1236-12456-346
-nofor word quicksnap  12345-13-234-1345-1-1234
-nofor word quickstep  12345-13-34-15-1234
-nofor word quickstepped  12345-13-34-15-1234-1234-1246
-nofor word quickstepper  12345-13-34-15-1234-1234-12456
-nofor word quickstepping  12345-13-34-15-1234-1234-346
-nofor word quicktempered  12345-13-2345-15-134-1234-12456-1246
-nofor word quicktime  12345-13-5-2345
-nofor word quickwitted  12345-13-2456-24-2345-2345-1246
-nofor word quickwittedly  12345-13-2456-24-2345-2345-1246-123-13456
-nofor word quickwittedness  12345-13-2456-24-2345-2345-1246-56-234
-nofor word quicky  12345-13-13456
-nofor word readacross  1235-2-145-1-14-1235
-nofor word rebraille  1235-15-12-1235-123
-nofor word rebrailled  1235-15-12-1235-123-145
-nofor word rebrailler  1235-15-12-1235-123-1235
-nofor word received  1235-14-1236-145
-nofor word receiver  1235-14-1236-1235
-nofor word receivership  1235-14-1236-1235-146-24-1234
-nofor word rejoiced  1235-245-14-145
-nofor word rejoiceful  1235-245-14-56-123
-nofor word rejoicefully  1235-245-14-56-123-123-13456
-nofor word rejoicefulness  1235-245-14-56-123-56-234
-nofor word rejoicer  1235-245-14-1235
-nofor word rejoicingly  1235-245-14-1245-123-13456
-nofor word reletter  1235-15-123-1235
-nofor word relettered  1235-15-123-1235-1246
-nofor word relettering  1235-15-123-1235-346
-nofor word repaid  1235-15-1234-145
-nofor word rightabout  5-1235-1-12
-nofor word roundabout  1235-46-145-1-12
-nofor word roustabout  1235-1256-34-1-12
-nofor word runabout  1235-136-1345-1-12
-nofor word saidest  234-145-15-34
-nofor word saidst  234-145-34
-nofor word scattergood  234-14-1-2345-2345-12456-1245-145
-nofor word schoolchildren  234-16-135-135-123-16-1345
-nofor word schoolfriend  234-16-135-135-123-124-1235
-nofor word should've  146-145-3-1236-15
-nofor word shoulda  146-145-1
-nofor word shouldest  146-145-15-34
-nofor word shouldn't  146-145-1345-3-2345
-nofor word shouldn't've  146-145-1345-3-2345-3-1236-15
-nofor word shouldst  146-145-34
-nofor word snowblind  234-1345-246-12-123
-nofor word snowblindness  234-1345-246-12-123-56-234
-nofor word snowblindnesses  234-1345-246-12-123-56-234-15-234
-nofor word somesuch  5-234-234-16
-nofor word southabout  234-1256-1456-1-12
-nofor word stepchildren  34-15-1234-16-1345
-nofor word stirabout  34-24-1235-1-12
-nofor word suchlike  234-16-123-24-13-15
-nofor word supergood  234-136-1234-12456-1245-145
-nofor word superquick  234-136-1234-12456-12345-13
-nofor word tailfirst  2345-1-24-123-124-34
-nofor word thereabout  5-2346-1-12
-nofor word thereafter  5-2346-1-124
-nofor word thereagain  5-2346-1-1245
-nofor word thereagainst  5-2346-1-1245-34
-nofor word thereinafter  5-2346-35-1-124
-nofor word thereinagain  5-2346-35-1-1245
-nofor word togetherness  2345-1245-1235-56-234
-nofor word turnabout  2345-136-1235-1345-1-12
-nofor word unaccording  136-1345-1-14
-nofor word unaccordingly  136-1345-1-14-123-13456
-nofor word unblindfold  136-1345-12-123-124-135-123-145
-nofor word unblindfolded  136-1345-12-123-124-135-123-145-1246
-nofor word unblindfolding  136-1345-12-123-124-135-123-145-346
-nofor word unbraille  136-1345-12-1235-123
-nofor word unbrailled  136-1345-12-1235-123-145
-nofor word undeceive  136-1345-145-14-1236
-nofor word undeceived  136-1345-145-14-1236-145
-nofor word undeceiver  136-1345-145-14-1236-1235
-nofor word undeceiving  136-1345-145-14-1236-1245
-nofor word undeclare  136-1345-145-14-123
-nofor word undeclared  136-1345-145-14-123-145
-nofor word underpaid  5-136-1234-145
-nofor word unfriend  136-1345-124-1235
-nofor word unfriendlier  136-1345-124-1235-123-24-12456
-nofor word unfriendliest  136-1345-124-1235-123-24-15-34
-nofor word unfriendliness  136-1345-124-1235-123-24-56-234
-nofor word unfriendlinesses  136-1345-124-1235-123-24-56-234-15-234
-nofor word unfriendly  136-1345-124-1235-123-13456
-nofor word unlettered  136-1345-123-1235-1246
-nofor word unnecessary  136-1345-1345-15-14
-nofor word unpaid  136-1345-1234-145
-nofor word unperceive  136-1345-1234-12456-14-1236
-nofor word unperceived  136-1345-1234-12456-14-1236-145
-nofor word unperceiving  136-1345-1234-12456-14-1236-1245
-nofor word unquick  136-1345-12345-13
-nofor word unreceived  136-1345-1235-14-1236-145
-nofor word unrejoice  136-1345-1235-245-14
-nofor word unrejoiced  136-1345-1235-245-14-145
-nofor word unrejoiceful  136-1345-1235-245-14-56-123
-nofor word unrejoicefully  136-1345-1235-245-14-56-123-123-13456
-nofor word unrejoicefulness  136-1345-1235-245-14-56-123-56-234
-nofor word unrejoicer  136-1345-1235-245-14-1235
-nofor word unrejoicing  136-1345-1235-245-14-1245
-nofor word unrejoicingly  136-1345-1235-245-14-1245-123-13456
-nofor word unrepaid  136-1345-1235-15-1234-145
-nofor word unsaid  136-1345-234-145
-nofor word walkabout  2456-1-123-13-1-12
-nofor word wellpaid  2456-15-123-123-1234-145
-nofor word westabout  2456-15-34-1-12
-nofor word whereabout  5-156-1-12
-nofor word whereafter  5-156-1-124
-nofor word whereagain  5-156-1-1245
-nofor word whereagainst  5-156-1-1245-34
-nofor word whereinafter  5-156-35-1-124
-nofor word whereinagain  5-156-35-1-1245
-nofor word womanfriend  2456-135-134-1-1345-124-1235
-nofor word womenfriends  2456-135-134-26-124-1235-234
-nofor word would've  2456-145-3-1236-15
-nofor word woulda  2456-145-1
-nofor word wouldest  2456-145-15-34
-nofor word wouldn't  2456-145-1345-3-2345
-nofor word wouldn't've  2456-145-1345-3-2345-3-1236-15
-nofor word wouldst  2456-145-34
+word 'twould  3-2345-2456-145
+word 'twould've  3-2345-2456-145-3-1236-15
+word 'twoulda  3-2345-2456-145-1
+word 'twouldn't  3-2345-2456-145-1345-3-2345
+word 'twouldn't've  3-2345-2456-145-1345-3-2345-3-1236-15
+word aboutface  1-12-124-1-14-15
+word aboutfaced  1-12-124-1-14-1246
+word aboutfacer  1-12-124-1-14-12456
+word aboutfacing  1-12-124-1-14-346
+word aboutturn  1-12-2345-136-1235-1345
+word aboutturned  1-12-2345-136-1235-1345-1246
+word aboveboard  1-12-1236-12-135-345-145
+word aboveground  1-12-1236-1245-1235-46-145
+word abovementioned  1-12-1236-134-26-56-1345-1246
+word accordingly  1-14-123-13456
+word aforesaid  1-123456-15-234-145
+word afterbattle  1-124-12-1-2345-2345-123-15
+word afterbirth  1-124-12-24-1235-1456
+word afterbreakfast  1-124-12-1235-2-13-124-1-34
+word afterburn  1-124-12-136-1235-1345
+word afterburned  1-124-12-136-1235-1345-1246
+word afterburner  1-124-12-136-1235-1345-12456
+word afterburning  1-124-12-136-1235-1345-346
+word aftercare  1-124-14-345-15
+word afterclap  1-124-14-123-1-1234
+word aftercoffee  1-124-14-12356-124-15-15
+word afterdamp  1-124-145-1-134-1234
+word afterdark  1-124-145-345-13
+word afterdeck  1-124-145-15-14-13
+word afterdinner  1-124-145-35-1345-12456
+word afterflow  1-124-124-123-246
+word aftergame  1-124-1245-1-134-15
+word afterglow  1-124-1245-123-246
+word afterguard  1-124-1245-136-345-145
+word afterhatch  1-124-125-1-2345-16
+word afterhatches  1-124-125-1-2345-16-15-234
+word afterhour  1-124-125-1256-1235
+word afterlife  1-124-123-24-124-15
+word afterlight  1-124-123-24-126-2345
+word afterlives  1-124-123-24-1236-15-234
+word afterlunch  1-124-123-136-1345-16
+word afterlunches  1-124-123-136-1345-16-15-234
+word aftermarket  1-124-134-345-13-15-2345
+word aftermatch 1-124-134-1-2345-16
+word aftermatches  1-124-134-1-2345-16-15-234
+word aftermath  1-124-134-1-1456
+word aftermeeting  1-124-134-15-15-2345-346
+word aftermentioned  1-124-134-26-56-1345-1246
+word aftermidday  1-124-134-24-145-5-145
+word aftermidnight  1-124-134-24-145-1345-24-126-2345
+word aftermost  1-124-134-135-34
+word afternoontea  1-124-1345-2345-15-1
+word afterpain  1-124-1234-1-35
+word afterparties  1-124-5-1234-24-15-234
+word afterparty  1-124-5-1234-13456
+word afterpiece  1-124-1234-24-15-14-15
+word afterplay  1-124-1234-123-1-13456
+word aftersale  1-124-234-1-123-15
+word afterschool  1-124-234-16-135-135-123
+word aftersensation  1-124-234-26-234-1-56-1345
+word aftershave  1-124-146-1-1236-15
+word aftershock  1-124-146-135-14-13
+word aftershow  1-124-146-246
+word aftershower  1-124-146-246-12456
+word aftersupper  1-124-234-136-1234-1234-12456
+word aftertaste  1-124-2345-1-34-15
+word aftertax  1-124-2345-1-1346
+word aftertaxes  1-124-2345-1-1346-15-234
+word aftertea  1-124-2345-15-1
+word aftertheater  1-124-2346-1-2345-12456
+word aftertheatre  1-124-2346-1-2345-1235-15
+word afterthought  1-124-1456-5-1256
+word aftertime  1-124-5-2345
+word aftertreatment  1-124-2345-1235-2-2345-56-2345
+word afterword  1-124-45-2456
+word afterwork  1-124-5-2456
+word afterworld  1-124-456-2456
+word apperceive  1-1234-1234-12456-14-1236
+word apperceived  1-1234-1234-12456-14-1236-145
+word apperceiver  1-1234-1234-12456-14-1236-1235
+word apperceiving  1-1234-1234-12456-14-1236-1245
+word archdeceiver  345-16-145-14-1236-1235
+word beforehand  23-124-125-12346
+word beforementioned  23-124-134-26-56-1345-1246
+word befriend  23-124-1235
+word behindhand  23-125-125-12346
+word belittle  23-123-123
+word belittled  23-123-123-145
+word belittlement  23-123-123-56-2345
+word belittler  23-123-123-1235
+word belowdeck  23-123-145-15-14-13
+word belowground  23-123-1245-1235-46-145
+word belowmentioned  23-123-134-26-56-1345-1246
+word beneathdeck  23-1345-145-15-14-13
+word beneathground  23-1345-1245-1235-46-145
+word betweendeck  23-2345-145-15-14-13
+word betweentime  23-2345-5-2345
+word betweenwhile  23-2345-156-24-123-15
+word blindfish  12-123-124-24-146
+word blindfishes  12-123-124-24-146-15-234
+word blindfold  12-123-124-135-123-145
+word blindfolded  12-123-124-135-123-145-1246
+word blindfolder  12-123-124-135-123-145-12456
+word blindfolding  12-123-124-135-123-145-346
+word blindly  12-123-123-13456
+word blindman  12-123-134-1-1345
+word blindmen  12-123-134-26
+word blindness  12-123-56-234
+word blindnesses  12-123-56-234-15-234
+word blindside  12-123-234-24-145-15
+word blindsided  12-123-234-24-145-1246
+word blindsider  12-123-234-24-145-12456
+word blindsiding  12-123-234-24-145-346
+word blindsight  12-123-234-24-126-2345
+word blindstories  12-123-34-135-1235-24-15-234
+word blindstory  12-123-34-135-1235-13456
+word blindworm  12-123-2456-135-1235-134
+word bloodletter  12-123-135-135-145-123-1235
+word boyfriend  12-135-13456-124-1235
+word brailled  12-1235-123-145
+word brailler  12-1235-123-1235
+word braillewriter  12-1235-123-2456-1235-24-2345-12456
+word braillewriting  12-1235-123-2456-1235-24-2345-346
+word brailley  12-1235-123-13456
+word brainchildren  12-1235-1-35-16-1345
+word chainletter  16-1-35-123-1235
+word children'swear  16-1345-3-234-2456-15-345
+word colorblind  14-135-123-135-1235-12-123
+word colorblindness  14-135-123-135-1235-12-123-56-234
+word colorblindnesses  14-135-123-135-1235-12-123-56-234-15-234
+word colourblind  14-135-123-1256-1235-12-123
+word colourblindness  14-135-123-1256-1235-12-123-56-234
+word colourblindnesses  14-135-123-1256-1235-12-123-56-234-15-234
+word conceived  25-14-1236-145
+word conceiver  25-14-1236-1235
+word could've  14-145-3-1236-15
+word coulda  14-145-1
+word couldest  14-145-15-34
+word couldn't  14-145-1345-3-2345
+word couldn't've  14-145-1345-3-2345-3-1236-15
+word couldst  14-145-34
+word deafblind  145-2-124-12-123
+word deafblindness  145-2-124-12-123-56-234
+word deafblindnesses  145-2-124-12-123-56-234-15-234
+word deceived  145-14-1236-145
+word deceiver  145-14-1236-1235
+word declared  145-14-123-145
+word declarer  145-14-123-1235
+word defriend  145-15-124-1235
+word do-it-yourselfer  145-36-1346-36-13456-1235-124-12456
+word doublequick  145-1256-12-123-15-12345-13
+word eastabout  15-1-34-1-12
+word feelgood  124-15-15-123-1245-145
+word feetfirst  124-15-15-2345-124-34
+word firstaid  124-34-1-24-145
+word firstaider  124-34-1-24-145-12456
+word firstborn  124-34-12-135-1235-1345
+word firstclass  124-34-14-123-1-234-234
+word firstclasses  124-34-14-123-1-234-234-15-234
+word firstday  124-34-5-145
+word firstdayer  124-34-5-145-12456
+word firstfruit  124-34-124-1235-136-24-2345
+word firstfruiting  124-34-124-1235-136-24-2345-346
+word firstgeneration  124-34-1245-26-12456-1-56-1345
+word firsthand  124-34-125-12346
+word firsthanded  124-34-125-12346-1246
+word firstling  124-34-123-346
+word firstly  124-34-123-13456
+word firstness  124-34-56-234
+word firstnight  124-34-1345-24-126-2345
+word firstnighter  124-34-1345-24-126-2345-12456
+word firstrate  124-34-1235-1-2345-15
+word firstrated  124-34-1235-1-2345-1246
+word firstrating  124-34-1235-1-2345-346
+word firststring  124-34-34-1235-346
+word forasmuch  123456-1-234-134-16
+word foresaid  123456-15-234-145
+word fosterchildren  124-135-34-12456-16-1345
+word friendless  124-1235-46-234
+word friendlessness  124-1235-46-234-56-234
+word friendlessnesses  124-1235-46-234-56-234-15-234
+word friendlier  124-1235-123-24-12456
+word friendlies  124-1235-123-24-15-234
+word friendliest  124-1235-123-24-15-34
+word friendliness  124-1235-123-24-56-234
+word friendlinesses  124-1235-123-24-56-234-15-234
+word friendly  124-1235-123-13456
+word friendship  124-1235-146-24-1234
+word gadabout  1245-1-145-1-12
+word gainsaid  1245-1-35-234-145
+word galfriend  1245-1-123-124-1235
+word gentlemanfriend  1245-26-2345-123-15-134-1-1345-124-1235
+word gentlemenfriends  1245-26-2345-123-15-134-26-124-1235-234
+word girlfriend  1245-24-1235-123-124-1235
+word godchildren  1245-135-145-16-1345
+word goodafternoon  1245-145-1-124-1345
+word goodby  1245-145-12-13456
+word goodbye  1245-145-12-13456-15
+word goodbyeing  1245-145-12-13456-15-346
+word goodbying  1245-145-12-13456-346
+word goodday  1245-145-5-145
+word gooder  1245-145-12456
+word goodest  1245-145-15-34
+word goodevening  1245-145-15-1236-26-346
+word goodfellow  1245-145-124-15-123-123-246
+word goodfellowship  1245-145-124-15-123-123-246-146-24-1234
+word goodhearted  1245-145-125-15-345-2345-1246
+word goodheartedly  1245-145-125-15-345-2345-1246-123-13456
+word goodheartedness  1245-145-125-15-345-2345-1246-56-234
+word goodhumor  1245-145-125-136-134-135-1235
+word goodhumored  1245-145-125-136-134-135-1235-1246
+word goodhumoredly  1245-145-125-136-134-135-1235-1246-123-13456
+word goodhumoredness  1245-145-125-136-134-135-1235-1246-56-234
+word goodhumorednesses  1245-145-125-136-134-135-1235-1246-56-234-15-234
+word goodhumour  1245-145-125-136-134-1256-1235
+word goodhumoured  1245-145-125-136-134-1256-1235-1246
+word goodhumouredly  1245-145-125-136-134-1256-1235-1246-123-13456
+word goodhumouredness  1245-145-125-136-134-1256-1235-1246-56-234
+word goodhumourednesses  1245-145-125-136-134-1256-1235-1246-56-234-15-234
+word goodie  1245-145-24-15
+word goodish  1245-145-24-146
+word goodlier  1245-145-123-24-12456
+word goodliest  1245-145-123-24-15-34
+word goodliness  1245-145-123-24-56-234
+word goodlook  1245-145-123-135-135-13
+word goodlooker  1245-145-123-135-135-13-12456
+word goodlooking  1245-145-123-135-135-13-346
+word goodly  1245-145-123-13456
+word goodman  1245-145-134-1-1345
+word goodmen  1245-145-134-26
+word goodmorning  1245-145-134-135-1235-1345-346
+word goodnature  1245-145-1345-1-2345-136-1235-15
+word goodnatured  1245-145-1345-1-2345-136-1235-1246
+word goodnaturedly  1245-145-1345-1-2345-136-1235-1246-123-13456
+word goodnaturedness  1245-145-1345-1-2345-136-1235-1246-56-234
+word goodness  1245-145-56-234
+word goodnesses  1245-145-56-234-15-234
+word goodnight  1245-145-1345-24-126-2345
+word goodsize  1245-145-234-24-1356-15
+word goodsized  1245-145-234-24-1356-1246
+word goodtempered  1245-145-2345-15-134-1234-12456-1246
+word goodtemperedly  1245-145-2345-15-134-1234-12456-1246-123-13456
+word goodtime  1245-145-5-2345
+word goodun  1245-145-136-1345
+word goodwife  1245-145-2456-24-124-15
+word goodwill  1245-145-2456-24-123-123
+word goodwilled  1245-145-2456-24-123-123-1246
+word goodwives  1245-145-2456-24-1236-15-234
+word goody  1245-145-13456
+word goodyear  1245-145-13456-15-345
+word grandchildren  1245-1235-12346-16-1345
+word greataunt  1245-1235-2345-1-136-1345-2345
+word greatbatch  1245-1235-2345-12-1-2345-16
+word greatcircle  1245-1235-2345-14-24-1235-14-123-15
+word greatcoat  1245-1235-2345-14-135-1-2345
+word greaten  1245-1235-2345-26
+word greatened  1245-1235-2345-26-1246
+word greatener  1245-1235-2345-26-12456
+word greatening  1245-1235-2345-26-346
+word greater  1245-1235-2345-12456
+word greatest  1245-1235-2345-15-34
+word greatgrandaunt  1245-1235-2345-1245-1235-12346-1-136-1345-2345
+word greatgrandchild  1245-1235-2345-1245-1235-12346-16-24-123-145
+word greatgrandchildren  1245-1235-2345-1245-1235-12346-16-1345
+word greatgranddad  1245-1235-2345-1245-1235-12346-145-1-145
+word greatgranddaughter  1245-1235-2345-1245-1235-12346-145-1-136-126-2345-12456
+word greatgrandfather  1245-1235-2345-1245-1235-12346-5-124
+word greatgrandfatherhood  1245-1235-2345-1245-1235-12346-5-124-125-135-135-145
+word greatgrandma  1245-1235-2345-1245-1235-12346-134-1
+word greatgrandmother  1245-1235-2345-1245-1235-12346-5-134
+word greatgrandmotherhood  1245-1235-2345-1245-1235-12346-5-134-125-135-135-145
+word greatgrandnephew  1245-1235-2345-1245-1235-12346-1345-15-1234-125-15-2456
+word greatgrandniece  1245-1235-2345-1245-1235-12346-1345-24-15-14-15
+word greatgrandpa  1245-1235-2345-1245-1235-12346-1234-1
+word greatgrandparent  1245-1235-2345-1245-1235-12346-1234-345-26-2345
+word greatgrandparenthood  1245-1235-2345-1245-1235-12346-1234-345-26-2345-125-135-135-145
+word greatgrandson  1245-1235-2345-1245-1235-12346-234-135-1345
+word greatgranduncle  1245-1235-2345-1245-1235-12346-136-1345-14-123-15
+word greathearted  1245-1235-2345-125-15-345-2345-1246
+word greatheartedly  1245-1235-2345-125-15-345-2345-1246-123-13456
+word greatheartedness  1245-1235-2345-125-15-345-2345-1246-56-234
+word greatheartednesses  1245-1235-2345-125-15-345-2345-1246-56-234-15-234
+word greatly  1245-1235-2345-123-13456
+word greatnephew  1245-1235-2345-1345-15-1234-125-15-2456
+word greatness  1245-1235-2345-56-234
+word greatnesses  1245-1235-2345-56-234-15-234
+word greatniece  1245-1235-2345-1345-24-15-14-15
+word greatsword  1245-1235-2345-234-45-2456
+word greatuncle  1245-1235-2345-136-1345-14-123-15
+word guyfriend  1245-136-13456-124-1235
+word hateletter  125-1-2345-15-123-1235
+word headfirst  125-2-145-124-34
+word hereabout  5-125-1-12
+word hereafter  5-125-1-124
+word hereagain  5-125-1-1245
+word hereagainst  5-125-1-1245-34
+word hereinabove  5-125-35-1-12-1236
+word hereinafter  5-125-35-1-124
+word hereinagain  5-125-35-1-1245
+word highlypaid  125-24-126-123-13456-1234-145
+word himbo  125-134-12-135
+word himboes  125-134-12-135-15-234
+word illpaid  24-123-123-1234-145
+word immediately  24-134-134-123-13456
+word immediateness  24-134-134-56-234
+word inasmuch  35-1-234-134-16
+word insomuch  35-234-135-134-16
+word knockabout  13-1345-135-14-13-1-12
+word ladyfriend  123-1-145-13456-124-1235
+word layabout  123-1-13456-1-12
+word letterbodies  123-1235-12-135-145-24-15-234
+word letterbody  123-1235-12-135-145-13456
+word letterbomb  123-1235-12-135-134-12
+word letterbombed  123-1235-12-135-134-12-1246
+word letterbomber  123-1235-12-135-134-12-12456
+word letterbombing  123-1235-12-135-134-12-346
+word letterbox  123-1235-12-135-1346
+word letterboxed  123-1235-12-135-1346-1246
+word letterboxer  123-1235-12-135-1346-12456
+word letterboxes  123-1235-12-135-1346-15-234
+word letterboxing  123-1235-12-135-1346-346
+word lettered  123-1235-1246
+word letterer  123-1235-12456
+word letterform  123-1235-123456-134
+word letterhead  123-1235-125-2-145
+word letterheading  123-1235-125-2-145-346
+word lettering  123-1235-346
+word letterman  123-1235-134-1-1345
+word lettermen  123-1235-134-26
+word letteropener  123-1235-135-1234-26-12456
+word letterperfect  123-1235-1234-12456-124-15-14-2345
+word letterpress  123-1235-1234-1235-15-234-234
+word letterpressed  123-1235-1234-1235-15-234-234-1246
+word letterpresses  123-1235-1234-1235-15-234-234-15-234
+word letterpressing  123-1235-1234-1235-15-234-234-346
+word letterquality  123-1235-12345-136-1-123-56-13456
+word letterspace  123-1235-234-1234-1-14-15
+word letterspaced  123-1235-234-1234-1-14-1246
+word letterspacing  123-1235-234-1234-1-14-346
+word lettertext  123-1235-2345-15-1346-2345
+word littled  123-123-145
+word littleneck  123-123-1345-15-14-13
+word littleness  123-123-56-234
+word littlenesses  123-123-56-234-15-234
+word littler  123-123-1235
+word littlest  123-123-34
+word lovechildren  123-135-1236-15-16-1345
+word loveletter  123-135-1236-15-123-1235
+word lowlypaid  123-246-123-13456-1234-145
+word manfriend  134-1-1345-124-1235
+word menfriends  134-26-124-1235-234
+word midafternoon  134-24-145-1-124-1345
+word misbraille  134-24-234-12-1235-123
+word misbrailled  134-24-234-12-1235-123-145
+word misperceive  134-24-234-1234-12456-14-1236
+word misperceived  134-24-234-1234-12456-14-1236-145
+word misperceiver  134-24-234-1234-12456-14-1236-1235
+word misperceiving  134-24-234-1234-12456-14-1236-1245
+word missaid  134-24-234-234-145
+word morningafter  134-135-1235-1345-346-1-124
+word muchly  134-16-123-13456
+word muchness  134-16-56-234
+word must've  134-34-3-1236-15
+word musta  134-34-1
+word mustard  134-34-345-145
+word mustardy  134-34-345-145-13456
+word mustier  134-34-24-12456
+word mustiest  134-34-24-15-34
+word mustily  134-34-24-123-13456
+word mustiness  134-34-24-56-234
+word mustn't  134-34-1345-3-2345
+word mustn't've  134-34-1345-3-2345-3-1236-15
+word musty  134-34-13456
+word newsletter  1345-15-2456-234-123-1235
+word nonesuch  1345-5-135-234-16
+word nonsuch  1345-135-1345-234-16
+word northabout  1345-135-1235-1456-1-12
+word overmuch  135-1236-12456-134-16
+word overpaid  135-1236-12456-1234-145
+word penfriend  1234-26-124-1235
+word perceived  1234-12456-14-1236-145
+word perceiver  1234-12456-14-1236-1235
+word perhapses  1234-12456-125-15-234
+word poorlypaid  1234-135-135-1235-123-13456-1234-145
+word postpaid  1234-135-34-1234-145
+word preceive  1234-1235-14-1236
+word preceiver  1234-1235-14-1236-1235
+word preceiving  1234-1235-14-1236-1245
+word prepaid  1234-1235-15-1234-145
+word purblind  1234-136-1235-12-123
+word purblindly  1234-136-1235-12-123-123-13456
+word purblindness  1234-136-1235-12-123-56-234
+word purblindnesses  1234-136-1235-12-123-56-234-15-234
+word quickdraw  12345-13-145-1235-1-2456
+word quicken  12345-13-26
+word quickened  12345-13-26-1246
+word quickener  12345-13-26-12456
+word quickening  12345-13-26-346
+word quicker  12345-13-12456
+word quickest  12345-13-15-34
+word quickfire  12345-13-124-24-1235-15
+word quickfiring  12345-13-124-24-1235-346
+word quickfreeze  12345-13-124-1235-15-15-1356-15
+word quickfreezing  12345-13-124-1235-15-15-1356-346
+word quickfroze  12345-13-124-1235-135-1356-15
+word quickfrozen  12345-13-124-1235-135-1356-26
+word quickie  12345-13-24-15
+word quickish  12345-13-24-146
+word quickishly  12345-13-24-146-123-13456
+word quicklime  12345-13-123-24-134-15
+word quickly  12345-13-123-13456
+word quickness  12345-13-56-234
+word quicknesses  12345-13-56-234-15-234
+word quicksand  12345-13-234-12346
+word quickset  12345-13-234-15-2345
+word quicksilver  12345-13-234-24-123-1236-12456
+word quicksilvered  12345-13-234-24-123-1236-12456-1246
+word quicksilvering  12345-13-234-24-123-1236-12456-346
+word quicksnap  12345-13-234-1345-1-1234
+word quickstep  12345-13-34-15-1234
+word quickstepped  12345-13-34-15-1234-1234-1246
+word quickstepper  12345-13-34-15-1234-1234-12456
+word quickstepping  12345-13-34-15-1234-1234-346
+word quicktempered  12345-13-2345-15-134-1234-12456-1246
+word quicktime  12345-13-5-2345
+word quickwitted  12345-13-2456-24-2345-2345-1246
+word quickwittedly  12345-13-2456-24-2345-2345-1246-123-13456
+word quickwittedness  12345-13-2456-24-2345-2345-1246-56-234
+word quicky  12345-13-13456
+word readacross  1235-2-145-1-14-1235
+word rebraille  1235-15-12-1235-123
+word rebrailled  1235-15-12-1235-123-145
+word rebrailler  1235-15-12-1235-123-1235
+word received  1235-14-1236-145
+word receiver  1235-14-1236-1235
+word receivership  1235-14-1236-1235-146-24-1234
+word rejoiced  1235-245-14-145
+word rejoiceful  1235-245-14-56-123
+word rejoicefully  1235-245-14-56-123-123-13456
+word rejoicefulness  1235-245-14-56-123-56-234
+word rejoicer  1235-245-14-1235
+word rejoicingly  1235-245-14-1245-123-13456
+word reletter  1235-15-123-1235
+word relettered  1235-15-123-1235-1246
+word relettering  1235-15-123-1235-346
+word repaid  1235-15-1234-145
+word rightabout  5-1235-1-12
+word roundabout  1235-46-145-1-12
+word roustabout  1235-1256-34-1-12
+word runabout  1235-136-1345-1-12
+word saidest  234-145-15-34
+word saidst  234-145-34
+word scattergood  234-14-1-2345-2345-12456-1245-145
+word schoolchildren  234-16-135-135-123-16-1345
+word schoolfriend  234-16-135-135-123-124-1235
+word should've  146-145-3-1236-15
+word shoulda  146-145-1
+word shouldest  146-145-15-34
+word shouldn't  146-145-1345-3-2345
+word shouldn't've  146-145-1345-3-2345-3-1236-15
+word shouldst  146-145-34
+word snowblind  234-1345-246-12-123
+word snowblindness  234-1345-246-12-123-56-234
+word snowblindnesses  234-1345-246-12-123-56-234-15-234
+word somesuch  5-234-234-16
+word southabout  234-1256-1456-1-12
+word stepchildren  34-15-1234-16-1345
+word stirabout  34-24-1235-1-12
+word suchlike  234-16-123-24-13-15
+word supergood  234-136-1234-12456-1245-145
+word superquick  234-136-1234-12456-12345-13
+word tailfirst  2345-1-24-123-124-34
+word thereabout  5-2346-1-12
+word thereafter  5-2346-1-124
+word thereagain  5-2346-1-1245
+word thereagainst  5-2346-1-1245-34
+word thereinafter  5-2346-35-1-124
+word thereinagain  5-2346-35-1-1245
+word togetherness  2345-1245-1235-56-234
+word turnabout  2345-136-1235-1345-1-12
+word unaccording  136-1345-1-14
+word unaccordingly  136-1345-1-14-123-13456
+word unblindfold  136-1345-12-123-124-135-123-145
+word unblindfolded  136-1345-12-123-124-135-123-145-1246
+word unblindfolding  136-1345-12-123-124-135-123-145-346
+word unbraille  136-1345-12-1235-123
+word unbrailled  136-1345-12-1235-123-145
+word undeceive  136-1345-145-14-1236
+word undeceived  136-1345-145-14-1236-145
+word undeceiver  136-1345-145-14-1236-1235
+word undeceiving  136-1345-145-14-1236-1245
+word undeclare  136-1345-145-14-123
+word undeclared  136-1345-145-14-123-145
+word underpaid  5-136-1234-145
+word unfriend  136-1345-124-1235
+word unfriendlier  136-1345-124-1235-123-24-12456
+word unfriendliest  136-1345-124-1235-123-24-15-34
+word unfriendliness  136-1345-124-1235-123-24-56-234
+word unfriendlinesses  136-1345-124-1235-123-24-56-234-15-234
+word unfriendly  136-1345-124-1235-123-13456
+word unlettered  136-1345-123-1235-1246
+word unnecessary  136-1345-1345-15-14
+word unpaid  136-1345-1234-145
+word unperceive  136-1345-1234-12456-14-1236
+word unperceived  136-1345-1234-12456-14-1236-145
+word unperceiving  136-1345-1234-12456-14-1236-1245
+word unquick  136-1345-12345-13
+word unreceived  136-1345-1235-14-1236-145
+word unrejoice  136-1345-1235-245-14
+word unrejoiced  136-1345-1235-245-14-145
+word unrejoiceful  136-1345-1235-245-14-56-123
+word unrejoicefully  136-1345-1235-245-14-56-123-123-13456
+word unrejoicefulness  136-1345-1235-245-14-56-123-56-234
+word unrejoicer  136-1345-1235-245-14-1235
+word unrejoicing  136-1345-1235-245-14-1245
+word unrejoicingly  136-1345-1235-245-14-1245-123-13456
+word unrepaid  136-1345-1235-15-1234-145
+word unsaid  136-1345-234-145
+word walkabout  2456-1-123-13-1-12
+word wellpaid  2456-15-123-123-1234-145
+word westabout  2456-15-34-1-12
+word whereabout  5-156-1-12
+word whereafter  5-156-1-124
+word whereagain  5-156-1-1245
+word whereagainst  5-156-1-1245-34
+word whereinafter  5-156-35-1-124
+word whereinagain  5-156-35-1-1245
+word womanfriend  2456-135-134-1-1345-124-1235
+word womenfriends  2456-135-134-26-124-1235-234
+word would've  2456-145-3-1236-15
+word woulda  2456-145-1
+word wouldest  2456-145-15-34
+word wouldn't  2456-145-1345-3-2345
+word wouldn't've  2456-145-1345-3-2345-3-1236-15
+word wouldst  2456-145-34
 
 #TODO:  backmatch should be able to merge these
-nofor word 'twoulds  3-2345-2456-145-234
-nofor word 'twould'ves  3-2345-2456-145-3-1236-15-234
-nofor word 'twouldas  3-2345-2456-145-1-234
-nofor word 'twouldn'ts  3-2345-2456-145-1345-3-2345-234
-nofor word 'twouldn't'ves  3-2345-2456-145-1345-3-2345-3-1236-15-234
-nofor word aboutfaces  1-12-124-1-14-15-234
-nofor word aboutfacers  1-12-124-1-14-12456-234
-nofor word aboutfacings  1-12-124-1-14-346-234
-nofor word aboutturns  1-12-2345-136-1235-1345-234
-nofor word aboveboards  1-12-1236-12-135-345-145-234
-nofor word abovegrounds  1-12-1236-1245-1235-46-145-234
-nofor word aforesaids  1-123456-15-234-145-234
-nofor word afterbattles  1-124-12-1-2345-2345-123-15-234
-nofor word afterbirths  1-124-12-24-1235-1456-234
-nofor word afterbreakfasts  1-124-12-1235-2-13-124-1-34-234
-nofor word afterburns  1-124-12-136-1235-1345-234
-nofor word afterburners  1-124-12-136-1235-1345-12456-234
-nofor word afterburnings  1-124-12-136-1235-1345-346-234
-nofor word aftercares  1-124-14-345-15-234
-nofor word afterclaps  1-124-14-123-1-1234-234
-nofor word aftercoffees  1-124-14-12356-124-15-15-234
-nofor word afterdamps  1-124-145-1-134-1234-234
-nofor word afterdarks  1-124-145-345-13-234
-nofor word afterdecks  1-124-145-15-14-13-234
-nofor word afterdinners  1-124-145-35-1345-12456-234
-nofor word afterflows  1-124-124-123-246-234
-nofor word aftergames  1-124-1245-1-134-15-234
-nofor word afterglows  1-124-1245-123-246-234
-nofor word afterguards  1-124-1245-136-345-145-234
-nofor word afterhatchs  1-124-125-1-2345-16-234
-nofor word afterhatchess  1-124-125-1-2345-16-15-234-234
-nofor word afterhours  1-124-125-1256-1235-234
-nofor word afterlifes  1-124-123-24-124-15-234
-nofor word afterlights  1-124-123-24-126-2345-234
-nofor word afterlivess  1-124-123-24-1236-15-234-234
-nofor word afterlunchs  1-124-123-136-1345-16-234
-nofor word afterlunchess  1-124-123-136-1345-16-15-234-234
-nofor word aftermarkets  1-124-134-345-13-15-2345-234
-nofor word aftermatchs 1-124-134-1-2345-16-234
-nofor word aftermaths  1-124-134-1-1456-234
-nofor word aftermeetings  1-124-134-15-15-2345-346-234
-nofor word aftermentioneds  1-124-134-26-56-1345-1246-234
-nofor word aftermiddays  1-124-134-24-145-5-145-234
-nofor word aftermidnights  1-124-134-24-145-1345-24-126-2345-234
-nofor word aftermosts  1-124-134-135-34-234
-nofor word afternoonteas  1-124-1345-2345-15-1-234
-nofor word afterpains  1-124-1234-1-35-234
-nofor word afterpartiess  1-124-5-1234-24-15-234-234
-nofor word afterpartys  1-124-5-1234-13456-234
-nofor word afterpieces  1-124-1234-24-15-14-15-234
-nofor word afterplays  1-124-1234-123-1-13456-234
-nofor word aftersales  1-124-234-1-123-15-234
-nofor word afterschools  1-124-234-16-135-135-123-234
-nofor word aftersensations  1-124-234-26-234-1-56-1345-234
-nofor word aftershaves  1-124-146-1-1236-15-234
-nofor word aftershocks  1-124-146-135-14-13-234
-nofor word aftershows  1-124-146-246-234
-nofor word aftershowers  1-124-146-246-12456-234
-nofor word aftersuppers  1-124-234-136-1234-1234-12456-234
-nofor word aftertastes  1-124-2345-1-34-15-234
-nofor word aftertaxs  1-124-2345-1-1346-234
-nofor word aftertaxess  1-124-2345-1-1346-15-234-234
-nofor word afterteas  1-124-2345-15-1-234
-nofor word aftertheaters  1-124-2346-1-2345-12456-234
-nofor word aftertheatres  1-124-2346-1-2345-1235-15-234
-nofor word afterthoughts  1-124-1456-5-1256-234
-nofor word aftertimes  1-124-5-2345-234
-nofor word aftertreatments  1-124-2345-1235-2-2345-56-2345-234
-nofor word afterwords  1-124-45-2456-234
-nofor word afterworks  1-124-5-2456-234
-nofor word afterworlds  1-124-456-2456-234
-nofor word apperceives  1-1234-1234-12456-14-1236-234
-nofor word apperceivers  1-1234-1234-12456-14-1236-1235-234
-nofor word apperceivings  1-1234-1234-12456-14-1236-1245-234
-nofor word archdeceivers  345-16-145-14-1236-1235-234
-nofor word beforehands  23-124-125-12346-234
-nofor word beforementioneds  23-124-134-26-56-1345-1246-234
-nofor word befriends  23-124-1235-234
-nofor word behindhands  23-125-125-12346-234
-nofor word belittles  23-123-123-234
-nofor word belittlements  23-123-123-56-2345-234
-nofor word belittlers  23-123-123-1235-234
-nofor word belowdecks  23-123-145-15-14-13-234
-nofor word belowgrounds  23-123-1245-1235-46-145-234
-nofor word beneathdecks  23-1345-145-15-14-13-234
-nofor word beneathgrounds  23-1345-1245-1235-46-145-234
-nofor word betweendecks  23-2345-145-15-14-13-234
-nofor word betweentimes  23-2345-5-2345-234
-nofor word betweenwhiles  23-2345-156-24-123-15-234
-nofor word blindfishs  12-123-124-24-146-234
-nofor word blindfishess  12-123-124-24-146-15-234-234
-nofor word blindfolds  12-123-124-135-123-145-234
-nofor word blindfolders  12-123-124-135-123-145-12456-234
-nofor word blindfoldings  12-123-124-135-123-145-346-234
-nofor word blindlys  12-123-123-13456-234
-nofor word blindmans  12-123-134-1-1345-234
-nofor word blindmens  12-123-134-26-234
-nofor word blindnesss  12-123-56-234-234
-nofor word blindnessess  12-123-56-234-15-234-234
-nofor word blindsides  12-123-234-24-145-15-234
-nofor word blindsiders  12-123-234-24-145-12456-234
-nofor word blindsidings  12-123-234-24-145-346-234
-nofor word blindsights  12-123-234-24-126-2345-234
-nofor word blindstoriess  12-123-34-135-1235-24-15-234-234
-nofor word blindstorys  12-123-34-135-1235-13456-234
-nofor word blindworms  12-123-2456-135-1235-134-234
-nofor word bloodletters  12-123-135-135-145-123-1235-234
-nofor word boyfriends  12-135-13456-124-1235-234
-nofor word braillers  12-1235-123-1235-234
-nofor word braillewriters  12-1235-123-2456-1235-24-2345-12456-234
-nofor word braillewritings  12-1235-123-2456-1235-24-2345-346-234
-nofor word brailleys  12-1235-123-13456-234
-nofor word brainchildrens  12-1235-1-35-16-1345-234
-nofor word chainletters  16-1-35-123-1235-234
-nofor word children'swears  16-1345-3-234-2456-15-345-234
-nofor word colorblinds  14-135-123-135-1235-12-123-234
-nofor word colorblindnesss  14-135-123-135-1235-12-123-56-234-234
-nofor word colorblindnessess  14-135-123-135-1235-12-123-56-234-15-234-234
-nofor word colourblinds  14-135-123-1256-1235-12-123-234
-nofor word colourblindnesss  14-135-123-1256-1235-12-123-56-234-234
-nofor word colourblindnessess  14-135-123-1256-1235-12-123-56-234-15-234-234
-nofor word conceivers  25-14-1236-1235-234
-nofor word could'ves  14-145-3-1236-15-234
-nofor word couldas  14-145-1-234
-nofor word couldests  14-145-15-34-234
-nofor word couldn'ts  14-145-1345-3-2345-234
-nofor word couldn't'ves  14-145-1345-3-2345-3-1236-15-234
-nofor word couldsts  14-145-34-234
-nofor word deafblinds  145-2-124-12-123-234
-nofor word deafblindnesss  145-2-124-12-123-56-234-234
-nofor word deafblindnessess  145-2-124-12-123-56-234-15-234-234
-nofor word deceivers  145-14-1236-1235-234
-nofor word declarers  145-14-123-1235-234
-nofor word defriends  145-15-124-1235-234
-nofor word do-it-yourselfers  145-36-1346-36-13456-1235-124-12456-234
-nofor word doublequicks  145-1256-12-123-15-12345-13-234
-nofor word eastabouts  15-1-34-1-12-234
-nofor word feelgoods  124-15-15-123-1245-145-234
-nofor word feetfirsts  124-15-15-2345-124-34-234
-nofor word firstaids  124-34-1-24-145-234
-nofor word firstaiders  124-34-1-24-145-12456-234
-nofor word firstborns  124-34-12-135-1235-1345-234
-nofor word firstclasss  124-34-14-123-1-234-234-234
-nofor word firstclassess  124-34-14-123-1-234-234-15-234-234
-nofor word firstdays  124-34-5-145-234
-nofor word firstdayers  124-34-5-145-12456-234
-nofor word firstfruits  124-34-124-1235-136-24-2345-234
-nofor word firstfruitings  124-34-124-1235-136-24-2345-346-234
-nofor word firstgenerations  124-34-1245-26-12456-1-56-1345-234
-nofor word firsthands  124-34-125-12346-234
-nofor word firstlings  124-34-123-346-234
-nofor word firstlys  124-34-123-13456-234
-nofor word firstnesss  124-34-56-234-234
-nofor word firstnights  124-34-1345-24-126-2345-234
-nofor word firstnighters  124-34-1345-24-126-2345-12456-234
-nofor word firstrates  124-34-1235-1-2345-15-234
-nofor word firstratings  124-34-1235-1-2345-346-234
-nofor word firststrings  124-34-34-1235-346-234
-nofor word forasmuchs  123456-1-234-134-16-234
-nofor word foresaids  123456-15-234-145-234
-nofor word fosterchildrens  124-135-34-12456-16-1345-234
-nofor word friendlesss  124-1235-46-234-234
-nofor word friendlessnesss  124-1235-46-234-56-234-234
-nofor word friendlessnessess  124-1235-46-234-56-234-15-234-234
-nofor word friendliers  124-1235-123-24-12456-234
-nofor word friendliess  124-1235-123-24-15-234-234
-nofor word friendliests  124-1235-123-24-15-34-234
-nofor word friendlinesss  124-1235-123-24-56-234-234
-nofor word friendlinessess  124-1235-123-24-56-234-15-234-234
-nofor word friendlys  124-1235-123-13456-234
-nofor word friendships  124-1235-146-24-1234-234
-nofor word gadabouts  1245-1-145-1-12-234
-nofor word gainsaids  1245-1-35-234-145-234
-nofor word galfriends  1245-1-123-124-1235-234
-nofor word gentlemanfriends  1245-26-2345-123-15-134-1-1345-124-1235-234
-nofor word gentlemenfriendss  1245-26-2345-123-15-134-26-124-1235-234-234
-nofor word girlfriends  1245-24-1235-123-124-1235-234
-nofor word godchildrens  1245-135-145-16-1345-234
-nofor word goodafternoons  1245-145-1-124-1345-234
-nofor word goodbys  1245-145-12-13456-234
-nofor word goodbyes  1245-145-12-13456-15-234
-nofor word goodbyeings  1245-145-12-13456-15-346-234
-nofor word goodbyings  1245-145-12-13456-346-234
-nofor word gooddays  1245-145-5-145-234
-nofor word gooders  1245-145-12456-234
-nofor word goodests  1245-145-15-34-234
-nofor word goodevenings  1245-145-15-1236-26-346-234
-nofor word goodfellows  1245-145-124-15-123-123-246-234
-nofor word goodfellowships  1245-145-124-15-123-123-246-146-24-1234-234
-nofor word goodheartedlys  1245-145-125-15-345-2345-1246-123-13456-234
-nofor word goodheartednesss  1245-145-125-15-345-2345-1246-56-234-234
-nofor word goodhumors  1245-145-125-136-134-135-1235-234
-nofor word goodhumoredlys  1245-145-125-136-134-135-1235-1246-123-13456-234
-nofor word goodhumorednesss  1245-145-125-136-134-135-1235-1246-56-234-234
-nofor word goodhumorednessess  1245-145-125-136-134-135-1235-1246-56-234-15-234-234
-nofor word goodhumours  1245-145-125-136-134-1256-1235-234
-nofor word goodhumouredlys  1245-145-125-136-134-1256-1235-1246-123-13456-234
-nofor word goodhumourednesss  1245-145-125-136-134-1256-1235-1246-56-234-234
-nofor word goodhumourednessess  1245-145-125-136-134-1256-1235-1246-56-234-15-234-234
-nofor word goodies  1245-145-24-15-234
-nofor word goodishs  1245-145-24-146-234
-nofor word goodliers  1245-145-123-24-12456-234
-nofor word goodliests  1245-145-123-24-15-34-234
-nofor word goodlinesss  1245-145-123-24-56-234-234
-nofor word goodlooks  1245-145-123-135-135-13-234
-nofor word goodlookers  1245-145-123-135-135-13-12456-234
-nofor word goodlookings  1245-145-123-135-135-13-346-234
-nofor word goodlys  1245-145-123-13456-234
-nofor word goodmans  1245-145-134-1-1345-234
-nofor word goodmens  1245-145-134-26-234
-nofor word goodmornings  1245-145-134-135-1235-1345-346-234
-nofor word goodnatures  1245-145-1345-1-2345-136-1235-15-234
-nofor word goodnaturedlys  1245-145-1345-1-2345-136-1235-1246-123-13456-234
-nofor word goodnaturednesss  1245-145-1345-1-2345-136-1235-1246-56-234-234
-nofor word goodnesss  1245-145-56-234-234
-nofor word goodnessess  1245-145-56-234-15-234-234
-nofor word goodnights  1245-145-1345-24-126-2345-234
-nofor word goodsizes  1245-145-234-24-1356-15-234
-nofor word goodtemperedlys  1245-145-2345-15-134-1234-12456-1246-123-13456-234
-nofor word goodtimes  1245-145-5-2345-234
-nofor word gooduns  1245-145-136-1345-234
-nofor word goodwifes  1245-145-2456-24-124-15-234
-nofor word goodwills  1245-145-2456-24-123-123-234
-nofor word goodwivess  1245-145-2456-24-1236-15-234-234
-nofor word goodys  1245-145-13456-234
-nofor word goodyears  1245-145-13456-15-345-234
-nofor word grandchildrens  1245-1235-12346-16-1345-234
-nofor word greataunts  1245-1235-2345-1-136-1345-2345-234
-nofor word greatbatchs  1245-1235-2345-12-1-2345-16-234
-nofor word greatcircles  1245-1235-2345-14-24-1235-14-123-15-234
-nofor word greatcoats  1245-1235-2345-14-135-1-2345-234
-nofor word greatens  1245-1235-2345-26-234
-nofor word greateners  1245-1235-2345-26-12456-234
-nofor word greatenings  1245-1235-2345-26-346-234
-nofor word greaters  1245-1235-2345-12456-234
-nofor word greatests  1245-1235-2345-15-34-234
-nofor word greatgrandaunts  1245-1235-2345-1245-1235-12346-1-136-1345-2345-234
-nofor word greatgrandchilds  1245-1235-2345-1245-1235-12346-16-24-123-145-234
-nofor word greatgrandchildrens  1245-1235-2345-1245-1235-12346-16-1345-234
-nofor word greatgranddads  1245-1235-2345-1245-1235-12346-145-1-145-234
-nofor word greatgranddaughters  1245-1235-2345-1245-1235-12346-145-1-136-126-2345-12456-234
-nofor word greatgrandfathers  1245-1235-2345-1245-1235-12346-5-124-234
-nofor word greatgrandfatherhoods  1245-1235-2345-1245-1235-12346-5-124-125-135-135-145-234
-nofor word greatgrandmas  1245-1235-2345-1245-1235-12346-134-1-234
-nofor word greatgrandmothers  1245-1235-2345-1245-1235-12346-5-134-234
-nofor word greatgrandmotherhoods  1245-1235-2345-1245-1235-12346-5-134-125-135-135-145-234
-nofor word greatgrandnephews  1245-1235-2345-1245-1235-12346-1345-15-1234-125-15-2456-234
-nofor word greatgrandnieces  1245-1235-2345-1245-1235-12346-1345-24-15-14-15-234
-nofor word greatgrandpas  1245-1235-2345-1245-1235-12346-1234-1-234
-nofor word greatgrandparents  1245-1235-2345-1245-1235-12346-1234-345-26-2345-234
-nofor word greatgrandparenthoods  1245-1235-2345-1245-1235-12346-1234-345-26-2345-125-135-135-145-234
-nofor word greatgrandsons  1245-1235-2345-1245-1235-12346-234-135-1345-234
-nofor word greatgranduncles  1245-1235-2345-1245-1235-12346-136-1345-14-123-15-234
-nofor word greatheartedlys  1245-1235-2345-125-15-345-2345-1246-123-13456-234
-nofor word greatheartednesss  1245-1235-2345-125-15-345-2345-1246-56-234-234
-nofor word greatheartednessess  1245-1235-2345-125-15-345-2345-1246-56-234-15-234-234
-nofor word greatlys  1245-1235-2345-123-13456-234
-nofor word greatnephews  1245-1235-2345-1345-15-1234-125-15-2456-234
-nofor word greatnesss  1245-1235-2345-56-234-234
-nofor word greatnessess  1245-1235-2345-56-234-15-234-234
-nofor word greatnieces  1245-1235-2345-1345-24-15-14-15-234
-nofor word greatswords  1245-1235-2345-234-45-2456-234
-nofor word greatuncles  1245-1235-2345-136-1345-14-123-15-234
-nofor word guyfriends  1245-136-13456-124-1235-234
-nofor word hateletters  125-1-2345-15-123-1235-234
-nofor word headfirsts  125-2-145-124-34-234
-nofor word hereabouts  5-125-1-12-234
-nofor word hereafters  5-125-1-124-234
-nofor word hereagains  5-125-1-1245-234
-nofor word hereagainsts  5-125-1-1245-34-234
-nofor word hereinaboves  5-125-35-1-12-1236-234
-nofor word hereinafters  5-125-35-1-124-234
-nofor word hereinagains  5-125-35-1-1245-234
-nofor word highlypaids  125-24-126-123-13456-1234-145-234
-nofor word himbos  125-134-12-135-234
-nofor word himboess  125-134-12-135-15-234-234
-nofor word illpaids  24-123-123-1234-145-234
-nofor word immediatelys  24-134-134-123-13456-234
-nofor word immediatenesss  24-134-134-56-234-234
-nofor word inasmuchs  35-1-234-134-16-234
-nofor word insomuchs  35-234-135-134-16-234
-nofor word knockabouts  13-1345-135-14-13-1-12-234
-nofor word ladyfriends  123-1-145-13456-124-1235-234
-nofor word layabouts  123-1-13456-1-12-234
-nofor word letterbodiess  123-1235-12-135-145-24-15-234-234
-nofor word letterbodys  123-1235-12-135-145-13456-234
-nofor word letterbombs  123-1235-12-135-134-12-234
-nofor word letterbombers  123-1235-12-135-134-12-12456-234
-nofor word letterbombings  123-1235-12-135-134-12-346-234
-nofor word letterboxs  123-1235-12-135-1346-234
-nofor word letterboxers  123-1235-12-135-1346-12456-234
-nofor word letterboxess  123-1235-12-135-1346-15-234-234
-nofor word letterboxings  123-1235-12-135-1346-346-234
-nofor word letterers  123-1235-12456-234
-nofor word letterforms  123-1235-123456-134-234
-nofor word letterheads  123-1235-125-2-145-234
-nofor word letterheadings  123-1235-125-2-145-346-234
-nofor word letterings  123-1235-346-234
-nofor word lettermans  123-1235-134-1-1345-234
-nofor word lettermens  123-1235-134-26-234
-nofor word letteropeners  123-1235-135-1234-26-12456-234
-nofor word letterperfects  123-1235-1234-12456-124-15-14-2345-234
-nofor word letterpresss  123-1235-1234-1235-15-234-234-234
-nofor word letterpressess  123-1235-1234-1235-15-234-234-15-234-234
-nofor word letterpressings  123-1235-1234-1235-15-234-234-346-234
-nofor word letterqualitys  123-1235-12345-136-1-123-56-13456-234
-nofor word letterspaces  123-1235-234-1234-1-14-15-234
-nofor word letterspacings  123-1235-234-1234-1-14-346-234
-nofor word lettertexts  123-1235-2345-15-1346-2345-234
-nofor word littlenecks  123-123-1345-15-14-13-234
-nofor word littlenesss  123-123-56-234-234
-nofor word littlenessess  123-123-56-234-15-234-234
-nofor word littlers  123-123-1235-234
-nofor word littlests  123-123-34-234
-nofor word lovechildrens  123-135-1236-15-16-1345-234
-nofor word loveletters  123-135-1236-15-123-1235-234
-nofor word lowlypaids  123-246-123-13456-1234-145-234
-nofor word manfriends  134-1-1345-124-1235-234
-nofor word menfriendss  134-26-124-1235-234-234
-nofor word midafternoons  134-24-145-1-124-1345-234
-nofor word misbrailles  134-24-234-12-1235-123-234
-nofor word misperceives  134-24-234-1234-12456-14-1236-234
-nofor word misperceivers  134-24-234-1234-12456-14-1236-1235-234
-nofor word misperceivings  134-24-234-1234-12456-14-1236-1245-234
-nofor word missaids  134-24-234-234-145-234
-nofor word morningafters  134-135-1235-1345-346-1-124-234
-nofor word muchlys  134-16-123-13456-234
-nofor word muchnesss  134-16-56-234-234
-nofor word must'ves  134-34-3-1236-15-234
-nofor word mustas  134-34-1-234
-nofor word mustards  134-34-345-145-234
-nofor word mustardys  134-34-345-145-13456-234
-nofor word mustiers  134-34-24-12456-234
-nofor word mustiests  134-34-24-15-34-234
-nofor word mustilys  134-34-24-123-13456-234
-nofor word mustinesss  134-34-24-56-234-234
-nofor word mustn'ts  134-34-1345-3-2345-234
-nofor word mustn't'ves  134-34-1345-3-2345-3-1236-15-234
-nofor word mustys  134-34-13456-234
-nofor word newsletters  1345-15-2456-234-123-1235-234
-nofor word nonesuchs  1345-5-135-234-16-234
-nofor word nonsuchs  1345-135-1345-234-16-234
-nofor word northabouts  1345-135-1235-1456-1-12-234
-nofor word overmuchs  135-1236-12456-134-16-234
-nofor word overpaids  135-1236-12456-1234-145-234
-nofor word penfriends  1234-26-124-1235-234
-nofor word perceivers  1234-12456-14-1236-1235-234
-nofor word perhapsess  1234-12456-125-15-234-234
-nofor word poorlypaids  1234-135-135-1235-123-13456-1234-145-234
-nofor word postpaids  1234-135-34-1234-145-234
-nofor word preceives  1234-1235-14-1236-234
-nofor word preceivers  1234-1235-14-1236-1235-234
-nofor word preceivings  1234-1235-14-1236-1245-234
-nofor word prepaids  1234-1235-15-1234-145-234
-nofor word purblinds  1234-136-1235-12-123-234
-nofor word purblindlys  1234-136-1235-12-123-123-13456-234
-nofor word purblindnesss  1234-136-1235-12-123-56-234-234
-nofor word purblindnessess  1234-136-1235-12-123-56-234-15-234-234
-nofor word quickdraws  12345-13-145-1235-1-2456-234
-nofor word quickens  12345-13-26-234
-nofor word quickeners  12345-13-26-12456-234
-nofor word quickenings  12345-13-26-346-234
-nofor word quickers  12345-13-12456-234
-nofor word quickests  12345-13-15-34-234
-nofor word quickfires  12345-13-124-24-1235-15-234
-nofor word quickfirings  12345-13-124-24-1235-346-234
-nofor word quickfreezes  12345-13-124-1235-15-15-1356-15-234
-nofor word quickfreezings  12345-13-124-1235-15-15-1356-346-234
-nofor word quickfrozes  12345-13-124-1235-135-1356-15-234
-nofor word quickfrozens  12345-13-124-1235-135-1356-26-234
-nofor word quickies  12345-13-24-15-234
-nofor word quickishs  12345-13-24-146-234
-nofor word quickishlys  12345-13-24-146-123-13456-234
-nofor word quicklimes  12345-13-123-24-134-15-234
-nofor word quicklys  12345-13-123-13456-234
-nofor word quicknesss  12345-13-56-234-234
-nofor word quicknessess  12345-13-56-234-15-234-234
-nofor word quicksands  12345-13-234-12346-234
-nofor word quicksets  12345-13-234-15-2345-234
-nofor word quicksilvers  12345-13-234-24-123-1236-12456-234
-nofor word quicksilverings  12345-13-234-24-123-1236-12456-346-234
-nofor word quicksnaps  12345-13-234-1345-1-1234-234
-nofor word quicksteps  12345-13-34-15-1234-234
-nofor word quicksteppers  12345-13-34-15-1234-1234-12456-234
-nofor word quicksteppings  12345-13-34-15-1234-1234-346-234
-nofor word quicktimes  12345-13-5-2345-234
-nofor word quickwittedlys  12345-13-2456-24-2345-2345-1246-123-13456-234
-nofor word quickwittednesss  12345-13-2456-24-2345-2345-1246-56-234-234
-nofor word quickys  12345-13-13456-234
-nofor word readacrosss  1235-2-145-1-14-1235-234
-nofor word rebrailles  1235-15-12-1235-123-234
-nofor word rebraillers  1235-15-12-1235-123-1235-234
-nofor word receivers  1235-14-1236-1235-234
-nofor word receiverships  1235-14-1236-1235-146-24-1234-234
-nofor word rejoicefuls  1235-245-14-56-123-234
-nofor word rejoicefullys  1235-245-14-56-123-123-13456-234
-nofor word rejoicefulnesss  1235-245-14-56-123-56-234-234
-nofor word rejoicers  1235-245-14-1235-234
-nofor word rejoicinglys  1235-245-14-1245-123-13456-234
-nofor word reletters  1235-15-123-1235-234
-nofor word reletterings  1235-15-123-1235-346-234
-nofor word repaids  1235-15-1234-145-234
-nofor word rightabouts  5-1235-1-12-234
-nofor word roundabouts  1235-46-145-1-12-234
-nofor word roustabouts  1235-1256-34-1-12-234
-nofor word runabouts  1235-136-1345-1-12-234
-nofor word saidests  234-145-15-34-234
-nofor word saidsts  234-145-34-234
-nofor word scattergoods  234-14-1-2345-2345-12456-1245-145-234
-nofor word schoolchildrens  234-16-135-135-123-16-1345-234
-nofor word schoolfriends  234-16-135-135-123-124-1235-234
-nofor word should'ves  146-145-3-1236-15-234
-nofor word shouldas  146-145-1-234
-nofor word shouldests  146-145-15-34-234
-nofor word shouldn'ts  146-145-1345-3-2345-234
-nofor word shouldn't'ves  146-145-1345-3-2345-3-1236-15-234
-nofor word shouldsts  146-145-34-234
-nofor word snowblinds  234-1345-246-12-123-234
-nofor word snowblindnesss  234-1345-246-12-123-56-234-234
-nofor word snowblindnessess  234-1345-246-12-123-56-234-15-234-234
-nofor word somesuchs  5-234-234-16-234
-nofor word southabouts  234-1256-1456-1-12-234
-nofor word stepchildrens  34-15-1234-16-1345-234
-nofor word stirabouts  34-24-1235-1-12-234
-nofor word suchlikes  234-16-123-24-13-15-234
-nofor word supergoods  234-136-1234-12456-1245-145-234
-nofor word superquicks  234-136-1234-12456-12345-13-234
-nofor word tailfirsts  2345-1-24-123-124-34-234
-nofor word thereabouts  5-2346-1-12-234
-nofor word thereafters  5-2346-1-124-234
-nofor word thereagains  5-2346-1-1245-234
-nofor word thereagainsts  5-2346-1-1245-34-234
-nofor word thereinafters  5-2346-35-1-124-234
-nofor word thereinagains  5-2346-35-1-1245-234
-nofor word togethernesss  2345-1245-1235-56-234-234
-nofor word turnabouts  2345-136-1235-1345-1-12-234
-nofor word unaccordings  136-1345-1-14-234
-nofor word unaccordinglys  136-1345-1-14-123-13456-234
-nofor word unblindfolds  136-1345-12-123-124-135-123-145-234
-nofor word unblindfoldings  136-1345-12-123-124-135-123-145-346-234
-nofor word unbrailles  136-1345-12-1235-123-234
-nofor word undeceives  136-1345-145-14-1236-234
-nofor word undeceivers  136-1345-145-14-1236-1235-234
-nofor word undeceivings  136-1345-145-14-1236-1245-234
-nofor word undeclares  136-1345-145-14-123-234
-nofor word underpaids  5-136-1234-145-234
-nofor word unfriends  136-1345-124-1235-234
-nofor word unfriendliers  136-1345-124-1235-123-24-12456-234
-nofor word unfriendliests  136-1345-124-1235-123-24-15-34-234
-nofor word unfriendlinesss  136-1345-124-1235-123-24-56-234-234
-nofor word unfriendlinessess  136-1345-124-1235-123-24-56-234-15-234-234
-nofor word unfriendlys  136-1345-124-1235-123-13456-234
-nofor word unnecessarys  136-1345-1345-15-14-234
-nofor word unpaids  136-1345-1234-145-234
-nofor word unperceives  136-1345-1234-12456-14-1236-234
-nofor word unperceivings  136-1345-1234-12456-14-1236-1245-234
-nofor word unquicks  136-1345-12345-13-234
-nofor word unrejoices  136-1345-1235-245-14-234
-nofor word unrejoicefuls  136-1345-1235-245-14-56-123-234
-nofor word unrejoicefullys  136-1345-1235-245-14-56-123-123-13456-234
-nofor word unrejoicefulnesss  136-1345-1235-245-14-56-123-56-234-234
-nofor word unrejoicers  136-1345-1235-245-14-1235-234
-nofor word unrejoicings  136-1345-1235-245-14-1245-234
-nofor word unrejoicinglys  136-1345-1235-245-14-1245-123-13456-234
-nofor word unrepaids  136-1345-1235-15-1234-145-234
-nofor word unsaids  136-1345-234-145-234
-nofor word walkabouts  2456-1-123-13-1-12-234
-nofor word wellpaids  2456-15-123-123-1234-145-234
-nofor word westabouts  2456-15-34-1-12-234
-nofor word whereabouts  5-156-1-12-234
-nofor word whereafters  5-156-1-124-234
-nofor word whereagains  5-156-1-1245-234
-nofor word whereagainsts  5-156-1-1245-34-234
-nofor word whereinafters  5-156-35-1-124-234
-nofor word whereinagains  5-156-35-1-1245-234
-nofor word womanfriends  2456-135-134-1-1345-124-1235-234
-nofor word womenfriendss  2456-135-134-26-124-1235-234-234
-nofor word would'ves  2456-145-3-1236-15-234
-nofor word wouldas  2456-145-1-234
-nofor word wouldests  2456-145-15-34-234
-nofor word wouldn'ts  2456-145-1345-3-2345-234
-nofor word wouldn't'ves  2456-145-1345-3-2345-3-1236-15-234
-nofor word wouldsts  2456-145-34-234
+word 'twoulds  3-2345-2456-145-234
+word 'twould'ves  3-2345-2456-145-3-1236-15-234
+word 'twouldas  3-2345-2456-145-1-234
+word 'twouldn'ts  3-2345-2456-145-1345-3-2345-234
+word 'twouldn't'ves  3-2345-2456-145-1345-3-2345-3-1236-15-234
+word aboutfaces  1-12-124-1-14-15-234
+word aboutfacers  1-12-124-1-14-12456-234
+word aboutfacings  1-12-124-1-14-346-234
+word aboutturns  1-12-2345-136-1235-1345-234
+word aboveboards  1-12-1236-12-135-345-145-234
+word abovegrounds  1-12-1236-1245-1235-46-145-234
+word aforesaids  1-123456-15-234-145-234
+word afterbattles  1-124-12-1-2345-2345-123-15-234
+word afterbirths  1-124-12-24-1235-1456-234
+word afterbreakfasts  1-124-12-1235-2-13-124-1-34-234
+word afterburns  1-124-12-136-1235-1345-234
+word afterburners  1-124-12-136-1235-1345-12456-234
+word afterburnings  1-124-12-136-1235-1345-346-234
+word aftercares  1-124-14-345-15-234
+word afterclaps  1-124-14-123-1-1234-234
+word aftercoffees  1-124-14-12356-124-15-15-234
+word afterdamps  1-124-145-1-134-1234-234
+word afterdarks  1-124-145-345-13-234
+word afterdecks  1-124-145-15-14-13-234
+word afterdinners  1-124-145-35-1345-12456-234
+word afterflows  1-124-124-123-246-234
+word aftergames  1-124-1245-1-134-15-234
+word afterglows  1-124-1245-123-246-234
+word afterguards  1-124-1245-136-345-145-234
+word afterhatchs  1-124-125-1-2345-16-234
+word afterhatchess  1-124-125-1-2345-16-15-234-234
+word afterhours  1-124-125-1256-1235-234
+word afterlifes  1-124-123-24-124-15-234
+word afterlights  1-124-123-24-126-2345-234
+word afterlivess  1-124-123-24-1236-15-234-234
+word afterlunchs  1-124-123-136-1345-16-234
+word afterlunchess  1-124-123-136-1345-16-15-234-234
+word aftermarkets  1-124-134-345-13-15-2345-234
+word aftermatchs 1-124-134-1-2345-16-234
+word aftermaths  1-124-134-1-1456-234
+word aftermeetings  1-124-134-15-15-2345-346-234
+word aftermentioneds  1-124-134-26-56-1345-1246-234
+word aftermiddays  1-124-134-24-145-5-145-234
+word aftermidnights  1-124-134-24-145-1345-24-126-2345-234
+word aftermosts  1-124-134-135-34-234
+word afternoonteas  1-124-1345-2345-15-1-234
+word afterpains  1-124-1234-1-35-234
+word afterpartiess  1-124-5-1234-24-15-234-234
+word afterpartys  1-124-5-1234-13456-234
+word afterpieces  1-124-1234-24-15-14-15-234
+word afterplays  1-124-1234-123-1-13456-234
+word aftersales  1-124-234-1-123-15-234
+word afterschools  1-124-234-16-135-135-123-234
+word aftersensations  1-124-234-26-234-1-56-1345-234
+word aftershaves  1-124-146-1-1236-15-234
+word aftershocks  1-124-146-135-14-13-234
+word aftershows  1-124-146-246-234
+word aftershowers  1-124-146-246-12456-234
+word aftersuppers  1-124-234-136-1234-1234-12456-234
+word aftertastes  1-124-2345-1-34-15-234
+word aftertaxs  1-124-2345-1-1346-234
+word aftertaxess  1-124-2345-1-1346-15-234-234
+word afterteas  1-124-2345-15-1-234
+word aftertheaters  1-124-2346-1-2345-12456-234
+word aftertheatres  1-124-2346-1-2345-1235-15-234
+word afterthoughts  1-124-1456-5-1256-234
+word aftertimes  1-124-5-2345-234
+word aftertreatments  1-124-2345-1235-2-2345-56-2345-234
+word afterwords  1-124-45-2456-234
+word afterworks  1-124-5-2456-234
+word afterworlds  1-124-456-2456-234
+word apperceives  1-1234-1234-12456-14-1236-234
+word apperceivers  1-1234-1234-12456-14-1236-1235-234
+word apperceivings  1-1234-1234-12456-14-1236-1245-234
+word archdeceivers  345-16-145-14-1236-1235-234
+word beforehands  23-124-125-12346-234
+word beforementioneds  23-124-134-26-56-1345-1246-234
+word befriends  23-124-1235-234
+word behindhands  23-125-125-12346-234
+word belittles  23-123-123-234
+word belittlements  23-123-123-56-2345-234
+word belittlers  23-123-123-1235-234
+word belowdecks  23-123-145-15-14-13-234
+word belowgrounds  23-123-1245-1235-46-145-234
+word beneathdecks  23-1345-145-15-14-13-234
+word beneathgrounds  23-1345-1245-1235-46-145-234
+word betweendecks  23-2345-145-15-14-13-234
+word betweentimes  23-2345-5-2345-234
+word betweenwhiles  23-2345-156-24-123-15-234
+word blindfishs  12-123-124-24-146-234
+word blindfishess  12-123-124-24-146-15-234-234
+word blindfolds  12-123-124-135-123-145-234
+word blindfolders  12-123-124-135-123-145-12456-234
+word blindfoldings  12-123-124-135-123-145-346-234
+word blindlys  12-123-123-13456-234
+word blindmans  12-123-134-1-1345-234
+word blindmens  12-123-134-26-234
+word blindnesss  12-123-56-234-234
+word blindnessess  12-123-56-234-15-234-234
+word blindsides  12-123-234-24-145-15-234
+word blindsiders  12-123-234-24-145-12456-234
+word blindsidings  12-123-234-24-145-346-234
+word blindsights  12-123-234-24-126-2345-234
+word blindstoriess  12-123-34-135-1235-24-15-234-234
+word blindstorys  12-123-34-135-1235-13456-234
+word blindworms  12-123-2456-135-1235-134-234
+word bloodletters  12-123-135-135-145-123-1235-234
+word boyfriends  12-135-13456-124-1235-234
+word braillers  12-1235-123-1235-234
+word braillewriters  12-1235-123-2456-1235-24-2345-12456-234
+word braillewritings  12-1235-123-2456-1235-24-2345-346-234
+word brailleys  12-1235-123-13456-234
+word brainchildrens  12-1235-1-35-16-1345-234
+word chainletters  16-1-35-123-1235-234
+word children'swears  16-1345-3-234-2456-15-345-234
+word colorblinds  14-135-123-135-1235-12-123-234
+word colorblindnesss  14-135-123-135-1235-12-123-56-234-234
+word colorblindnessess  14-135-123-135-1235-12-123-56-234-15-234-234
+word colourblinds  14-135-123-1256-1235-12-123-234
+word colourblindnesss  14-135-123-1256-1235-12-123-56-234-234
+word colourblindnessess  14-135-123-1256-1235-12-123-56-234-15-234-234
+word conceivers  25-14-1236-1235-234
+word could'ves  14-145-3-1236-15-234
+word couldas  14-145-1-234
+word couldests  14-145-15-34-234
+word couldn'ts  14-145-1345-3-2345-234
+word couldn't'ves  14-145-1345-3-2345-3-1236-15-234
+word couldsts  14-145-34-234
+word deafblinds  145-2-124-12-123-234
+word deafblindnesss  145-2-124-12-123-56-234-234
+word deafblindnessess  145-2-124-12-123-56-234-15-234-234
+word deceivers  145-14-1236-1235-234
+word declarers  145-14-123-1235-234
+word defriends  145-15-124-1235-234
+word do-it-yourselfers  145-36-1346-36-13456-1235-124-12456-234
+word doublequicks  145-1256-12-123-15-12345-13-234
+word eastabouts  15-1-34-1-12-234
+word feelgoods  124-15-15-123-1245-145-234
+word feetfirsts  124-15-15-2345-124-34-234
+word firstaids  124-34-1-24-145-234
+word firstaiders  124-34-1-24-145-12456-234
+word firstborns  124-34-12-135-1235-1345-234
+word firstclasss  124-34-14-123-1-234-234-234
+word firstclassess  124-34-14-123-1-234-234-15-234-234
+word firstdays  124-34-5-145-234
+word firstdayers  124-34-5-145-12456-234
+word firstfruits  124-34-124-1235-136-24-2345-234
+word firstfruitings  124-34-124-1235-136-24-2345-346-234
+word firstgenerations  124-34-1245-26-12456-1-56-1345-234
+word firsthands  124-34-125-12346-234
+word firstlings  124-34-123-346-234
+word firstlys  124-34-123-13456-234
+word firstnesss  124-34-56-234-234
+word firstnights  124-34-1345-24-126-2345-234
+word firstnighters  124-34-1345-24-126-2345-12456-234
+word firstrates  124-34-1235-1-2345-15-234
+word firstratings  124-34-1235-1-2345-346-234
+word firststrings  124-34-34-1235-346-234
+word forasmuchs  123456-1-234-134-16-234
+word foresaids  123456-15-234-145-234
+word fosterchildrens  124-135-34-12456-16-1345-234
+word friendlesss  124-1235-46-234-234
+word friendlessnesss  124-1235-46-234-56-234-234
+word friendlessnessess  124-1235-46-234-56-234-15-234-234
+word friendliers  124-1235-123-24-12456-234
+word friendliess  124-1235-123-24-15-234-234
+word friendliests  124-1235-123-24-15-34-234
+word friendlinesss  124-1235-123-24-56-234-234
+word friendlinessess  124-1235-123-24-56-234-15-234-234
+word friendlys  124-1235-123-13456-234
+word friendships  124-1235-146-24-1234-234
+word gadabouts  1245-1-145-1-12-234
+word gainsaids  1245-1-35-234-145-234
+word galfriends  1245-1-123-124-1235-234
+word gentlemanfriends  1245-26-2345-123-15-134-1-1345-124-1235-234
+word gentlemenfriendss  1245-26-2345-123-15-134-26-124-1235-234-234
+word girlfriends  1245-24-1235-123-124-1235-234
+word godchildrens  1245-135-145-16-1345-234
+word goodafternoons  1245-145-1-124-1345-234
+word goodbys  1245-145-12-13456-234
+word goodbyes  1245-145-12-13456-15-234
+word goodbyeings  1245-145-12-13456-15-346-234
+word goodbyings  1245-145-12-13456-346-234
+word gooddays  1245-145-5-145-234
+word gooders  1245-145-12456-234
+word goodests  1245-145-15-34-234
+word goodevenings  1245-145-15-1236-26-346-234
+word goodfellows  1245-145-124-15-123-123-246-234
+word goodfellowships  1245-145-124-15-123-123-246-146-24-1234-234
+word goodheartedlys  1245-145-125-15-345-2345-1246-123-13456-234
+word goodheartednesss  1245-145-125-15-345-2345-1246-56-234-234
+word goodhumors  1245-145-125-136-134-135-1235-234
+word goodhumoredlys  1245-145-125-136-134-135-1235-1246-123-13456-234
+word goodhumorednesss  1245-145-125-136-134-135-1235-1246-56-234-234
+word goodhumorednessess  1245-145-125-136-134-135-1235-1246-56-234-15-234-234
+word goodhumours  1245-145-125-136-134-1256-1235-234
+word goodhumouredlys  1245-145-125-136-134-1256-1235-1246-123-13456-234
+word goodhumourednesss  1245-145-125-136-134-1256-1235-1246-56-234-234
+word goodhumourednessess  1245-145-125-136-134-1256-1235-1246-56-234-15-234-234
+word goodies  1245-145-24-15-234
+word goodishs  1245-145-24-146-234
+word goodliers  1245-145-123-24-12456-234
+word goodliests  1245-145-123-24-15-34-234
+word goodlinesss  1245-145-123-24-56-234-234
+word goodlooks  1245-145-123-135-135-13-234
+word goodlookers  1245-145-123-135-135-13-12456-234
+word goodlookings  1245-145-123-135-135-13-346-234
+word goodlys  1245-145-123-13456-234
+word goodmans  1245-145-134-1-1345-234
+word goodmens  1245-145-134-26-234
+word goodmornings  1245-145-134-135-1235-1345-346-234
+word goodnatures  1245-145-1345-1-2345-136-1235-15-234
+word goodnaturedlys  1245-145-1345-1-2345-136-1235-1246-123-13456-234
+word goodnaturednesss  1245-145-1345-1-2345-136-1235-1246-56-234-234
+word goodnesss  1245-145-56-234-234
+word goodnessess  1245-145-56-234-15-234-234
+word goodnights  1245-145-1345-24-126-2345-234
+word goodsizes  1245-145-234-24-1356-15-234
+word goodtemperedlys  1245-145-2345-15-134-1234-12456-1246-123-13456-234
+word goodtimes  1245-145-5-2345-234
+word gooduns  1245-145-136-1345-234
+word goodwifes  1245-145-2456-24-124-15-234
+word goodwills  1245-145-2456-24-123-123-234
+word goodwivess  1245-145-2456-24-1236-15-234-234
+word goodys  1245-145-13456-234
+word goodyears  1245-145-13456-15-345-234
+word grandchildrens  1245-1235-12346-16-1345-234
+word greataunts  1245-1235-2345-1-136-1345-2345-234
+word greatbatchs  1245-1235-2345-12-1-2345-16-234
+word greatcircles  1245-1235-2345-14-24-1235-14-123-15-234
+word greatcoats  1245-1235-2345-14-135-1-2345-234
+word greatens  1245-1235-2345-26-234
+word greateners  1245-1235-2345-26-12456-234
+word greatenings  1245-1235-2345-26-346-234
+word greaters  1245-1235-2345-12456-234
+word greatests  1245-1235-2345-15-34-234
+word greatgrandaunts  1245-1235-2345-1245-1235-12346-1-136-1345-2345-234
+word greatgrandchilds  1245-1235-2345-1245-1235-12346-16-24-123-145-234
+word greatgrandchildrens  1245-1235-2345-1245-1235-12346-16-1345-234
+word greatgranddads  1245-1235-2345-1245-1235-12346-145-1-145-234
+word greatgranddaughters  1245-1235-2345-1245-1235-12346-145-1-136-126-2345-12456-234
+word greatgrandfathers  1245-1235-2345-1245-1235-12346-5-124-234
+word greatgrandfatherhoods  1245-1235-2345-1245-1235-12346-5-124-125-135-135-145-234
+word greatgrandmas  1245-1235-2345-1245-1235-12346-134-1-234
+word greatgrandmothers  1245-1235-2345-1245-1235-12346-5-134-234
+word greatgrandmotherhoods  1245-1235-2345-1245-1235-12346-5-134-125-135-135-145-234
+word greatgrandnephews  1245-1235-2345-1245-1235-12346-1345-15-1234-125-15-2456-234
+word greatgrandnieces  1245-1235-2345-1245-1235-12346-1345-24-15-14-15-234
+word greatgrandpas  1245-1235-2345-1245-1235-12346-1234-1-234
+word greatgrandparents  1245-1235-2345-1245-1235-12346-1234-345-26-2345-234
+word greatgrandparenthoods  1245-1235-2345-1245-1235-12346-1234-345-26-2345-125-135-135-145-234
+word greatgrandsons  1245-1235-2345-1245-1235-12346-234-135-1345-234
+word greatgranduncles  1245-1235-2345-1245-1235-12346-136-1345-14-123-15-234
+word greatheartedlys  1245-1235-2345-125-15-345-2345-1246-123-13456-234
+word greatheartednesss  1245-1235-2345-125-15-345-2345-1246-56-234-234
+word greatheartednessess  1245-1235-2345-125-15-345-2345-1246-56-234-15-234-234
+word greatlys  1245-1235-2345-123-13456-234
+word greatnephews  1245-1235-2345-1345-15-1234-125-15-2456-234
+word greatnesss  1245-1235-2345-56-234-234
+word greatnessess  1245-1235-2345-56-234-15-234-234
+word greatnieces  1245-1235-2345-1345-24-15-14-15-234
+word greatswords  1245-1235-2345-234-45-2456-234
+word greatuncles  1245-1235-2345-136-1345-14-123-15-234
+word guyfriends  1245-136-13456-124-1235-234
+word hateletters  125-1-2345-15-123-1235-234
+word headfirsts  125-2-145-124-34-234
+word hereabouts  5-125-1-12-234
+word hereafters  5-125-1-124-234
+word hereagains  5-125-1-1245-234
+word hereagainsts  5-125-1-1245-34-234
+word hereinaboves  5-125-35-1-12-1236-234
+word hereinafters  5-125-35-1-124-234
+word hereinagains  5-125-35-1-1245-234
+word highlypaids  125-24-126-123-13456-1234-145-234
+word himbos  125-134-12-135-234
+word himboess  125-134-12-135-15-234-234
+word illpaids  24-123-123-1234-145-234
+word immediatelys  24-134-134-123-13456-234
+word immediatenesss  24-134-134-56-234-234
+word inasmuchs  35-1-234-134-16-234
+word insomuchs  35-234-135-134-16-234
+word knockabouts  13-1345-135-14-13-1-12-234
+word ladyfriends  123-1-145-13456-124-1235-234
+word layabouts  123-1-13456-1-12-234
+word letterbodiess  123-1235-12-135-145-24-15-234-234
+word letterbodys  123-1235-12-135-145-13456-234
+word letterbombs  123-1235-12-135-134-12-234
+word letterbombers  123-1235-12-135-134-12-12456-234
+word letterbombings  123-1235-12-135-134-12-346-234
+word letterboxs  123-1235-12-135-1346-234
+word letterboxers  123-1235-12-135-1346-12456-234
+word letterboxess  123-1235-12-135-1346-15-234-234
+word letterboxings  123-1235-12-135-1346-346-234
+word letterers  123-1235-12456-234
+word letterforms  123-1235-123456-134-234
+word letterheads  123-1235-125-2-145-234
+word letterheadings  123-1235-125-2-145-346-234
+word letterings  123-1235-346-234
+word lettermans  123-1235-134-1-1345-234
+word lettermens  123-1235-134-26-234
+word letteropeners  123-1235-135-1234-26-12456-234
+word letterperfects  123-1235-1234-12456-124-15-14-2345-234
+word letterpresss  123-1235-1234-1235-15-234-234-234
+word letterpressess  123-1235-1234-1235-15-234-234-15-234-234
+word letterpressings  123-1235-1234-1235-15-234-234-346-234
+word letterqualitys  123-1235-12345-136-1-123-56-13456-234
+word letterspaces  123-1235-234-1234-1-14-15-234
+word letterspacings  123-1235-234-1234-1-14-346-234
+word lettertexts  123-1235-2345-15-1346-2345-234
+word littlenecks  123-123-1345-15-14-13-234
+word littlenesss  123-123-56-234-234
+word littlenessess  123-123-56-234-15-234-234
+word littlers  123-123-1235-234
+word littlests  123-123-34-234
+word lovechildrens  123-135-1236-15-16-1345-234
+word loveletters  123-135-1236-15-123-1235-234
+word lowlypaids  123-246-123-13456-1234-145-234
+word manfriends  134-1-1345-124-1235-234
+word menfriendss  134-26-124-1235-234-234
+word midafternoons  134-24-145-1-124-1345-234
+word misbrailles  134-24-234-12-1235-123-234
+word misperceives  134-24-234-1234-12456-14-1236-234
+word misperceivers  134-24-234-1234-12456-14-1236-1235-234
+word misperceivings  134-24-234-1234-12456-14-1236-1245-234
+word missaids  134-24-234-234-145-234
+word morningafters  134-135-1235-1345-346-1-124-234
+word muchlys  134-16-123-13456-234
+word muchnesss  134-16-56-234-234
+word must'ves  134-34-3-1236-15-234
+word mustas  134-34-1-234
+word mustards  134-34-345-145-234
+word mustardys  134-34-345-145-13456-234
+word mustiers  134-34-24-12456-234
+word mustiests  134-34-24-15-34-234
+word mustilys  134-34-24-123-13456-234
+word mustinesss  134-34-24-56-234-234
+word mustn'ts  134-34-1345-3-2345-234
+word mustn't'ves  134-34-1345-3-2345-3-1236-15-234
+word mustys  134-34-13456-234
+word newsletters  1345-15-2456-234-123-1235-234
+word nonesuchs  1345-5-135-234-16-234
+word nonsuchs  1345-135-1345-234-16-234
+word northabouts  1345-135-1235-1456-1-12-234
+word overmuchs  135-1236-12456-134-16-234
+word overpaids  135-1236-12456-1234-145-234
+word penfriends  1234-26-124-1235-234
+word perceivers  1234-12456-14-1236-1235-234
+word perhapsess  1234-12456-125-15-234-234
+word poorlypaids  1234-135-135-1235-123-13456-1234-145-234
+word postpaids  1234-135-34-1234-145-234
+word preceives  1234-1235-14-1236-234
+word preceivers  1234-1235-14-1236-1235-234
+word preceivings  1234-1235-14-1236-1245-234
+word prepaids  1234-1235-15-1234-145-234
+word purblinds  1234-136-1235-12-123-234
+word purblindlys  1234-136-1235-12-123-123-13456-234
+word purblindnesss  1234-136-1235-12-123-56-234-234
+word purblindnessess  1234-136-1235-12-123-56-234-15-234-234
+word quickdraws  12345-13-145-1235-1-2456-234
+word quickens  12345-13-26-234
+word quickeners  12345-13-26-12456-234
+word quickenings  12345-13-26-346-234
+word quickers  12345-13-12456-234
+word quickests  12345-13-15-34-234
+word quickfires  12345-13-124-24-1235-15-234
+word quickfirings  12345-13-124-24-1235-346-234
+word quickfreezes  12345-13-124-1235-15-15-1356-15-234
+word quickfreezings  12345-13-124-1235-15-15-1356-346-234
+word quickfrozes  12345-13-124-1235-135-1356-15-234
+word quickfrozens  12345-13-124-1235-135-1356-26-234
+word quickies  12345-13-24-15-234
+word quickishs  12345-13-24-146-234
+word quickishlys  12345-13-24-146-123-13456-234
+word quicklimes  12345-13-123-24-134-15-234
+word quicklys  12345-13-123-13456-234
+word quicknesss  12345-13-56-234-234
+word quicknessess  12345-13-56-234-15-234-234
+word quicksands  12345-13-234-12346-234
+word quicksets  12345-13-234-15-2345-234
+word quicksilvers  12345-13-234-24-123-1236-12456-234
+word quicksilverings  12345-13-234-24-123-1236-12456-346-234
+word quicksnaps  12345-13-234-1345-1-1234-234
+word quicksteps  12345-13-34-15-1234-234
+word quicksteppers  12345-13-34-15-1234-1234-12456-234
+word quicksteppings  12345-13-34-15-1234-1234-346-234
+word quicktimes  12345-13-5-2345-234
+word quickwittedlys  12345-13-2456-24-2345-2345-1246-123-13456-234
+word quickwittednesss  12345-13-2456-24-2345-2345-1246-56-234-234
+word quickys  12345-13-13456-234
+word readacrosss  1235-2-145-1-14-1235-234
+word rebrailles  1235-15-12-1235-123-234
+word rebraillers  1235-15-12-1235-123-1235-234
+word receivers  1235-14-1236-1235-234
+word receiverships  1235-14-1236-1235-146-24-1234-234
+word rejoicefuls  1235-245-14-56-123-234
+word rejoicefullys  1235-245-14-56-123-123-13456-234
+word rejoicefulnesss  1235-245-14-56-123-56-234-234
+word rejoicers  1235-245-14-1235-234
+word rejoicinglys  1235-245-14-1245-123-13456-234
+word reletters  1235-15-123-1235-234
+word reletterings  1235-15-123-1235-346-234
+word repaids  1235-15-1234-145-234
+word rightabouts  5-1235-1-12-234
+word roundabouts  1235-46-145-1-12-234
+word roustabouts  1235-1256-34-1-12-234
+word runabouts  1235-136-1345-1-12-234
+word saidests  234-145-15-34-234
+word saidsts  234-145-34-234
+word scattergoods  234-14-1-2345-2345-12456-1245-145-234
+word schoolchildrens  234-16-135-135-123-16-1345-234
+word schoolfriends  234-16-135-135-123-124-1235-234
+word should'ves  146-145-3-1236-15-234
+word shouldas  146-145-1-234
+word shouldests  146-145-15-34-234
+word shouldn'ts  146-145-1345-3-2345-234
+word shouldn't'ves  146-145-1345-3-2345-3-1236-15-234
+word shouldsts  146-145-34-234
+word snowblinds  234-1345-246-12-123-234
+word snowblindnesss  234-1345-246-12-123-56-234-234
+word snowblindnessess  234-1345-246-12-123-56-234-15-234-234
+word somesuchs  5-234-234-16-234
+word southabouts  234-1256-1456-1-12-234
+word stepchildrens  34-15-1234-16-1345-234
+word stirabouts  34-24-1235-1-12-234
+word suchlikes  234-16-123-24-13-15-234
+word supergoods  234-136-1234-12456-1245-145-234
+word superquicks  234-136-1234-12456-12345-13-234
+word tailfirsts  2345-1-24-123-124-34-234
+word thereabouts  5-2346-1-12-234
+word thereafters  5-2346-1-124-234
+word thereagains  5-2346-1-1245-234
+word thereagainsts  5-2346-1-1245-34-234
+word thereinafters  5-2346-35-1-124-234
+word thereinagains  5-2346-35-1-1245-234
+word togethernesss  2345-1245-1235-56-234-234
+word turnabouts  2345-136-1235-1345-1-12-234
+word unaccordings  136-1345-1-14-234
+word unaccordinglys  136-1345-1-14-123-13456-234
+word unblindfolds  136-1345-12-123-124-135-123-145-234
+word unblindfoldings  136-1345-12-123-124-135-123-145-346-234
+word unbrailles  136-1345-12-1235-123-234
+word undeceives  136-1345-145-14-1236-234
+word undeceivers  136-1345-145-14-1236-1235-234
+word undeceivings  136-1345-145-14-1236-1245-234
+word undeclares  136-1345-145-14-123-234
+word underpaids  5-136-1234-145-234
+word unfriends  136-1345-124-1235-234
+word unfriendliers  136-1345-124-1235-123-24-12456-234
+word unfriendliests  136-1345-124-1235-123-24-15-34-234
+word unfriendlinesss  136-1345-124-1235-123-24-56-234-234
+word unfriendlinessess  136-1345-124-1235-123-24-56-234-15-234-234
+word unfriendlys  136-1345-124-1235-123-13456-234
+word unnecessarys  136-1345-1345-15-14-234
+word unpaids  136-1345-1234-145-234
+word unperceives  136-1345-1234-12456-14-1236-234
+word unperceivings  136-1345-1234-12456-14-1236-1245-234
+word unquicks  136-1345-12345-13-234
+word unrejoices  136-1345-1235-245-14-234
+word unrejoicefuls  136-1345-1235-245-14-56-123-234
+word unrejoicefullys  136-1345-1235-245-14-56-123-123-13456-234
+word unrejoicefulnesss  136-1345-1235-245-14-56-123-56-234-234
+word unrejoicers  136-1345-1235-245-14-1235-234
+word unrejoicings  136-1345-1235-245-14-1245-234
+word unrejoicinglys  136-1345-1235-245-14-1245-123-13456-234
+word unrepaids  136-1345-1235-15-1234-145-234
+word unsaids  136-1345-234-145-234
+word walkabouts  2456-1-123-13-1-12-234
+word wellpaids  2456-15-123-123-1234-145-234
+word westabouts  2456-15-34-1-12-234
+word whereabouts  5-156-1-12-234
+word whereafters  5-156-1-124-234
+word whereagains  5-156-1-1245-234
+word whereagainsts  5-156-1-1245-34-234
+word whereinafters  5-156-35-1-124-234
+word whereinagains  5-156-35-1-1245-234
+word womanfriends  2456-135-134-1-1345-124-1235-234
+word womenfriendss  2456-135-134-26-124-1235-234-234
+word would'ves  2456-145-3-1236-15-234
+word wouldas  2456-145-1-234
+word wouldests  2456-145-15-34-234
+word wouldn'ts  2456-145-1345-3-2345-234
+word wouldn't'ves  2456-145-1345-3-2345-3-1236-15-234
+word wouldsts  2456-145-34-234
 
 #TODO:  what about s'?
 nofor word 'twould's  3-2345-2456-145-3-234
@@ -4467,3 +3849,71 @@ nofor always : 56-25
 nofor always . 56-256
 nofor always ! 56-235
 nofor always ? 56-236
+
+#   forward rules for typographic-apostrophe (U+2019) forms
+
+word children’swear  16-1345-3-234-2456-15-345
+word couldn’t  14-145-1345-3-2345
+word couldn’t’ve  14-145-1345-3-2345-3-1236-15
+word could’ve  14-145-3-1236-15
+word mustn’t  134-34-1345-3-2345
+word mustn’t’ve  134-34-1345-3-2345-3-1236-15
+word must’ve  134-34-3-1236-15
+word shouldn’t  146-145-1345-3-2345
+word shouldn’t’ve  146-145-1345-3-2345-3-1236-15
+word should’ve  146-145-3-1236-15
+word wouldn’t  2456-145-1345-3-2345
+word wouldn’t’ve  2456-145-1345-3-2345-3-1236-15
+word would’ve  2456-145-3-1236-15
+word ’twould  3-2345-2456-145
+word ’twoulda  3-2345-2456-145-1
+word ’twouldn’t  3-2345-2456-145-1345-3-2345
+word ’twouldn’t’ve  3-2345-2456-145-1345-3-2345-3-1236-15
+word ’twould’ve  3-2345-2456-145-3-1236-15
+
+#   forward-only 'shortform + s' forms
+
+noback word aboutfaceds  1-12-124-1-14-1246-234
+noback word aboutturneds  1-12-2345-136-1235-1345-1246-234
+noback word abovementioneds  1-12-1236-134-26-56-1345-1246-234
+noback word accordinglys  1-14-123-13456-234
+noback word afterburneds  1-124-12-136-1235-1345-1246-234
+noback word aftermatchess  1-124-134-1-2345-16-15-234-234
+noback word apperceiveds  1-1234-1234-12456-14-1236-145-234
+noback word belittleds  23-123-123-145-234
+noback word belowmentioneds  23-123-134-26-56-1345-1246-234
+noback word children’swears  16-1345-3-234-2456-15-345-234
+noback word conceiveds  25-14-1236-145-234
+noback word couldn’ts  14-145-1345-3-2345-234
+noback word couldn’t’ves  14-145-1345-3-2345-3-1236-15-234
+noback word could’ves  14-145-3-1236-15-234
+noback word deceiveds  145-14-1236-145-234
+noback word declareds  145-14-123-145-234
+noback word lettereds  123-1235-1246-234
+noback word misperceiveds  134-24-234-1234-12456-14-1236-145-234
+noback word mustn’ts  134-34-1345-3-2345-234
+noback word mustn’t’ves  134-34-1345-3-2345-3-1236-15-234
+noback word must’ves  134-34-3-1236-15-234
+noback word perceiveds  1234-12456-14-1236-145-234
+noback word quickeneds  12345-13-26-1246-234
+noback word receiveds  1235-14-1236-145-234
+noback word rejoiceds  1235-245-14-145-234
+noback word relettereds  1235-15-123-1235-1246-234
+noback word shouldn’ts  146-145-1345-3-2345-234
+noback word shouldn’t’ves  146-145-1345-3-2345-3-1236-15-234
+noback word should’ves  146-145-3-1236-15-234
+noback word unblindfoldeds  136-1345-12-123-124-135-123-145-1246-234
+noback word undeceiveds  136-1345-145-14-1236-145-234
+noback word undeclareds  136-1345-145-14-123-145-234
+noback word unlettereds  136-1345-123-1235-1246-234
+noback word unperceiveds  136-1345-1234-12456-14-1236-145-234
+noback word unreceiveds  136-1345-1235-14-1236-145-234
+noback word unrejoiceds  136-1345-1235-245-14-145-234
+noback word wouldn’ts  2456-145-1345-3-2345-234
+noback word wouldn’t’ves  2456-145-1345-3-2345-3-1236-15-234
+noback word would’ves  2456-145-3-1236-15-234
+noback word ’twoulds  3-2345-2456-145-234
+noback word ’twouldas  3-2345-2456-145-1-234
+noback word ’twouldn’ts  3-2345-2456-145-1345-3-2345-234
+noback word ’twouldn’t’ves  3-2345-2456-145-1345-3-2345-3-1236-15-234
+noback word ’twould’ves  3-2345-2456-145-3-1236-15-234

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -3667,6 +3667,29 @@ tests:
 - - about’s
   - ab's
 
+# Shortform contraction in all-capitals words followed by 'VE. The
+# shortform applies just as in the lowercase and capitalised forms;
+# capitals re-indication around the apostrophe is unchanged.
+
+- - could've
+  - cd've
+- - COULD'VE
+  - ',,cd'',,ve'
+- - COULD’VE
+  - ',,cd'',,ve'
+- - MUST'VE
+  - ',,m/'',,ve'
+- - MUST’VE
+  - ',,m/'',,ve'
+- - SHOULD'VE
+  - ',,%d'',,ve'
+- - SHOULD’VE
+  - ',,%d'',,ve'
+- - WOULD'VE
+  - ',,wd'',,ve'
+- - WOULD’VE
+  - ',,wd'',,ve'
+
 # 10.9.2 page 137
 
 - - aboveground

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -3647,6 +3647,26 @@ tests:
 - - www.living.beyond.myself.org
   - www4liv+4beyond4myself4org
 
+# A trailing right single quotation mark (U+2019) after a plural shortform
+# must remain an apostrophe (dot 3), not become a closing quotation mark,
+# even though the shortform word rule consumes the word-final "s"
+# (see the "noback endword s\x2019" rule in en-ueb-chardefs.uti).
+
+- - the afternoons’ heat
+  - '! afns'' h1t'
+- - his friends’ interference
+  - '8 frs'' 9t}f};e'
+- - the braillewriters’ keys
+  - '! brlwrit}s'' keys'
+- - the dogs’ bones
+  - '! dogs'' b"os'
+- - the afternoons' heat
+  - '! afns'' h1t'
+- - his friends' interference
+  - '8 frs'' 9t}f};e'
+- - about’s
+  - ab's
+
 # 10.9.2 page 137
 
 - - aboveground


### PR DESCRIPTION
### Motivation

`en-ueb-g2.ctb` carries two parallel rule blocks for the UEB 10.9 shortforms and the Appendix 1 shortform extensions: forward-only `match` rules whose pre/post patterns encode the *standing alone* condition (UEB 2.6), and backward-only `nofor word` rules with the same dot patterns. For the overwhelming majority of entries the `word` opcode already enforces exactly what the match patterns express, so the table effectively stores every shortform twice. That duplication is a measurable memory cost for consumers that keep the compiled table resident (e.g. screen readers on low-spec hardware).

The idea of replacing the `match` rules with bidirectional `word` rules was suggested by James Bowden ([@jrbowden](https://github.com/jrbowden)). Applied literally, the substitution breaks translation in a few subtle ways (detailed below), so this PR implements a revised version of his proposal that keeps the memory saving while remaining behavior-safe.

### What changed

- **618 `match` rules deleted** — those whose pattern is the plain standing-alone shape, fully redundant with a `word` rule.
- **11 `match` rules kept** — the UEB 10.9.3 / Appendix 1.4 forms (`blind`, `braille`, `children`, `first`, `friend`, `good`, `great`, `letter`, `little`, `quick`, `whereabouts`) whose patterns express in-word conditions a `word` rule cannot (`Blindcraft`, `Braillette`, `greatgreatgrandchildren`, …).
- **1,166 `nofor word` rules promoted to bidirectional `word`** (base words and `+s` plurals).
- **611 possessive `X's` rules left back-only** — they are redundant forward (`word X` already fires before the apostrophe), and promoting them would only lengthen the forward hash chains.
- **18 `word` rules added for typographic-apostrophe forms** (`wouldn’t`, `could’ve`, `’twould`, …) — previously covered only by match rules; the `nofor` blocks contain no U+2019 entries at all.
- **44 `noback word` rules added** for `+s` forms that only the match rules' `([Ss]|['’][Ss])?` post-pattern had covered.
- **`nofor word whereabouts's` left back-only** — its dots (`5-156-1-12-234-234`) are missing the apostrophe cell and are only valid as a back-translation target (pre-existing bug, to be fixed separately).
- **1 `match` rule added** to preserve the trailing plural-possessive apostrophe (next section).

### Preserving the trailing plural-possessive apostrophe (U+2019)

`noback endword s\x2019 234-3` (en-ueb-chardefs.uti) is what keeps a trailing right single quotation mark after plural `s` an apostrophe (`the dogs’ bones`). The old match rules consumed only the base word, leaving `s’` for that endword rule; a promoted `word Xs` rule consumes the `s`, so the lone `’` would fall through to the default close-quote punctuation rule (`friends’` → ⠋⠗⠎⠠⠴ instead of ⠋⠗⠎⠄). One added rule restores the heuristic at positions where the `s` was consumed by a preceding rule:

```
noback match [sS] \x2019 %>*%[_~^] 3
```

ASCII `'` is unaffected either way (its default is already dot 3).

### Side-effect bug fix: shortform contraction in all-caps `'VE` words

Previously the table contracted `could've` → ⠉⠙⠄⠧⠑ and `Could've` → ⠠⠉⠙⠄⠧⠑, but failed to contract the all-caps form: `COULD'VE` came out spelled letter-for-letter (⠠⠠⠉⠳⠇⠙⠄⠠⠠⠧⠑). The match rules' post-patterns could not match `'VE` following the shortform, whereas the promoted `word could` rule fires regardless of what follows the word boundary. With this PR:

```
COULD'VE   ⠠⠠⠉⠳⠇⠙⠄⠠⠠⠧⠑  →  ⠠⠠⠉⠙⠄⠠⠠⠧⠑
```

and likewise `MUST'VE`, `SHOULD'VE`, `WOULD'VE` (both apostrophe forms). Only the shortform contraction changes; the capitals re-indication around the apostrophe (⠄⠠⠠⠧⠑) is identical to before and consistent with the table's existing handling of e.g. `DON'T` → ⠠⠠⠙⠕⠝⠄⠠⠞. These all-caps forms had no test coverage (which is why no existing spec changes result); this PR adds tests locking in the corrected behavior.

### Verification

- Full test suite: 209/209 pass, including `en-ueb-g2-dictionary_harness.yaml` (106,604 tests) and `mn-MN_harness.yaml`; `th-g2.ctb` and `mn-MN-g2.ctb` (which include this table) still compile and pass.
- Differential against master over 1,228 affected words × 20 contexts (bare, `+s`, `+'s`, `+’s`, capitalised, ALLCAPS, quoted, parenthesised, hyphenated, prefixed, mid-sentence, …): backward translation byte-identical; forward differences limited to (a) the all-caps fix above, and (b) harness-style non-words such as `aboutfaceds's` now contracting.

### Impact

| | master | this PR | delta |
|---|---|---|---|
| compiled table size (`lou_debug` "Bytes used") | 738,496 B | 543,168 B | **−26.4%** |
| forward translation | 278 µs/call | 291 µs/call | +5% |
| backward translation | 30.6 µs/call | 30.7 µs/call | — |

(Timing: interleaved A/B runs, ~1.3M translation calls in ≤1,000-character units, run-to-run spread <1%.) The slowdown is because promoted `word` rules join the forward hash chains that `nofor` rules are excluded from; keeping the 611 possessives back-only recovers more than half of what full promotion would cost. Net: ~195 KB of table memory for ~5% forward throughput — the right trade for memory-constrained consumers.

### Follow-ups (not in this PR)

- Fix the `nofor word whereabouts's` dot pattern (`-234-234` → `-234-3-234`).
- The same match/`nofor word` duplication exists in `vi-vn-g2.ctb` (546), `vi-saigon-g1.ctb` (417), `vi-vn-g1.ctb` (368), `fil-g2.ctb` (95) — not audited here.
- No `nofor word` rule anywhere in the table uses U+2019; back-translation into typographic-apostrophe text is untested territory.
