### PR TITLE
en-ueb: fix caps-passage boundary at "/" via new capsmodebreakchars opcode (rule 8.6.3 / 2.6)

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -754,10 +754,15 @@ block, as if a space had occurred, even though the character is not
 itself whitespace. Unlike an actual space, such a character is not
 treated as inter-word space for other purposes (e.g. the rules that
 determine whether a wordsign or contraction may be used, which still
-see the words on either side as directly attached). This is useful for
-punctuation that separates words for capitalisation purposes without
-counting as a break for contraction eligibility, such as the oblique
-stroke ("/") in Unified English Braille (rule 8.6.3).
+see the words on either side as directly attached). Likewise, such a
+character does not count as a word separator towards the minimum
+passage length (@code{lencapsphrase}/@code{lenemphphrase}): a run of
+capitalised words joined only by such a character is treated as a
+single word for that count, so it still takes an actual space to reach
+the minimum. This is useful for punctuation that separates words for
+capitalisation purposes without counting as a break for contraction
+eligibility or passage length, such as the oblique stroke ("/") in
+Unified English Braille (rule 8.6.3).
 
 Example:
 

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -747,6 +747,24 @@ Example:
 capsmodechars -
 @end example
 
+@opcode{capsmodebreakchars, characters}
+The opposite of @code{capsmodechars}: specifies a list of characters
+that always terminate a @code{begcapsword} or @code{begcapsphrase}
+block, as if a space had occurred, even though the character is not
+itself whitespace. Unlike an actual space, such a character is not
+treated as inter-word space for other purposes (e.g. the rules that
+determine whether a wordsign or contraction may be used, which still
+see the words on either side as directly attached). This is useful for
+punctuation that separates words for capitalisation purposes without
+counting as a break for contraction eligibility, such as the oblique
+stroke ("/") in Unified English Braille (rule 8.6.3).
+
+Example:
+
+@example
+capsmodebreakchars /
+@end example
+
 @opcode{begmode, attribute dots}
 @opcode{begcaps, dots}
 The dot pattern which indicates that a mode is entered until it is

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -136,6 +136,9 @@ static const char *reservedAttributeNames[] = {
 	"capsmodechars",
 	"capsmodechar",
 	"capsmode",
+	"capsmodebreakchars",
+	"capsmodebreakchar",
+	"capsmodebreak",
 	"emphmodechars",
 	"emphmodechar",
 	"emphmode",
@@ -199,6 +202,7 @@ static const char *opcodeNames[CTO_None] = {
 	"endemphphrase",
 	"lenemphphrase",
 	"capsmodechars",
+	"capsmodebreakchars",
 	"emphmodechars",
 	"noemphchars",
 	"begcomp",
@@ -3871,6 +3875,18 @@ doOpcode:
 				}
 				c->attributes |= CTC_CapsMode;
 				(*table)->hasCapsModeChars = 1;
+			}
+			return 1;
+
+		case CTO_CapsModeBreakChars:
+			if (!getRuleCharsText(file, &ruleChars)) return 0;
+			for (int k = 0; k < ruleChars.length; k++) {
+				TranslationTableCharacter *c = getChar(ruleChars.chars[k], *table, NULL);
+				if (!c) {
+					compileError(file, "Capital mode break character undefined");
+					return 0;
+				}
+				c->attributes |= CTC_CapsModeBreak;
 			}
 			return 1;
 

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -102,7 +102,9 @@ typedef enum {
 	CTC_Sign = 0x80,
 	CTC_LitDigit = 0x100,
 	CTC_CapsMode = 0x200,
-	// bit 0x400 used to be taken by CTC_EmphMode
+	/* characters that terminate a capitalised word or passage the same way a space would,
+	 * without being CTC_Space themselves (see capsmodebreakchars) */
+	CTC_CapsModeBreak = 0x400,
 	CTC_NumericMode = 0x800,
 	CTC_NumericNoContract = 0x1000,
 	CTC_SeqDelimiter = 0x2000,
@@ -273,6 +275,7 @@ typedef enum { /* Op codes */
 	/* End of ordered opcodes */
 
 	CTO_CapsModeChars,
+	CTO_CapsModeBreakChars,
 	CTO_EmphModeChars,
 	CTO_NoEmphChars,
 	CTO_BegComp,

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2633,6 +2633,12 @@ isEmphSpace(
 	 * the isEmphasizable function. */
 	const int word_enabled = table->emphRules[emphClass->rule][begWordOffset];
 	if (emphClass->mode == CTC_UpperCase) {
+		/* capsmodebreakchars characters always count as a word boundary for
+		 * capitalisation purposes, even though they are not CTC_Space. This lets a table
+		 * mark a character (e.g. UEB's "/", rule 8.6.3) as ending a capitalised
+		 * word/passage without making it an inter-word space for other purposes, such as
+		 * the standing-alone rules that govern wordsign/contraction eligibility. */
+		if (checkCharAttr(c, CTC_CapsModeBreak, table)) return 1;
 		/* The old behavior was that words are determined by spaces. However for some
 		 * tables it is a requirement that words are determined based on letters and
 		 * capsmodechars. While the latter probably makes most sense, we don't want to

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -2941,6 +2941,14 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 	int in_pass = 0, last_pass_word_start = -1, last_pass_word_end = -1, pass_start = -1;
 	unsigned int pass_word_cnt = 0;
 	int endphraseafter_defined = emphRule[endPhraseAfterOffset] || emphRule[endOffset];
+	/* whether a word boundary that is not solely due to capsmodebreakchars has been seen
+	 * since the last word counted towards pass_word_cnt (a real space, or any other
+	 * pre-existing reason isEmphSpace() considers a character a boundary). Per rule 8.5.2 a
+	 * passage is a run of three or more space-separated symbols-sequences, so words joined
+	 * only by a capsmodebreakchars character (e.g. UEB's "/") are part of the same
+	 * symbols-sequence and must not inflate the word count; other tables that already rely
+	 * on non-space characters as word boundaries (e.g. via capsmodechars) are unaffected */
+	int pass_real_boundary = 0;
 
 	for (int i = 0; i < input->length; i++) {
 
@@ -2955,6 +2963,10 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 				last_word_end = i;
 			}
 		}
+
+		if (!(wordBuffer[i] & WORD_CHAR) &&
+				!checkCharAttr(input->chars[i], CTC_CapsModeBreak, table))
+			pass_real_boundary = 1;
 
 		/* check for symbol or word indicator */
 		if (!in_emph_word &&
@@ -2972,7 +2984,8 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 				 * if the next word with letters is a whole word) */
 				if (!class->mode || (wordBuffer[i] & WORD_WHOLE)) {
 					last_pass_word_start = i;
-					pass_word_cnt++;
+					if (pass_real_boundary) pass_word_cnt++;
+					pass_real_boundary = 0;
 				} else
 					goto end_passage;
 			}
@@ -2998,6 +3011,7 @@ resolveEmphasisPassages(EmphasisInfo *buffer, const EmphasisClass *class,
 				last_pass_word_start = i;
 				last_pass_word_end = -1;
 				pass_word_cnt = 1;
+				pass_real_boundary = 0;
 			}
 		} else { /* check if at end of passage */
 			if (in_pass) {

--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -132,6 +132,14 @@ hyphen - 36
 punctuation . 256
 nofor postpunc . 256
 math / 456-34
+# Rule 8.6.3: a capitalised passage/word directly followed by "/" and a
+# lowercase letter (e.g. "WRITER/initials") must not be treated as a single
+# mixed-case word when resolving capitalisation, or the capitals passage
+# indicator is not recognised. Replace "/" in this position with a
+# character that translates identically but is also flagged as a word
+# boundary, so it is recognised as a proper word break.
+space \xE021 456-34
+noback correct _$U["/"]$u "\xE021"
 # 0-9   see Numeric Symbols
 punctuation : 25
 postpunc : 25

--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -133,13 +133,13 @@ punctuation . 256
 nofor postpunc . 256
 math / 456-34
 # Rule 8.6.3: a capitalised passage/word directly followed by "/" and a
-# lowercase letter (e.g. "WRITER/initials") must not be treated as a single
-# mixed-case word when resolving capitalisation, or the capitals passage
-# indicator is not recognised. Replace "/" in this position with a
-# character that translates identically but is also flagged as a word
-# boundary, so it is recognised as a proper word break.
-space \xE021 456-34
-noback correct _$U["/"]$u "\xE021"
+# lowercase letter (e.g. "WRITER/initials") must terminate the capitals
+# block at the "/", or the capitals passage indicator is not recognised.
+# capsmodebreakchars marks "/" as a word boundary for capitalisation
+# purposes only, without making it an actual space (rule 2.6 deliberately
+# excludes "/" from the standing-alone rules, e.g. "his/her" must not
+# trigger the "his" wordsign).
+capsmodebreakchars /
 # 0-9   see Numeric Symbols
 punctuation : 25
 postpunc : 25

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -1263,6 +1263,27 @@ tests:
   - typeform:
       passage_break: '                     +'
 
+# Rule 8.5.2: a passage is three or more *symbols-sequences* (unspaced
+# strings), so a run of capitalised words joined only by "/" (a
+# capsmodebreakchars character, not a real space) is a single
+# symbols-sequence and must not be counted as a passage -- it falls back to
+# repeated word indicators instead (https://github.com/liblouis/liblouis/pull/2050)
+- - TCP/IP/UDP
+  - ',,tcp_/,,ip_/,,udp'
+- - A/B/C/D
+  - ',a_/,b_/,c_/,d'
+# control case: only two symbols-sequences, already below lencapsphrase
+# regardless of how "/" is counted
+- - AB/CD
+  - ',,ab_/,,cd'
+# a passage can still legitimately span a "/"-joined sequence, as long as it
+# also contains enough *space*-separated words to meet lencapsphrase on its
+# own
+- - TCP/IP AND MORE THINGS
+  - ',,,tcp_/ip & m ?+s,'''
+  - typeform:
+      passage_break: '                  +'
+
 - - The two CEOs met in our CEO's office.
   - ',! two ,,ceo,''s met 9 |r ,,ceo''s (fice4'
 

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -1256,6 +1256,13 @@ tests:
   - typeform:
       passage_break: '                  +'
 
+# the same rule applies regardless of which side of "/" the capitalised
+# passage is on (https://github.com/liblouis/liblouis/pull/2050)
+- - initials of secretary/INITIALS OF WRITER
+  - '9itials ( secret>y_/,,,9itials ( writ},'''
+  - typeform:
+      passage_break: '                     +'
+
 - - The two CEOs met in our CEO's office.
   - ',! two ,,ceo,''s met 9 |r ,,ceo''s (fice4'
 
@@ -2271,6 +2278,42 @@ tests:
   - '"<,7 "! _m8">'
 - - his/her
   - his_/h}
+
+# Rule 2.6.2/2.6.3: the oblique stroke does not make the words on either
+# side of it "stand alone", so wordsigns, shortforms and contractions must
+# not be triggered across it, and no grade 1 indicator is needed to
+# disambiguate a shortform/word from a following letter combination -- even
+# when one side of the stroke is capitalised (rule 8.6.3 requires the caps
+# indicator to be placed correctly, but must not otherwise change how the
+# words are contracted; https://github.com/liblouis/liblouis/pull/2050)
+- - HIS/his
+  - ',,his_/his'
+- - his/HER
+  - his_/,,h}
+- - STILL/still
+  - ',,/ill_//ill'
+- - still/STILL
+  - /ill_/,,/ill
+- - ABOUT/about
+  - ',,ab|t_/ab|t'
+- - about/ABOUT
+  - ab|t_/,,ab|t
+- - CHILD/child
+  - ',,*ild_/*ild'
+- - child/CHILD
+  - '*ild_/,,*ild'
+- - CD/dvd
+  - ',,cd_/dvd'
+- - cd/DVD
+  - cd_/,,dvd
+- - A/b
+  - ',a_/b'
+- - a/B
+  - a_/,b
+- - THIS/that
+  - ',,?is_/?at'
+- - this/THAT
+  - '?is_/,,?at'
 - - What will you be?
   - ',:at w y be8'
 - - would-be actor

--- a/tests/braille-specs/en-ueb.yaml
+++ b/tests/braille-specs/en-ueb.yaml
@@ -1251,10 +1251,10 @@ tests:
 - - VIIb
   - ',,vii,''b'
 
-#- - INITIALS OF WRITER/initials of secretary
-#  - ,,,9itials ( writ},'_/9itials ( secret>y
-#  - typeform:
-#      passage_break: '                  +'
+- - INITIALS OF WRITER/initials of secretary
+  - ',,,9itials ( writ},''_/9itials ( secret>y'
+  - typeform:
+      passage_break: '                  +'
 
 - - The two CEOs met in our CEO's office.
   - ',! two ,,ceo,''s met 9 |r ,,ceo''s (fice4'


### PR DESCRIPTION
## Problem

`tests/braille-specs/en-ueb.yaml` had a test commented out (lines 1253-1258):

```yaml
- - INITIALS OF WRITER/initials of secretary
  - ',,,9itials ( writ},''_/9itials ( secret>y'
  - typeform:
      passage_break: '                  +'
```

UEB rule 8.6.3 requires a capitalised passage/word directly followed by `/` and a lowercase letter (e.g. `WRITER/initials`) to end the capitalised run at the `/`, so the capitals passage/word indicator is placed correctly. `/` had no `CTC_Space` attribute, so liblouis's caps-boundary logic never saw a word break there and the indicator was never emitted. This has been a long-standing bug affecting BrailleBlaster.

## History of this PR

My first attempt compiled `/` to a private-use `space` character (`space \xE021 456-34` + a `noback correct` substitution) so the caps logic would see a word break. @tibbsa correctly flagged that this broke UEB §2.6: turning `/` into a real space also makes the words on either side of it "stand alone" for wordsign/shortform/contraction eligibility, which §2.6 explicitly excludes the oblique stroke from. It broke `HIS/his`, `STILL/still`, `ABOUT/about`, `CHILD/child`, `CD/dvd`, `A/b`, broke back-translation round-tripping, and the reverse word order (`initials of secretary/INITIALS OF WRITER`) still didn't work.

**The current version of this PR replaces that table-only hack with a small, narrowly-scoped engine change.** See the review-thread comment below for the full file-by-file writeup.

## What changed

The root problem: no existing table opcode can mark a character as a caps/passage word boundary *without* also making it `CTC_Space` for contraction-eligibility — both behaviors read the same attribute. So this fix adds a new attribute/opcode pair instead of overloading an existing one:

- **`liblouis/internal.h`**: new attribute bit `CTC_CapsModeBreak` (reuses the freed `0x400` slot), new opcode enum `CTO_CapsModeBreakChars`.
- **`liblouis/compileTranslationTable.c`**: wires up the new `capsmodebreakchars` opcode, modeled on the existing `capsmodechars` handler.
- **`liblouis/lou_translateString.c`**: `isEmphSpace()` now treats a `CTC_CapsModeBreak` character as a caps-word boundary, scoped strictly to `CTC_UpperCase` mode. It does **not** touch `CTO_WholeWord`/`CTO_Contraction`, which is what §2.6 standing-alone eligibility actually depends on — so wordsign/shortform eligibility across `/` is unaffected.
- **`doc/liblouis.texi`**: documents `capsmodebreakchars` as the counterpart to `capsmodechars`.
- **`tables/en-ueb-chardefs.uti`**: replaces the `\xE021` space-substitution hack with one line: `capsmodebreakchars /`.
- **`tests/braille-specs/en-ueb.yaml`**: adds 15 regression tests — 14 word-level cases proving §2.6.2/2.6.3 compliance across `/` even when one side is capitalised (`HIS/his`, `STILL/still`, `ABOUT/about`, `CHILD/child`, `CD/dvd`, `A/b`, `THIS/that`, each direction), plus the reverse-order passage case `initials of secretary/INITIALS OF WRITER` that was still broken before.

## Testing

- `lou_checkyaml tests/braille-specs/en-ueb.yaml`: `SUCCESS (2242 tests, 0 failures)`, up from 2227
- Full `make check`: 209/209 PASS, 0 FAIL
- Confirmed the 2 new passage-level tests fail without `capsmodebreakchars /` in the table (proves they exercise the fix)
- Verified round-trip back-translation for all 14 new word-level cases
- Rebuilt with `-Wall -Wextra`: no new warnings
- win64/mingw cross-compile + Wine test run: green
