### PR TITLE
fix: incompatible function-ptr triggers UBSan function_type_mismatch in list_conj

### DIFF
--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -105,7 +105,8 @@ list_conj(List *list, void *x, int (*cmp)(void *, void *), void *(*dup)(void *),
  * Free an instance of type List.
  */
 static void
-list_free(List *list) {
+list_free(void *v) {
+	List *list = v;
 	if (list) {
 		if (list->free) list->free(list->head);
 		list_free(list->tail);
@@ -116,8 +117,9 @@ list_free(List *list) {
 /**
  * Duplicate an instance of type List.
  */
-static List *
-list_dup(List *list) {
+static void *
+list_dup(void *v) {
+	List *list = v;
 	if (!list) return list;
 	List *d = malloc(sizeof(List));
 	d->head = list->dup ? list->dup(list->head) : list->head;
@@ -217,7 +219,8 @@ feat_new(char *key, void *val, void *(*dup)(void *), void (*free)(void *)) {
  * Free an instance of type Feature.
  */
 static void
-feat_free(Feature *f) {
+feat_free(void *v) {
+	Feature *f = v;
 	if (f) {
 		free(f->key);
 		if (f->free) f->free(f->val);
@@ -228,8 +231,9 @@ feat_free(Feature *f) {
 /**
  * Duplicate an instance of type Feature.
  */
-static Feature *
-feat_dup(Feature *f) {
+static void *
+feat_dup(void *v) {
+	Feature *f = v;
 	if (!f) return NULL;
 	Feature *d = malloc(sizeof(Feature));
 	d->key = strdup(f->key);
@@ -245,7 +249,8 @@ feat_dup(Feature *f) {
  * Both `name' string and `features' list are freed.
  */
 static void
-meta_free(TableMeta *m) {
+meta_free(void *v) {
+	TableMeta *m = v;
 	if (m) {
 		free(m->name);
 		list_free(m->features);
@@ -339,7 +344,9 @@ serializeLanguageTag(const List *tag) {
  * Sort features by their key (alphabetical order).
  */
 static int
-cmpKeys(Feature *f1, Feature *f2) {
+cmpKeys(void *v1, void *v2) {
+	Feature *f1 = v1;
+    Feature *f2 = v2;
 	return strcasecmp(f1->key, f2->key);
 }
 
@@ -347,7 +354,9 @@ cmpKeys(Feature *f1, Feature *f2) {
  * Sort features by their key and value (alphabetical order).
  */
 static int
-cmpFeatures(Feature *f1, Feature *f2) {
+cmpFeatures(void *v1, void *v2) {
+	Feature *f1 = v1;
+    Feature *f2 = v2;
 	int r = strcasecmp(f1->key, f2->key);
 	if (r != 0) return r;
 	if (isLanguageTag(f1->key, MAXSTRING)) {
@@ -1103,7 +1112,9 @@ typedef struct {
 } TableMatch;
 
 static int
-cmpMatches(TableMatch *m1, TableMatch *m2) {
+cmpMatches(void *v1, void *v2) {
+	TableMatch *m1 = v1;
+    TableMatch *m2 = v2;
 	if (m1->matchQuotient > m2->matchQuotient)
 		return -1;
 	else

--- a/liblouis/metadata.c
+++ b/liblouis/metadata.c
@@ -105,8 +105,7 @@ list_conj(List *list, void *x, int (*cmp)(void *, void *), void *(*dup)(void *),
  * Free an instance of type List.
  */
 static void
-list_free(void *v) {
-	List *list = v;
+list_free(List *list) {
 	if (list) {
 		if (list->free) list->free(list->head);
 		list_free(list->tail);
@@ -115,11 +114,21 @@ list_free(void *v) {
 }
 
 /**
+ * Adapters so that list_free/list_dup can be used as generic List/Feature
+ * callbacks (which are typed `void (*)(void *)' / `void *(*)(void *)') without
+ * calling through an incompatibly-typed function pointer, which is undefined
+ * behaviour.
+ */
+static void
+list_free_(void *v) {
+	list_free(v);
+}
+
+/**
  * Duplicate an instance of type List.
  */
-static void *
-list_dup(void *v) {
-	List *list = v;
+static List *
+list_dup(List *list) {
 	if (!list) return list;
 	List *d = malloc(sizeof(List));
 	d->head = list->dup ? list->dup(list->head) : list->head;
@@ -127,6 +136,24 @@ list_dup(void *v) {
 	d->dup = list->dup;
 	d->tail = list_dup(list->tail);
 	return d;
+}
+
+/**
+ * Adapter, see list_free_/list_dup_ above.
+ */
+static void *
+list_dup_(void *v) {
+	return list_dup(v);
+}
+
+/**
+ * Adapter so that strdup can be used as a generic List/Feature dup callback
+ * (typed `void *(*)(void *)') without calling through an incompatibly-typed
+ * function pointer, which is undefined behaviour.
+ */
+static void *
+strdup_(void *s) {
+	return strdup(s);
 }
 
 /**
@@ -219,8 +246,7 @@ feat_new(char *key, void *val, void *(*dup)(void *), void (*free)(void *)) {
  * Free an instance of type Feature.
  */
 static void
-feat_free(void *v) {
-	Feature *f = v;
+feat_free(Feature *f) {
 	if (f) {
 		free(f->key);
 		if (f->free) f->free(f->val);
@@ -229,11 +255,18 @@ feat_free(void *v) {
 }
 
 /**
+ * Adapters, see list_free_/list_dup_ above.
+ */
+static void
+feat_free_(void *v) {
+	feat_free(v);
+}
+
+/**
  * Duplicate an instance of type Feature.
  */
-static void *
-feat_dup(void *v) {
-	Feature *f = v;
+static Feature *
+feat_dup(Feature *f) {
 	if (!f) return NULL;
 	Feature *d = malloc(sizeof(Feature));
 	d->key = strdup(f->key);
@@ -244,18 +277,33 @@ feat_dup(void *v) {
 }
 
 /**
+ * Adapter, see list_free_/list_dup_ above.
+ */
+static void *
+feat_dup_(void *v) {
+	return feat_dup(v);
+}
+
+/**
  * Free an instance of type TableMeta.
  *
  * Both `name' string and `features' list are freed.
  */
 static void
-meta_free(void *v) {
-	TableMeta *m = v;
+meta_free(TableMeta *m) {
 	if (m) {
 		free(m->name);
 		list_free(m->features);
 		free(m);
 	}
+}
+
+/**
+ * Adapter, see list_free_/list_dup_ above.
+ */
+static void
+meta_free_(void *v) {
+	meta_free(v);
 }
 
 /* =========================== LANGUAGE TAGS ============================== */
@@ -295,7 +343,7 @@ parseLanguageTag(const char *val) {
 		if (val[1] && val[1] != '-') return NULL;
 		*subtag = '\0';
 		strncat(subtag, val, 1);
-		*tail = list_conj(NULL, strdup(subtag), NULL, (void *(*)(void *))strdup, free);
+		*tail = list_conj(NULL, strdup(subtag), NULL, strdup_, free);
 		tail = &(*tail)->tail;
 		if (!val[1]) return list;
 		val = &val[2];
@@ -311,7 +359,7 @@ parseLanguageTag(const char *val) {
 		}
 		*subtag = '\0';
 		strncat(subtag, val, len);
-		*tail = list_conj(NULL, strdup(subtag), NULL, (void *(*)(void *))strdup, free);
+		*tail = list_conj(NULL, strdup(subtag), NULL, strdup_, free);
 		tail = &(*tail)->tail;
 		if (!val[len]) return list;
 		val = &val[len + 1];
@@ -344,19 +392,23 @@ serializeLanguageTag(const List *tag) {
  * Sort features by their key (alphabetical order).
  */
 static int
-cmpKeys(void *v1, void *v2) {
-	Feature *f1 = v1;
-    Feature *f2 = v2;
+cmpKeys(Feature *f1, Feature *f2) {
 	return strcasecmp(f1->key, f2->key);
+}
+
+/**
+ * Adapter, see list_free_/list_dup_ above.
+ */
+static int
+cmpKeys_(void *v1, void *v2) {
+	return cmpKeys(v1, v2);
 }
 
 /**
  * Sort features by their key and value (alphabetical order).
  */
 static int
-cmpFeatures(void *v1, void *v2) {
-	Feature *f1 = v1;
-    Feature *f2 = v2;
+cmpFeatures(Feature *f1, Feature *f2) {
 	int r = strcasecmp(f1->key, f2->key);
 	if (r != 0) return r;
 	if (isLanguageTag(f1->key, MAXSTRING)) {
@@ -371,6 +423,14 @@ cmpFeatures(void *v1, void *v2) {
 		return l1 ? 1 : l2 ? -1 : 0;
 	} else
 		return strcasecmp(f1->val, f2->val);
+}
+
+/**
+ * Adapter, see list_free_/list_dup_ above.
+ */
+static int
+cmpFeatures_(void *v1, void *v2) {
+	return cmpFeatures(v1, v2);
 }
 
 /**
@@ -583,14 +643,12 @@ parseQuery(const char *query) {
 					}
 					if (strcasecmp(k, "locale") == 0) {
 						// locale is shorthand for language + region
-						FeatureWithImportance f1 = { feat_new(strdup("language"), tag,
-															 (void *(*)(void *))list_dup,
-															 (void (*)(void *))list_free),
-							0 };
+						FeatureWithImportance f1 = {
+							feat_new(strdup("language"), tag, list_dup_, list_free_), 0
+						};
 						FeatureWithImportance f2 = { feat_new(strdup("region"),
-															 list_dup(tag),
-															 (void *(*)(void *))list_dup,
-															 (void (*)(void *))list_free),
+															 list_dup(tag), list_dup_,
+															 list_free_),
 							0 };
 						_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'",
 								f1.feature.key, v);
@@ -598,29 +656,27 @@ parseQuery(const char *query) {
 								f2.feature.key, v);
 						features = list_conj(features,
 								memcpy(malloc(sizeof(f1)), &f1, sizeof(f1)), NULL,
-								(void *(*)(void *))feat_dup, (void (*)(void *))feat_free);
+								feat_dup_, feat_free_);
 						features = list_conj(features,
 								memcpy(malloc(sizeof(f2)), &f2, sizeof(f2)), NULL,
-								(void *(*)(void *))feat_dup, (void (*)(void *))feat_free);
+								feat_dup_, feat_free_);
 					} else {
-						FeatureWithImportance f = { feat_new(strdup(k), tag,
-															(void *(*)(void *))list_dup,
-															(void (*)(void *))list_free),
-							0 };
+						FeatureWithImportance f = {
+							feat_new(strdup(k), tag, list_dup_, list_free_), 0
+						};
 						_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'", k, v);
 						features = list_conj(features,
-								memcpy(malloc(sizeof(f)), &f, sizeof(f)), NULL,
-								(void *(*)(void *))feat_dup, (void (*)(void *))feat_free);
+								memcpy(malloc(sizeof(f)), &f, sizeof(f)), NULL, feat_dup_,
+								feat_free_);
 					}
 				} else {
-					FeatureWithImportance f = { feat_new(strdup(k), strdup(v),
-														(void *(*)(void *))strdup,
-														(void (*)(void *))free),
-						0 };
+					FeatureWithImportance f = {
+						feat_new(strdup(k), strdup(v), strdup_, free), 0
+					};
 					_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'", k, v);
-					features = list_conj(features,
-							memcpy(malloc(sizeof(f)), &f, sizeof(f)), NULL,
-							(void *(*)(void *))feat_dup, (void (*)(void *))feat_free);
+					features =
+							list_conj(features, memcpy(malloc(sizeof(f)), &f, sizeof(f)),
+									NULL, feat_dup_, feat_free_);
 					if (strcasecmp(k, "unicode-range") == 0) unicodeRange = 1;
 				}
 				free(k);
@@ -659,14 +715,12 @@ parseQuery(const char *query) {
 		if (!*value) sprintf(value, "ucs%ld", CHARSIZE);
 		FeatureWithImportance *f = memcpy(malloc(sizeof(FeatureWithImportance)),
 				(&(FeatureWithImportance){
-						feat_new(strdup("unicode-range"), strdup(value),
-								(void *(*)(void *))strdup, (void (*)(void *))free),
+						feat_new(strdup("unicode-range"), strdup(value), strdup_, free),
 						-1 }),
 				sizeof(FeatureWithImportance));
 		_lou_logMessage(LOU_LOG_DEBUG, "Query has feature '%s:%s'", f->feature.key,
 				f->feature.val);
-		features = list_conj(features, f, NULL, (void *(*)(void *))feat_dup,
-				(void (*)(void *))feat_free);
+		features = list_conj(features, f, NULL, feat_dup_, feat_free_);
 	}
 	// attach importance to features
 	{
@@ -678,7 +732,7 @@ parseQuery(const char *query) {
 		}
 	}
 	// sort features by key (alphabetical order)
-	return list_sort(features, (int (*)(void *, void *))cmpKeys);
+	return list_sort(features, cmpKeys_);
 compile_error:
 	_lou_logMessage(LOU_LOG_ERROR, "Unexpected character '%c' at position %d", *c, pos);
 	list_free(features);
@@ -828,17 +882,15 @@ analyzeTable(const char *table, int activeOnly) {
 											malloc(sizeof(FeatureWithLineNumber)),
 											(&(FeatureWithLineNumber){
 													feat_new(strdup("language"), tag,
-															(void *(*)(void *))list_dup,
-															(void (*)(void *))list_free),
+															list_dup_, list_free_),
 													info.lineNumber }),
 											sizeof(FeatureWithLineNumber));
 									FeatureWithLineNumber *f2 = memcpy(
 											malloc(sizeof(FeatureWithLineNumber)),
 											(&(FeatureWithLineNumber){
 													feat_new(strdup("region"),
-															list_dup(tag),
-															(void *(*)(void *))list_dup,
-															(void (*)(void *))list_free),
+															list_dup(tag), list_dup_,
+															list_free_),
 													info.lineNumber }),
 											sizeof(FeatureWithLineNumber));
 									_lou_logMessage(LOU_LOG_DEBUG,
@@ -847,28 +899,24 @@ analyzeTable(const char *table, int activeOnly) {
 									_lou_logMessage(LOU_LOG_DEBUG,
 											"Table has feature '%s:%s'", f2->feature.key,
 											v);
-									features = list_conj(features, f1, NULL,
-											(void *(*)(void *))feat_dup,
-											(void (*)(void *))feat_free);
-									features = list_conj(features, f2, NULL,
-											(void *(*)(void *))feat_dup,
-											(void (*)(void *))feat_free);
+									features = list_conj(
+											features, f1, NULL, feat_dup_, feat_free_);
+									features = list_conj(
+											features, f2, NULL, feat_dup_, feat_free_);
 									if (!language) language = f1;
 									if (!region) region = f2;
 								} else {
 									FeatureWithLineNumber *f = memcpy(
 											malloc(sizeof(FeatureWithLineNumber)),
 											(&(FeatureWithLineNumber){
-													feat_new(strdup(k), tag,
-															(void *(*)(void *))list_dup,
-															(void (*)(void *))list_free),
+													feat_new(strdup(k), tag, list_dup_,
+															list_free_),
 													info.lineNumber }),
 											sizeof(FeatureWithLineNumber));
 									_lou_logMessage(LOU_LOG_DEBUG,
 											"Table has feature '%s:%s'", k, v);
-									features = list_conj(features, f, NULL,
-											(void *(*)(void *))feat_dup,
-											(void (*)(void *))feat_free);
+									features = list_conj(
+											features, f, NULL, feat_dup_, feat_free_);
 									if (strcasecmp(k, "language") == 0) {
 										if (!language) language = f;
 									} else if (strcasecmp(k, "region") == 0) {
@@ -880,15 +928,13 @@ analyzeTable(const char *table, int activeOnly) {
 										memcpy(malloc(sizeof(FeatureWithLineNumber)),
 												(&(FeatureWithLineNumber){
 														feat_new(strdup(k), strdup(v),
-																(void *(*)(void *))strdup,
-																(void (*)(void *))free),
+																strdup_, free),
 														info.lineNumber }),
 												sizeof(FeatureWithLineNumber));
 								_lou_logMessage(
 										LOU_LOG_DEBUG, "Table has feature '%s:%s'", k, v);
-								features = list_conj(features, f, NULL,
-										(void *(*)(void *))feat_dup,
-										(void (*)(void *))feat_free);
+								features = list_conj(
+										features, f, NULL, feat_dup_, feat_free_);
 								if (strcasecmp(k, "unicode-range") == 0) unicodeRange = 1;
 							}
 							free(k);
@@ -909,33 +955,29 @@ analyzeTable(const char *table, int activeOnly) {
 			region = memcpy(malloc(sizeof(FeatureWithLineNumber)),
 					(&(FeatureWithLineNumber){
 							feat_new(strdup("region"), list_dup(language->feature.val),
-									(void *(*)(void *))list_dup,
-									(void (*)(void *))list_free),
+									list_dup_, list_free_),
 							-1 }),
 					sizeof(FeatureWithLineNumber));
 			char *v = serializeLanguageTag(region->feature.val);
 			_lou_logMessage(
 					LOU_LOG_DEBUG, "Table has feature '%s:%s'", region->feature.key, v);
 			free(v);
-			features = list_conj(features, region, NULL, (void *(*)(void *))feat_dup,
-					(void (*)(void *))feat_free);
+			features = list_conj(features, region, NULL, feat_dup_, feat_free_);
 		}
 		if (features && !unicodeRange) {
 			// by default we assume unicode-range: ucs2
 			FeatureWithLineNumber *f = memcpy(malloc(sizeof(FeatureWithLineNumber)),
-					(&(FeatureWithLineNumber){
-							feat_new(strdup("unicode-range"), strdup("ucs2"),
-									(void *(*)(void *))strdup, (void (*)(void *))free),
+					(&(FeatureWithLineNumber){ feat_new(strdup("unicode-range"),
+													   strdup("ucs2"), strdup_, free),
 							-1 }),
 					sizeof(FeatureWithLineNumber));
 			_lou_logMessage(LOU_LOG_DEBUG, "Table has feature '%s:%s'", f->feature.key,
 					f->feature.val);
-			features = list_conj(features, f, NULL, (void *(*)(void *))feat_dup,
-					(void (*)(void *))feat_free);
+			features = list_conj(features, f, NULL, feat_dup_, feat_free_);
 		}
 	} else
 		_lou_logMessage(LOU_LOG_ERROR, "Cannot open table '%s'", info.fileName);
-	return list_sort(features, (int (*)(void *, void *))cmpFeatures);
+	return list_sort(features, cmpFeatures_);
 compile_error:
 	if (info.linepos < info.linelen)
 		_lou_logMessage(LOU_LOG_ERROR, "Unexpected character '%c' on line %d, column %d",
@@ -965,7 +1007,7 @@ lou_indexTables(const char **tables) {
 		if (features) {
 			TableMeta m = { strdup(*table), features };
 			tableIndex = list_conj(tableIndex, memcpy(malloc(sizeof(m)), &m, sizeof(m)),
-					NULL, NULL, (void (*)(void *))meta_free);
+					NULL, NULL, meta_free_);
 		}
 	}
 	if (!tableIndex) _lou_logMessage(LOU_LOG_WARN, "No tables were indexed");
@@ -998,8 +1040,7 @@ listDir(List *list, char *dirName) {
 		do {
 			if (!(ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
 				sprintf(fileName, "%s%c%s", dirName, DIR_SEP, ffd.cFileName);
-				list = list_conj(
-						list, strdup(fileName), NULL, (void *(*)(void *))strdup, free);
+				list = list_conj(list, strdup(fileName), NULL, strdup_, free);
 			}
 		} while (FindNextFileA(hFind, &ffd));
 		FindClose(hFind);
@@ -1017,8 +1058,7 @@ listDir(List *list, char *dirName) {
 		while ((file = readdir(dir))) {
 			sprintf(fileName, "%s%c%s", dirName, DIR_SEP, file->d_name);
 			if (stat(fileName, &info) == 0 && !(info.st_mode & S_IFDIR)) {
-				list = list_conj(
-						list, strdup(fileName), NULL, (void *(*)(void *))strdup, free);
+				list = list_conj(list, strdup(fileName), NULL, strdup_, free);
 			}
 		}
 		closedir(dir);
@@ -1112,13 +1152,29 @@ typedef struct {
 } TableMatch;
 
 static int
-cmpMatches(void *v1, void *v2) {
-	TableMatch *m1 = v1;
-    TableMatch *m2 = v2;
+cmpMatches(TableMatch *m1, TableMatch *m2) {
 	if (m1->matchQuotient > m2->matchQuotient)
 		return -1;
 	else
 		return 1;
+}
+
+/**
+ * Adapter, see list_free_/list_dup_ above.
+ */
+static int
+cmpMatches_(void *v1, void *v2) {
+	return cmpMatches(v1, v2);
+}
+
+/**
+ * Adapter so that strcmp can be used as a generic List comparator (typed
+ * `int (*)(void *, void *)') without calling through an incompatibly-typed
+ * function pointer, which is undefined behaviour.
+ */
+static int
+strcmp_(void *v1, void *v2) {
+	return strcmp(v1, v2);
 }
 
 /**
@@ -1137,7 +1193,7 @@ lou_findTables(const char *query) {
 		if (quotient > 0) {
 			TableMatch m = { strdup(table->name), quotient };
 			matches = list_conj(matches, memcpy(malloc(sizeof(m)), &m, sizeof(m)),
-					(int (*)(void *, void *))cmpMatches, NULL, free);
+					cmpMatches_, NULL, free);
 		}
 	}
 	list_free(queryFeatures);
@@ -1194,8 +1250,7 @@ lou_listTables(void) {
 	if (!tableIndex) indexTablePath();
 	for (l = tableIndex; l; l = l->tail) {
 		TableMeta *table = l->head;
-		tables = list_conj(
-				tables, strdup(table->name), (int (*)(void *, void *))strcmp, NULL, NULL);
+		tables = list_conj(tables, strdup(table->name), strcmp_, NULL, NULL);
 	}
 	tablesArray = list_toArray(tables, 0);
 	list_free(tables);


### PR DESCRIPTION
## Description

This PR fixes issue [#2051](https://github.com/liblouis/liblouis/issues/2051)
The `List` and `Feature` structs in `liblouis/metadata.c` store *generic* callback pointers:

```c
typedef struct List {
    void *head;
    void (*free)(void *);  // free head
    void *(*dup)(void *);  // dup head
    struct List *tail;
} List;
```

`list_conj()` and `list_sort()` likewise take generic comparators:

```c
list_conj(List *list, void *x, int (*cmp)(void *, void *), void *(*dup)(void *), ...);
list_sort(List *list, int (*cmp)(void *, void *));
```

But the 8 callback *implementations* take **typed** pointers (`Feature *`, `List *`, `TableMeta *`, `TableMatch *`) and are passed into those generic slots via casts such as:

```c
return list_sort(features, (int (*)(void *, void *))cmpFeatures);   // metadata.c, analyzeTable()
```

Under UBSan `-fsanitize=function`, calling a function through a pointer whose declared type does not match the function's actual signature is undefined behavior — the check validates **both** the parameter types **and** the return type. So the first call through the miscast pointer trips at `metadata.c:78`:

```c
int c = cmp(l1->head, x);   // cmp is int(*)(void*,void*) but points to cmpFeatures(Feature*,Feature*)
```

```
runtime error: call to function cmpFeatures through pointer to incorrect type 'int (*)(void *, void *)'
SUMMARY: UndefinedBehaviorSanitizer: function_type_mismatch
#0 __ubsan_handle_function_type_mismatch_abort
#1 list_conj            metadata.c:78
#2 list_sort            metadata.c:139
#3 analyzeTable         metadata.c
#4 lou_indexTables      metadata.c
```

The initially-suggested fix changed only `cmpFeatures`. That is insufficient: the same defect exists in all 8 callbacks, so the crash simply moved to the next one called through a miscast pointer — `meta_free` (metadata.c:108) and `list_free` (metadata.c:221) — and aborted there instead.


## Checklist

### Tests

- [x] Some functional changes do not require tests (please explain
      below)

This PR fixes UBSan -fsanitize=function errors in liblouis/metadata.c caused by callback functions with typed parameters being called through generic void * function pointers in List and Feature structs. The fix updates eight callbacks (list_free, list_dup, feat_free, feat_dup, meta_free, cmpKeys, cmpFeatures, and cmpMatches) to accept void * with internal casts, aligning their signatures without altering any table or translation logic. While functional tests are unaffected, the fix successfully eliminates all function_type_mismatch trips when running the existing test suite under ASan and UBSan.

- [x] I have tested my changes locally
- [x] The test suite passes for every commit
