### PR TITLE
Fix output->length underflow and grouping/pass-action buffer overflow

### DIFF
--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -544,6 +544,7 @@ replaceGrouping(const TranslationTableHeader *table, const InString **input,
 			replaceStart = replaceRule->charsdots[2];
 			replaceEnd = replaceRule->charsdots[3];
 		}
+		if ((output->length + 1) > output->maxlength) return 0;
 		output->chars[output->length] = replaceEnd;
 		for (p = output->length - 1; p >= 0; p--) {
 			if (output->chars[p] == endCharDots) level--;
@@ -978,6 +979,7 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 			ruleOffset =
 					(passInstructions[passIC + 1] << 16) | passInstructions[passIC + 2];
 			rule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
+			if ((output->length + 1) > output->maxlength) return 0;
 			posMapping[output->length] = match.startMatch;
 			output->chars[output->length++] = rule->charsdots[2 * passCharDots];
 			passIC += 3;
@@ -986,6 +988,7 @@ passDoAction(const TranslationTableHeader *table, const InString **input,
 			ruleOffset =
 					(passInstructions[passIC + 1] << 16) | passInstructions[passIC + 2];
 			rule = (TranslationTableRule *)&table->ruleArea[ruleOffset];
+			if ((output->length + 1) > output->maxlength) return 0;
 			posMapping[output->length] = match.startMatch;
 			output->chars[output->length++] = rule->charsdots[2 * passCharDots + 1];
 			passIC += 3;

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -3816,7 +3816,8 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 
 		switch (transOpcode) {
 		case CTO_EndNum:
-			if (table->letterSign && checkCharAttr(input->chars[pos], CTC_Letter, table))
+			if (table->letterSign && output->length > 0 &&
+					checkCharAttr(input->chars[pos], CTC_Letter, table))
 				output->length--;
 			break;
 		case CTO_Repeated:


### PR DESCRIPTION
## Summary

Cherry-picks the two safe, self-contained fixes from #1968 that Bert and Christian agreed were ready:

- Fix `output->length` underflow in `CTO_EndNum` handling (guards the decrement so `length` can't go negative)
- Prevent output buffer / `posMapping` overflow in grouping pass actions (`replaceGrouping` and the `pass_groupstart`/`pass_groupend` cases in `passDoAction`), bringing them in line with the existing bounds-check pattern already used by the neighboring `pass_string`/`pass_dots` case in the same function

The third fix in #1968 (the `multind` back-translation guard) is intentionally left out — it has open correctness concerns raised by both Bert and tibbsa (the guard masks rather than fixes an incorrect `doingMultind` initializer, and can skip valid candidate rules in the back-translation chain walk) and needs further work there.

Closes the underflow/overflow portion of #1968; the `multind` fix will continue in #1968 or a follow-up PR.

## Test plan

- [x] `make check` — 209/209 passing
- [x] `make format-sources` — clean (one line-length fix applied in a separate commit)