### PR TITLE
Fix NULL pointer dereference in resolveSubtable when search path is unavailable

### DIFF
--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -4676,7 +4676,9 @@ resolveSubtable(const char *table, const char *base, const char *searchPath) {
 	//
 	// Then search `LOUIS_TABLEPATH`, `dataPath` and `programPath`
 	//
-	if (searchPath[0] != '\0') {
+	// searchPath may be NULL if _lou_getTablePath failed (e.g. because the
+	// data path was too long); the earlier resolution steps still apply.
+	if (searchPath != NULL && searchPath[0] != '\0') {
 		char *dir;
 		int last;
 		char *cp;

--- a/tests/resolve_table.c
+++ b/tests/resolve_table.c
@@ -130,6 +130,18 @@ main(int argc, char **argv)
   setenv ("LOUIS_TABLEPATH", "tables/resolve_table/dir_1", 1);
   ASSERT (lou_getTable ("tables/resolve_table/table_6"));
 
+  // Overlong LOUIS_TABLEPATH: the search path cannot be constructed, but
+  // this must not crash, and full paths must still resolve (see issue #1999)
+  {
+    char longPath[4096];
+    memset (longPath, 'a', sizeof(longPath) - 1);
+    longPath[sizeof(longPath) - 1] = '\0';
+    setenv ("LOUIS_TABLEPATH", longPath, 1);
+    lou_free();  // clear the table cache so resolution actually runs
+    ASSERT (!lou_getTable ("table_1"));
+    ASSERT (lou_getTable ("tables/resolve_table/table_1"));
+  }
+
   lou_free();
 
   return result;


### PR DESCRIPTION
Fixes #1999.

## Problem

When `_lou_getTablePath()` fails because the assembled search path does not fit in its `MAXSTRING`-sized buffer (e.g. an overlong `LOUIS_TABLEPATH` environment variable, or an overlong path passed to `lou_setDataPath`), it returns NULL. This NULL return was introduced by 548f6a3b as the fix for the stack buffer overflow in #1859, but `_lou_defaultTableResolver` was never updated to handle it: it passes the NULL straight into `resolveSubtable`, which dereferences it (`searchPath[0]`), producing the SEGV reported in #1999 (e.g. via `lou_indexTables`). The other caller of `_lou_getTablePath`, `indexTablePath` in metadata.c, already has a NULL guard.

## Fix

Guard the search-path lookup in `resolveSubtable` so a NULL search path is treated like an empty one. Resolution against the base table and against absolute/relative paths runs *before* the search-path loop, so tables specified by full path still resolve even when the search path could not be constructed — the failure degrades gracefully instead of crashing, and `_lou_getTablePath` has already logged a diagnostic ("LOUIS_TABLEPATH too long" etc.) by that point.

## Testing

- Added a regression test to `tests/resolve_table.c`: with a 4095-character `LOUIS_TABLEPATH`, resolving a bare table name fails cleanly (no crash) and resolving a table by full path still succeeds. The test clears the table cache first so resolution actually runs rather than returning a cached table.
- Verified the issue's original reproducer (`lou_setDataPath` with a 1999-character path, then `lou_indexTables`) segfaults before this change and exits cleanly after it.
- Full `make check` passes: 209/209.