### PR TITLE
en-ueb-chardefs: fix combining macron dot pattern

### DIFF
--- a/tables/en-ueb-chardefs.uti
+++ b/tables/en-ueb-chardefs.uti
@@ -65,7 +65,7 @@ noback pass2 @45-12456-6 @6-45-12456  move after capital sign
 
 # macron
 sign \x00af 4-36 ¯
-sign \x0304 45-4-36 ̄ 
+sign \x0304 4-36 ̄
 noback correct [$l]"̄" "̄"*
 
 # cedilla

--- a/tests/braille-specs/en-ueb-symbols_harness.yaml
+++ b/tests/braille-specs/en-ueb-symbols_harness.yaml
@@ -186,6 +186,9 @@ tests:
   - [ÿ, ⠘⠒⠽] # lowercase y diaeresis [\x00ff]
   - [Ā, ⠠⠈⠤⠁] # capital a macron [\x0100]
   - [ā, ⠈⠤⠁] # lowercase a macron [\x0101]
+  - ["ā", ⠈⠤⠁] # lowercase a + combining macron [\x0304]
+  - ["Ā", ⠠⠈⠤⠁, {xfail: true}] # capital a + combining macron [\x0304]; modifier precedes capital sign (pre-existing, affects all combining marks except tilde)
+  - ["̄", ⠈⠤] # standalone combining macron [\x0304]
   - [Ă, ⠠⠈⠬⠁] # capital a breve [\x0102]
   - [ă, ⠈⠬⠁] # lowercase a breve [\x0103]
   - [Ć, ⠠⠘⠌⠉] # capital c acute [\x0106]


### PR DESCRIPTION
## Summary

Fixes the combining macron (U+0304) in `en-ueb-chardefs.uti`, which was brailled as `45-4-36`. The UEB macron modifier is dots `4-36`, matching the spacing macron (U+00AF) defined on the adjacent line and the precomposed letter-with-macron characters (ā, ē, ī, ō, ū) already covered by the symbols harness. Reported by James Bowden. cc @jrbowden

```
- sign \x0304 45-4-36 ̄
+ sign \x0304 4-36 ̄
```

## Scope note

While testing this, a second issue surfaced: for combining-diacritic input, modifier symbols are emitted *before* capitals indicators (e.g. `A`+U+0304 gives ⠈⠤⠠⠁ instead of ⠠⠈⠤⠁). An earlier version of this PR worked around that with pass2 reordering rules. Per the review discussion with @bertfrees, that workaround has been dropped, and the analysis plus a proposal to fix it properly (together with mid-word capsword cancellation) via `capsmodechars` is in #2074. Until that engine work lands, capitals combined with combining diacritics will remain incorrectly ordered. This PR now contains only the incorrect-cell fix so it can make the current release.

## Tests

- Adds combining-macron cases to the symbols harness: lowercase (`ā` gives ⠈⠤⠁), standalone (⠈⠤), and the capital case marked `xfail`, documenting the pre-existing ordering issue tracked in #2074.
- `lou_checkyaml` en-ueb suites pass. The pre-existing `tests/braille-specs/syc.yaml:16` xfail expects the old `45-4-36` pattern and should be updated whenever that xfail is addressed.
