### PR TITLE
Deprecate the spacing parameter of the translation functions

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -3664,10 +3664,13 @@ corresponding to a character in @code{outbuf} which was defined to
 have a dot representation containing dot 7, dot 8 or both, and to 0
 otherwise.
 
-The @code{spacing} parameter is used to indicate differences in
-spacing between the input string and the translated output string. It
-is also of the same length as the string pointed to by @code{*inbuf}.
-If this parameter is @code{NULL}, no spacing information is computed.
+@anchor{spacing parameter}
+The @code{spacing} parameter is deprecated and must be @code{NULL}.
+It was originally intended to indicate differences in spacing between
+the input string and the translated output string, but the feature
+never worked reliably and is no longer supported. The parameter is
+kept only for API and ABI compatibility. If a non-@code{NULL} value is
+passed, it is ignored and a warning is logged.
 
 The @code{mode} parameter specifies how the translation should be
 done. The valid values of mode are defined in @file{liblouis.h}. They
@@ -3799,11 +3802,10 @@ This is exactly the opposite of @code{lou_translateString}.
 @code{inbuf} is a string of Unicode characters representing
 braille. @code{outbuf} will contain a string of Unicode
 characters. @code{typeform} will indicate any emphasis found in the
-input string, while @code{spacing} will indicate any differences in
-spacing between the input and output strings. The @code{typeform} and
-@code{spacing} parameters may be @code{NULL} if this information is
-not needed. @code{mode} specifies how the back-translation
-should be done.
+input string; it may be @code{NULL} if this information is not
+needed. The @code{spacing} parameter is deprecated and must be
+@code{NULL} (@pxref{spacing parameter}). @code{mode} specifies how
+the back-translation should be done.
 
 By default, if a dot pattern in the input is undefined
 then its dot numbers will be included in the output (as \ddd/).

--- a/liblouis/compileTranslationTable.c
+++ b/liblouis/compileTranslationTable.c
@@ -5281,8 +5281,6 @@ lou_getTypeformForEmphClass(const char *tableList, const char *emphClass) {
 	return 0;
 }
 
-static unsigned char *destSpacing = NULL;
-static int sizeDestSpacing = 0;
 static formtype *typebuf = NULL;
 static unsigned int *wordBuffer = NULL;
 static EmphasisInfo *emphasisBuffer = NULL;
