### PR TITLE
Draft: document and test Persian computer Braille baseline

### DIFF
--- a/tables/fa-ir-comp8.ctb
+++ b/tables/fa-ir-comp8.ctb
@@ -19,6 +19,12 @@
 # TODO: Please add a reference to official documentation about
 # the implemented braille code. Preferably submit the documents
 # to https://github.com/liblouis/braille-specs.
+#
+# Provenance note: the Iranian 1393/2014 manual audited in
+# https://github.com/liblouis/liblouis/issues/2053 does not define a Persian
+# Unicode eight-dot allocation. The mappings below are preserved as the
+# existing Liblouis implementation baseline; they are not claimed to be
+# manual-certified or nationally authoritative.
 # -----------
 #
 # Copyright (C) 2017 by Mohammadreza Rashad <mohammadreza5712@gmail.com>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -125,6 +125,7 @@ dist_braille_specs_TESTS =				  \
 	braille-specs/es-g2.yaml			  \
 	braille-specs/et_harness.yaml			  \
 	braille-specs/ethio-g1_harness.yaml		  \
+	braille-specs/fa-ir-comp8.yaml			  \
 	braille-specs/fa-ir-comp8-harness.yaml		  \
 	braille-specs/fa-ir-g1-harness.yaml		  \
 	braille-specs/fi_harness.yaml			  \

--- a/tests/braille-specs/Makefile.am
+++ b/tests/braille-specs/Makefile.am
@@ -66,6 +66,7 @@ EXTRA_DIST =					\
 	es-g2.yaml				\
 	et_harness.yaml				\
 	ethio-g1_harness.yaml			\
+	fa-ir-comp8.yaml			\
 	fa-ir-comp8-harness.yaml		\
 	fa-ir-g1-harness.yaml			\
 	fi_harness.yaml				\

--- a/tests/braille-specs/fa-ir-comp8.yaml
+++ b/tests/braille-specs/fa-ir-comp8.yaml
@@ -1,0 +1,34 @@
+# Focused regression tests for the existing Persian computer Braille table.
+#
+# These mappings are a de-facto Liblouis implementation baseline. The Iranian
+# 1393/2014 manual discussed in
+# <https://github.com/liblouis/liblouis/issues/2053> does not define a Persian
+# Unicode eight-dot allocation, so these tests do not claim official or
+# nationally authoritative status.
+
+display: unicode-without-blank.dis
+table:
+  language: fa
+  type: computer
+  dots: 8
+  __assert-match: fa-ir-comp8.ctb
+
+flags: {testmode: bothDirections}
+
+tests:
+  # Preserve the table's distinct cells for Persian and Arabic code-point
+  # variants of kaf and yeh.
+  - [کكیي, ⠅⣅⠊⣪]
+
+  # Persian digits and ASCII digits have separate eight-dot allocations.
+  - [۰۱۲۳۴۵۶۷۸۹, ⣚⣁⣃⣉⣙⣑⣋⣛⣓⣊]
+  - ['0123456789', ⣴⣂⣆⣒⣲⣢⣖⣶⣦⣔]
+
+  # Latin uppercase and lowercase letters remain distinguishable.
+  - [AaZz, ⡁⢁⡵⢵]
+
+  # Preserve the current visible cell assigned to ZWNJ in Persian text.
+  - [می‌خوانم, ⠍⠊⢠⠭⠺⠁⠝⠍]
+
+  # Persian punctuation and numeric separators retain distinct cells.
+  - ['،؛؟ ٪٫٬', '⡂⡆⡹ ⡩⠐⡄']


### PR DESCRIPTION
## Summary

This draft documents and tests the existing Persian eight-dot computer-Braille
implementation baseline. It makes **no mapping changes**.

The provenance note records the key finding from
https://github.com/liblouis/liblouis/issues/2053: the Iranian 1393/2014 manual
contains legacy American and British computer-Braille sections, but it does not
define a Persian Unicode eight-dot allocation. The current table therefore
must not be presented as manual-certified or nationally authoritative.

## Changes

- add that provenance limitation to `fa-ir-comp8.ctb`
- add a small bidirectional test file for the table's current behavior:
  - distinct Persian/Arabic kaf and yeh code points
  - Persian and ASCII digit allocations
  - case-distinct Latin letters
  - the current visible ZWNJ cell
  - Persian punctuation and numeric separators
- register the focused test in both Makefiles

The ZWNJ case records the current implementation; it is not an endorsement of
that policy. A later reviewed Unicode policy may intentionally change it.

## Validation

```text
tools/lou_checktable tables/fa-ir-comp8.ctb
No errors found.

make -C tests check TESTS='braille-specs/fa-ir-comp8.yaml'
TOTAL: 1; PASS: 1; FAIL: 0

make -C tests check TESTS='braille-specs/fa-ir-comp8-harness.yaml'
TOTAL: 1; PASS: 1; FAIL: 0
```

## Status

This should remain a Draft until the allocation's provenance and modern Unicode
policy are adjudicated. No native/proficient Persian Braille-reader validation
or national approval is claimed.

Related work:

- Grade 1 draft: https://github.com/liblouis/liblouis/pull/2054
- source record draft: https://github.com/liblouis/braille-specs/pull/31

