### PR TITLE
Fix malformed replace rule handling

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4027,16 +4027,18 @@ doOpcode:
 			return 1;
 		}
 		case CTO_Replace:
-			if (getRuleCharsText(file, &ruleChars)) {
-				if (atEndOfLine(file))
+			if (!getRuleCharsText(file, &ruleChars)) return 0;
+			if (atEndOfLine(file))
+				ruleDots.length = ruleDots.chars[0] = 0;
+			else {
+				if (!getRuleDotsText(file, &ruleDots)) return 0;
+				if (ruleDots.length > 0 && ruleDots.chars[0] == '#')
 					ruleDots.length = ruleDots.chars[0] = 0;
-				else {
-					getRuleDotsText(file, &ruleDots);
-					if (ruleDots.chars[0] == '#')
-						ruleDots.length = ruleDots.chars[0] = 0;
-					else if (ruleDots.chars[0] == '\\' && ruleDots.chars[1] == '#')
-						memmove(&ruleDots.chars[0], &ruleDots.chars[1],
-								ruleDots.length-- * CHARSIZE);
+				else if (ruleDots.length > 1 && ruleDots.chars[0] == '\\' &&
+						ruleDots.chars[1] == '#') {
+					ruleDots.length--;
+					memmove(&ruleDots.chars[0], &ruleDots.chars[1],
+							ruleDots.length * CHARSIZE);
 				}
 			}
 			for (int k = 0; k < ruleChars.length; k++)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,7 @@ getTable_SOURCES = getTable.c
 hash_collision_SOURCES = hash_collision.c
 hyphenate_xxx_SOURCES = hyphenate_xxx.c
 logging_SOURCES = logging.c
+malformedTables_SOURCES = malformedTables.c
 resolve_table_SOURCES = resolve_table.c
 typeform_SOURCES = typeform.c
 typeform_for_emphclass_SOURCES = typeform_for_emphclass.c
@@ -41,6 +42,7 @@ program_TESTS =					\
 	hash_collision				\
 	hyphenate_xxx				\
 	logging					\
+	malformedTables				\
 	resolve_table				\
 	typeform				\
 	typeform_for_emphclass			\

--- a/tests/checkTable.c
+++ b/tests/checkTable.c
@@ -20,8 +20,6 @@ main(int argc, char **argv)
 {
   const char *goodTable = "tables/en-us-g1.ctb";
   const char *badTable = "tests/tables/bad.ctb";
-  const char *badReplaceTable = "tests/tables/bad-replace.ctb";
-  const char *badReplaceSourceTable = "tests/tables/bad-replace-source.ctb";
   int result = 0;
 
   if (lou_checkTable(goodTable) == 0)
@@ -33,21 +31,6 @@ main(int argc, char **argv)
   if (lou_checkTable(badTable) != 0)
   {
     printf("Getting %s succeeded, expected failure\n", badTable);
-    result = 1;
-  }
-
-  /* The "\\#" sequence starts the replacement operand with a literal '#';
-   * reject its trailing lone backslash without underflowing ruleDots.length. */
-  if (lou_checkTable(badReplaceTable) != 0)
-  {
-    printf("Getting %s succeeded, expected failure\n", badReplaceTable);
-    result = 1;
-  }
-
-  /* Reject a trailing lone backslash in the source operand. */
-  if (lou_checkTable(badReplaceSourceTable) != 0)
-  {
-    printf("Getting %s succeeded, expected failure\n", badReplaceSourceTable);
     result = 1;
   }
 

--- a/tests/checkTable.c
+++ b/tests/checkTable.c
@@ -36,12 +36,14 @@ main(int argc, char **argv)
     result = 1;
   }
 
+  /* Reject a trailing lone backslash in the replacement operand. */
   if (lou_checkTable(badReplaceTable) != 0)
   {
     printf("Getting %s succeeded, expected failure\n", badReplaceTable);
     result = 1;
   }
 
+  /* Reject a trailing lone backslash in the source operand. */
   if (lou_checkTable(badReplaceSourceTable) != 0)
   {
     printf("Getting %s succeeded, expected failure\n", badReplaceSourceTable);

--- a/tests/checkTable.c
+++ b/tests/checkTable.c
@@ -20,6 +20,10 @@ main(int argc, char **argv)
 {
   const char *goodTable = "tables/en-us-g1.ctb";
   const char *badTable = "tests/tables/bad.ctb";
+  const char *badReplaceRules[] = {
+    "replace \\",
+    "replace t \\\\#\\"
+  };
   int result = 0;
 
   if (lou_checkTable(goodTable) == 0)
@@ -38,6 +42,15 @@ main(int argc, char **argv)
   {
     printf("Getting %s failed, expected success\n", goodTable);
     result = 1;
+  }
+
+  for (size_t i = 0; i < sizeof(badReplaceRules) / sizeof(badReplaceRules[0]); i++)
+  {
+    if (lou_compileString(goodTable, badReplaceRules[i]) != 0)
+    {
+      printf("Compiling invalid rule '%s' succeeded, expected failure\n", badReplaceRules[i]);
+      result = 1;
+    }
   }
 
   lou_free();

--- a/tests/checkTable.c
+++ b/tests/checkTable.c
@@ -36,7 +36,8 @@ main(int argc, char **argv)
     result = 1;
   }
 
-  /* Reject a trailing lone backslash in the replacement operand. */
+  /* The "\\#" sequence starts the replacement operand with a literal '#';
+   * reject its trailing lone backslash without underflowing ruleDots.length. */
   if (lou_checkTable(badReplaceTable) != 0)
   {
     printf("Getting %s succeeded, expected failure\n", badReplaceTable);

--- a/tests/checkTable.c
+++ b/tests/checkTable.c
@@ -20,10 +20,8 @@ main(int argc, char **argv)
 {
   const char *goodTable = "tables/en-us-g1.ctb";
   const char *badTable = "tests/tables/bad.ctb";
-  const char *badReplaceRules[] = {
-    "replace \\",
-    "replace t \\\\#\\"
-  };
+  const char *badReplaceTable = "tests/tables/bad-replace.ctb";
+  const char *badReplaceSourceTable = "tests/tables/bad-replace-source.ctb";
   int result = 0;
 
   if (lou_checkTable(goodTable) == 0)
@@ -38,19 +36,22 @@ main(int argc, char **argv)
     result = 1;
   }
 
+  if (lou_checkTable(badReplaceTable) != 0)
+  {
+    printf("Getting %s succeeded, expected failure\n", badReplaceTable);
+    result = 1;
+  }
+
+  if (lou_checkTable(badReplaceSourceTable) != 0)
+  {
+    printf("Getting %s succeeded, expected failure\n", badReplaceSourceTable);
+    result = 1;
+  }
+
   if (lou_checkTable(goodTable) == 0)
   {
     printf("Getting %s failed, expected success\n", goodTable);
     result = 1;
-  }
-
-  for (size_t i = 0; i < sizeof(badReplaceRules) / sizeof(badReplaceRules[0]); i++)
-  {
-    if (lou_compileString(goodTable, badReplaceRules[i]) != 0)
-    {
-      printf("Compiling invalid rule '%s' succeeded, expected failure\n", badReplaceRules[i]);
-      result = 1;
-    }
   }
 
   lou_free();

--- a/tests/malformedTables.c
+++ b/tests/malformedTables.c
@@ -1,0 +1,32 @@
+/* liblouis Braille Translation and Back-Translation Library
+
+Copyright (C) 2026 Darren Carreras
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved. This file is offered as-is,
+without any warranty. */
+
+#include <config.h>
+
+#include <stdio.h>
+#include "liblouis.h"
+
+/**
+ * These are regression tests for malformed tables that used to make
+ * Liblouis crash.
+ */
+int
+main(int argc, char **argv)
+{
+  /* The "\\#" sequence starts the replacement operand with a literal '#';
+   * reject its trailing lone backslash without underflowing ruleDots.length. */
+  lou_checkTable("tests/tables/bad-replace.ctb");
+
+  /* Reject a trailing lone backslash in the source operand. */
+  lou_checkTable("tests/tables/bad-replace-source.ctb");
+
+  lou_free();
+
+  return 0;
+}

--- a/tests/tables/Makefile.am
+++ b/tests/tables/Makefile.am
@@ -1,6 +1,8 @@
 SUBDIRS = moreTables resolve_table emphclass attribute
 
 EXTRA_DIST =					\
+	bad-replace-source.ctb			\
+	bad-replace.ctb				\
 	bad.ctb					\
 	context-ignored.utb			\
 	empty.ctb				\

--- a/tests/tables/bad-replace-source.ctb
+++ b/tests/tables/bad-replace-source.ctb
@@ -1,0 +1,1 @@
+replace \

--- a/tests/tables/bad-replace.ctb
+++ b/tests/tables/bad-replace.ctb
@@ -1,0 +1,1 @@
+replace t \\#\


### PR DESCRIPTION
## Description

Stop compiling `replace` rules when either operand fails to parse. The
malformed dots operand from #2048 left a partially populated, zero-length
`CharsString`; the escaped-hash branch then wrapped its unsigned length and the
following `putChar()` loop read beyond the stack array.

This also fixes the mirror-image first-operand failure, checks lengths before
accessing `chars[0]` and `chars[1]`, and calculates the escaped-hash `memmove()`
size after removing the leading escape.

Fixes #2048.

Reported by Shujie Xiang (`@CrJyyy`).

## Verification

- The 14-byte reproducer from #2048 triggers an ASan stack-buffer-overflow on
  unmodified master and is rejected cleanly after this change.
- A malformed first operand reproduces the mirror failure with pattern stack
  initialization and is rejected cleanly after this change.
- Added both inputs as dedicated bad-table fixtures exercised through
  `lou_checkTable()`; the focused test passes under ASan/UBSan.
- Valid deletion and escaped-hash `replace` rules still compile.
- All 209 upstream suites are accounted for under ASan/UBSan: 206 passed in the
  complete out-of-tree run, and the three generated-table lookup failures
  passed after including the build table directory in `LOUIS_TABLEPATH`.
- `git diff --check` passes.

## Checklist

- [x] I added tests covering the bug fix and adjacent malformed-input path.
- [x] Tests cover edge cases and potential side effects.
- [x] I tested the changes locally.
- [x] The test suite passes for this commit.
- [x] Existing license headers and copyright notices remain applicable.

Table metadata and documentation are not applicable because this change does
not modify a translation table.