@@ -5324,14 +5322,6 @@ _lou_allocMem(AllocBuf buffer, int index, int srcmax, int destmax) {
 		if (emphasisBuffer == NULL) _lou_outOfMemory();
 		return emphasisBuffer;
 
-	case alloc_destSpacing:
-		if (destmax > sizeDestSpacing) {
-			if (destSpacing != NULL) free(destSpacing);
-			destSpacing = malloc(destmax + 4);
-			if (!destSpacing) _lou_outOfMemory();
-			sizeDestSpacing = destmax;
-		}
-		return destSpacing;
 	case alloc_passbuf:
 		if (index < 0 || index >= MAXPASSBUF) {
 			_lou_logMessage(LOU_LOG_FATAL, "Index out of bounds: %d\n", index);
@@ -5423,9 +5413,6 @@ lou_free(void) {
 	if (emphasisBuffer != NULL) free(emphasisBuffer);
 	emphasisBuffer = NULL;
 	sizeTypebuf = 0;
-	if (destSpacing != NULL) free(destSpacing);
-	destSpacing = NULL;
-	sizeDestSpacing = 0;
 	{
 		int k;
 		for (k = 0; k < MAXPASSBUF; k++) {

--- a/liblouis/internal.h
+++ b/liblouis/internal.h
@@ -497,7 +497,6 @@ typedef enum {
 	alloc_typebuf,
 	alloc_wordBuffer,
 	alloc_emphasisBuffer,
-	alloc_destSpacing,
 	alloc_passbuf,
 	alloc_posMapping1,
 	alloc_posMapping2,

--- a/liblouis/liblouis.h.in
+++ b/liblouis/liblouis.h.in
@@ -136,12 +136,12 @@ lou_charSize(void);
  * @warning BUFFER OVERFLOW RISK: Caller must ensure that:
  *          - `inlen` does not exceed actual size of `inbuf`
  *          - `typeform` array is NULL or at least `inlen` elements long
- *          - `spacing` is NULL or at least `inlen` elements long
  *          - `outbuf` can hold at least `outlen` elements
  *          Passing incorrect lengths will cause buffer overflows
  *
  * @note `typeform` may be NULL if no typeform checking is needed
- * @note `spacing` may be NULL if no spacing information is to be computed
+ * @note `spacing` is deprecated and must be NULL; any other value is
+ * ignored and a warning is logged
  */
 LIBLOUIS_API
 int EXPORT_CALL

--- a/liblouis/lou_backTranslateString.c
+++ b/liblouis/lou_backTranslateString.c
@@ -145,8 +145,8 @@ typedef struct {
 
 static int
 backTranslateString(const TranslationTableHeader *table, int mode, int currentPass,
-		const InString *input, OutString *output, unsigned char *typebuf, char *spacebuf,
-		int *posMapping, int *realInlen, int *cursorPosition, int *cursorStatus,
+		const InString *input, OutString *output, unsigned char *typebuf, int *posMapping,
+		int *realInlen, int *cursorPosition, int *cursorStatus,
 		const TranslationTableRule **appliedRules, int *appliedRulesCount,
 		int maxAppliedRules);
 static int
@@ -190,7 +190,6 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 	InString input;
 	OutString output;
 	unsigned char *typebuf = NULL;
-	char *spacebuf;
 	// posMapping contains position mapping info between the output of the current pass
 	// and the initial input. It is 1 longer than the (consumed) input. The values are
 	// monotonically increasing and can range between -1 and the output length. At the end
@@ -247,7 +246,9 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 		.length = 0,
 		.bufferIndex = idx };
 	typebuf = (unsigned char *)typeform;
-	spacebuf = spacing;
+	if (spacing != NULL)
+		_lou_logMessage(LOU_LOG_WARN,
+				"warning: the spacing parameter is deprecated and ignored; pass NULL");
 	if (outputPos != NULL)
 		for (k = 0; k < input.length; k++) outputPos[k] = -1;
 	if (cursorPos != NULL)
@@ -256,7 +257,6 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 		cursorPosition = -1;
 	cursorStatus = 0;
 	if (typebuf != NULL) memset(typebuf, 0, *outlen * sizeof(formtype));
-	if (spacebuf != NULL) memset(spacebuf, '*', *outlen);
 	if (!(posMapping1 = _lou_allocMem(alloc_posMapping1, 0, input.length, *outlen)))
 		return 0;
 	if (table->numPasses > 1 || table->corrections) {
@@ -283,8 +283,8 @@ _lou_backTranslate(const char *tableList, const char *displayTableList,
 		switch (currentPass) {
 		case 1:
 			if (!backTranslateString(table, mode, currentPass, &input, &output, typebuf,
-						spacebuf, passPosMapping, &realInlen, &cursorPosition,
-						&cursorStatus, appliedRules, &appliedRulesCount, maxAppliedRules))
+						passPosMapping, &realInlen, &cursorPosition, &cursorStatus,
+						appliedRules, &appliedRulesCount, maxAppliedRules))
 				return 0;
 			break;
 		case 0:
@@ -1064,13 +1064,12 @@ putCharacters(const widechar *characters, int count, const TranslationTableHeade
 
 static int
 insertSpace(const TranslationTableHeader *table, int pos, const InString *input,
-		OutString *output, char *spacebuf, int *posMapping, int *cursorPosition,
-		int *cursorStatus, TranslationContext *ctx) {
+		OutString *output, int *posMapping, int *cursorPosition, int *cursorStatus,
+		TranslationContext *ctx) {
 	widechar c = ' ';
 	if (!back_updatePositions(&c, 1, 1, table, pos, input, output, posMapping,
 				cursorPosition, cursorStatus, ctx))
 		return 0;
-	if (spacebuf) spacebuf[output->length - 1] = '1';
 	return 1;
 }
 
@@ -1185,8 +1184,8 @@ failure:
 
 static int
 backTranslateString(const TranslationTableHeader *table, int mode, int currentPass,
-		const InString *input, OutString *output, unsigned char *typebuf, char *spacebuf,
-		int *posMapping, int *realInlen, int *cursorPosition, int *cursorStatus,
+		const InString *input, OutString *output, unsigned char *typebuf, int *posMapping,
+		int *realInlen, int *cursorPosition, int *cursorStatus,
 		const TranslationTableRule **appliedRules, int *appliedRulesCount,
 		int maxAppliedRules) {
 	int pos;
@@ -1241,8 +1240,8 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 		switch (currentOpcode) {
 		case CTO_LargeSign:
 			if (previousOpcode == CTO_LargeSign)
-				if (!insertSpace(table, pos, input, output, spacebuf, posMapping,
-							cursorPosition, cursorStatus, &ctx))
+				if (!insertSpace(table, pos, input, output, posMapping, cursorPosition,
+							cursorStatus, &ctx))
 					goto failure;
 			break;
 		case CTO_CapsLetter:
@@ -1427,8 +1426,8 @@ backTranslateString(const TranslationTableHeader *table, int mode, int currentPa
 		switch (currentOpcode) {
 		case CTO_JoinNum:
 		case CTO_JoinableWord:
-			if (!insertSpace(table, pos, input, output, spacebuf, posMapping,
-						cursorPosition, cursorStatus, &ctx))
+			if (!insertSpace(table, pos, input, output, posMapping, cursorPosition,
+						cursorStatus, &ctx))
 				goto failure;
 			break;
 		default:

--- a/liblouis/lou_translateString.c
+++ b/liblouis/lou_translateString.c
@@ -1122,9 +1122,9 @@ failure:
 static int
 translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, formtype *typebuf,
-		unsigned char *srcSpacing, unsigned char *destSpacing, unsigned int *wordBuffer,
-		EmphasisInfo *emphasisBuffer, int haveEmphasis, int *realInlen,
-		int *cursorPosition, int *cursorStatus, int compbrlStart, int compbrlEnd);
+		unsigned int *wordBuffer, EmphasisInfo *emphasisBuffer, int haveEmphasis,
+		int *realInlen, int *cursorPosition, int *cursorStatus, int compbrlStart,
+		int compbrlEnd);
 
 int EXPORT_CALL
 lou_translateString(const char *tableList, const widechar *inbufx, int *inlen,
@@ -1174,8 +1174,6 @@ _lou_translate(const char *tableList, const char *displayTableList,
 	int *posMapping2;
 	int *posMapping3;
 	formtype *typebuf;
-	unsigned char *srcSpacing;
-	unsigned char *destSpacing;
 	unsigned int *wordBuffer;
 	EmphasisInfo *emphasisBuffer;
 	int cursorPosition;
@@ -1214,10 +1212,9 @@ _lou_translate(const char *tableList, const char *displayTableList,
 	} else
 		memset(typebuf, 0, input.length * sizeof(formtype));
 
-	if (!(spacing == NULL || *spacing == 'X'))
-		srcSpacing = (unsigned char *)spacing;
-	else
-		srcSpacing = NULL;
+	if (spacing != NULL)
+		_lou_logMessage(LOU_LOG_WARN,
+				"warning: the spacing parameter is deprecated and ignored; pass NULL");
 	if (outputPos != NULL)
 		for (k = 0; k < input.length; k++) outputPos[k] = -1;
 	if (cursorPos != NULL && *cursorPos >= 0) {
@@ -1258,13 +1255,6 @@ _lou_translate(const char *tableList, const char *displayTableList,
 		if (!(posMapping3 = _lou_allocMem(alloc_posMapping3, 0, input.length, *outlen)))
 			return 0;
 	}
-	if (srcSpacing != NULL) {
-		if (!(destSpacing = _lou_allocMem(alloc_destSpacing, 0, input.length, *outlen)))
-			goodTrans = 0;
-		else
-			memset(destSpacing, '*', *outlen);
-	} else
-		destSpacing = NULL;
 	appliedRulesCount = 0;
 	if (rules != NULL && rulesLen != NULL) {
 		appliedRules = rules;
@@ -1301,9 +1291,8 @@ _lou_translate(const char *tableList, const char *displayTableList,
 						  alloc_emphasisBuffer, 0, input.length, *outlen)))
 				return 0;
 			goodTrans = translateString(table, mode, currentPass, &input, &output,
-					passPosMapping, typebuf, srcSpacing, destSpacing, wordBuffer,
-					emphasisBuffer, haveEmphasis, &realInlen, &cursorPosition,
-					&cursorStatus, compbrlStart, compbrlEnd);
+					passPosMapping, typebuf, wordBuffer, emphasisBuffer, haveEmphasis,
+					&realInlen, &cursorPosition, &cursorStatus, compbrlStart, compbrlEnd);
 			break;
 		}
 		default:
@@ -1393,10 +1382,6 @@ _lou_translate(const char *tableList, const char *displayTableList,
 			if (inpos < 0) inpos = 0;
 			while (inpos < *inlen) outputPos[inpos++] = outpos;
 		}
-	}
-	if (destSpacing != NULL) {
-		memcpy(srcSpacing, destSpacing, input.length);
-		srcSpacing[input.length] = 0;
 	}
 	if (cursorPos != NULL && *cursorPos != -1) {
 		if (outputPos != NULL)
@@ -3624,9 +3609,9 @@ checkNumericMode(const TranslationTableHeader *table, int pos, const InString *i
 static int
 translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		const InString *input, OutString *output, int *posMapping, formtype *typebuf,
-		unsigned char *srcSpacing, unsigned char *destSpacing, unsigned int *wordBuffer,
-		EmphasisInfo *emphasisBuffer, int haveEmphasis, int *realInlen,
-		int *cursorPosition, int *cursorStatus, int compbrlStart, int compbrlEnd) {
+		unsigned int *wordBuffer, EmphasisInfo *emphasisBuffer, int haveEmphasis,
+		int *realInlen, int *cursorPosition, int *cursorStatus, int compbrlStart,
+		int compbrlEnd) {
 	int pos;
 	int transOpcode;
 	int prevTransOpcode;
@@ -4008,9 +3993,6 @@ translateString(const TranslationTableHeader *table, int mode, int currentPass,
 		default:
 			break;
 		}
-		if (srcSpacing != NULL && pos < input->length && srcSpacing[pos] >= '0' &&
-				srcSpacing[pos] <= '9')
-			destSpacing[output->length] = srcSpacing[pos];
 		if ((transOpcode >= CTO_Always && transOpcode <= CTO_None) ||
 				(transOpcode >= CTO_Digit && transOpcode <= CTO_LitDigit))
 			prevTransOpcode = transOpcode;

--- a/tools/lou_allround.c
+++ b/tools/lou_allround.c
@@ -86,9 +86,7 @@ static int enteredCursorPos = -1;
 static unsigned int mode;
 static char table[BUFSIZE];
 static formtype emphasis[BUFSIZE];
-static char spacing[BUFSIZE];
 static char enteredEmphasis[BUFSIZE];
-static char enteredSpacing[BUFSIZE];
 
 static int
 getInput(void) {
@@ -116,7 +114,7 @@ getYN(void) {
 static void
 paramLetters(void) {
 	printf("Press one of the letters in parentheses, then enter.\n");
-	printf("(t)able, (r)un, (m)ode, (c)ursor, (e)mphasis, (s)pacing, (h)elp,\n");
+	printf("(t)able, (r)un, (m)ode, (c)ursor, (e)mphasis, (h)elp,\n");
 	printf("(q)uit, (f)orward-only, (b)ack-only, show-(p)ositions m(i)nimal.\n");
 	printf("test-(l)engths.\n");
 }
@@ -192,12 +190,6 @@ getCommands(void) {
 			getInput();
 			strcpy(enteredEmphasis, inputBuffer);
 			break;
-		case 's':
-			printf("(Enter an x to cancel spacing.)\n");
-			printf("Enter a spacing string: ");
-			getInput();
-			strcpy(enteredSpacing, inputBuffer);
-			break;
 		case 'h':
 			printf("Commands: action\n");
 			printf("(t)able: Enter a table name\n");
@@ -205,7 +197,6 @@ getCommands(void) {
 			printf("(m)ode: Enter a mode parameter\n");
 			printf("(c)ursor: Enter a cursor position\n");
 			printf("(e)mphasis: Enter an emphasis string\n");
-			printf("(s)pacing: Enter a spacing string\n");
 			printf("(h)elp: print this page\n");
 			printf("(q)uit: leave the program\n");
 			printf("(f)orward-only: do only forward translation\n");
@@ -348,7 +339,6 @@ main(int argc, char **argv) {
 						emphasis[k] = (formtype)enteredEmphasis[k] - '0';
 					emphasis[k] = 0;
 				}
-				strcpy(spacing, enteredSpacing);
 				cursorPos = enteredCursorPos;
 				inlen = getInput();
 				if (inlen == 0) break;
@@ -361,8 +351,8 @@ main(int argc, char **argv) {
 					if (!(realInlen = _lou_extParseChars(inputBuffer, inbuf))) break;
 					inlen = realInlen;
 					if (!lou_translate(table, inbuf, &inlen, transbuf, &translen,
-								emphasis, spacing, &outputPos[0], &inputPos[0],
-								&cursorPos, mode))
+								emphasis, NULL, &outputPos[0], &inputPos[0], &cursorPos,
+								mode))
 						break;
 					transbuf[translen] = 0;
 					if (mode & dotsIO) {
@@ -383,7 +373,6 @@ main(int argc, char **argv) {
 					}
 				}
 				if (cursorPos != -1) printf("Cursor position: %d\n", cursorPos);
-				if (enteredSpacing[0]) printf("Returned spacing: %s\n", spacing);
 				if (showPositions) {
 					printf("Output positions:\n");
 					for (int k = 0; k < inlen; k++) printf("%d ", outputPos[k]);
@@ -394,8 +383,8 @@ main(int argc, char **argv) {
 				}
 				if (!forwardOnly) {
 					if (!lou_backTranslate(table, transbuf, &translen, outbuf, &outlen,
-								emphasis, spacing, &outputPos[0], &inputPos[0],
-								&cursorPos, mode))
+								emphasis, NULL, &outputPos[0], &inputPos[0], &cursorPos,
+								mode))
 						break;
 					printf("Back-translation:\n");
 #ifdef WIDECHARS_ARE_UCS4
@@ -409,7 +398,6 @@ main(int argc, char **argv) {
 						printf("input length = %d; output length = %d\n", translen,
 								outlen);
 					if (cursorPos != -1) printf("Cursor position: %d\n", cursorPos);
-					if (enteredSpacing[0]) printf("Returned spacing: %s\n", spacing);
 					if (showPositions) {
 						printf("Output positions:\n");
 						for (int k = 0; k < translen; k++) printf("%d ", outputPos[k]);


### PR DESCRIPTION
Fixes #496

As discussed in https://github.com/liblouis/liblouis/issues/496#issuecomment-5329641948, the `spacing` parameter of the translation functions was intended to track spaces deleted by `joinword`/`joinnum`/`largesign` rules during forward translation and re-inserted during back-translation, but it never worked reliably (no multi-pass support; output truncated or unterminated in both directions) and has no known consumers — liblouisutdml passes `NULL` in every call, and the Python bindings (and therefore NVDA) never exposed it.

This PR deprecates the feature while preserving API and ABI compatibility:

- The `spacing` parameter of `lou_translate`, `lou_translateString`, `lou_backTranslate` and `lou_backTranslateString` remains in the signatures, but is now ignored. Passing a non-`NULL` value logs a `LOU_LOG_WARN` message ("the spacing parameter is deprecated and ignored; pass NULL"); the caller's buffer is left untouched.
- The internal `srcSpacing`/`destSpacing`/`spacebuf` plumbing is removed from the translation and back-translation engines, along with the `alloc_destSpacing` buffer machinery.
- The `(s)pacing` command is removed from `lou_allround`.
- `liblouis.h.in` and the manual are updated to document that only `NULL` is supported.

No NEWS entry yet (can be added at release time).

Full test suite passes: 209/209.
