### PR TITLE
Hebrew: replace positional class references with named classes

### DIFF
--- a/tables/hbo-common-rules.uti
+++ b/tables/hbo-common-rules.uti
@@ -50,19 +50,16 @@ noback correct "‏" ?  # Right-to-left mark
 noback correct "‭" ?  # left-to-right override
 noback correct "‮" ?  # Right-to-left override
 
-# In rules below, attribute $x is %vowel, defined in he-common-vowels-ihbc.uti
-# Attribute $y is %extcant, defined in he-common-vowels-ihbc.uti
-
 # character reordering
 ## Move dagesh before nearest preceding consonant
 noback correct [$l]"ּ" "ּ"*
-noback correct [$l$xy.]"ּ" "ּ"*
+noback correct [$l%vowelCant.]"ּ" "ּ"*
 
 ## Move shin and sin dot next to sin/shin consonant
 ## Prerequisite for “always” rule in he-common-consonants.uti
 ## to work with vocalized texts.
-noback correct [$xy.]"ׂ" "ׂ"*
-noback correct [$xy.]"ׁ" "ׁ"*
+noback correct [%vowelCant.]"ׂ" "ׂ"*
+noback correct [%vowelCant.]"ׁ" "ׁ"*
 
 # Contracting dagesh for bet, kaf, pe, and tav
 noback context "ּב" @12
@@ -73,10 +70,11 @@ noback context "ּף" @1234
 noback context "ּת" @1256
 
 # Contracting ultralong vowels (vowel+mater lectionis)
-attribute majCant \x05bc\x05bd
+## Dagesh and meteg complete the vowelCantDagesh union
+attribute vowelCantDagesh \x05bc\x05bd
 
 ## Holam-waw and consonantal waw
-noback pass3 !$xyz[@2456-135a] @246
+noback pass3 !%vowelCantDagesh[@2456-135a] @246
 noback pass3 [@2456-135a]$sp @246
 noback pass3 [@2456-135a]~ @246
 noback pass3 [@135a-2456]%hebLetter @246
@@ -88,7 +86,7 @@ noback pass3 [@135a-2456]%hebLetter @246
 ## produced for a genuine shuruq. This avoids a later pass rule matching
 ## the naked 346 cell, which would also match identical cells produced by
 ## other languages when this table is combined with them.
-noback context ["ּו"]$x @5a-2456
+noback context ["ּו"]%vowel @5a-2456
 noback context "ּו" @346
 
 ## Hiriq Yod
@@ -98,8 +96,8 @@ noback pass3 @24a-245 @35 Hiriq-yod
 noback pass3 @34a-245 @3456
 
 ## Shin and sin with dagesh
-noback correct ["ש"$xy.]"\x05bc\x05c2" "\x05bc\x05c2"*
-noback correct ["ש"$xy.]"\x05bc\x05c1" "\x05bc\x05c1"*
+noback correct ["ש"%vowelCant.]"\x05bc\x05c2" "\x05bc\x05c2"*
+noback correct ["ש"%vowelCant.]"\x05bc\x05c1" "\x05bc\x05c1"*
 noback always \x05c1\x05e9 146
 noback always \x05c2\x05e9 156
 noback pass2 @146-5a @5a-146
@@ -121,7 +119,8 @@ nofor pass3 @45-125 @5-125
 nofor pass4 @35 @24-245 Hiriq-yod
 
 ## Uncontract tsere-yod
-nofor pass4 $lxy[@3456] @34-245
+nofor pass4 $l[@3456] @34-245
+nofor pass4 %vowelCant[@3456] @34-245
 
 ## Final letters
 nofor correct _$lS"כ"~ "ך"

--- a/tables/he-common-vowels-ihbc.uti
+++ b/tables/he-common-vowels-ihbc.uti
@@ -73,8 +73,10 @@ noback pass4 @135a @135  # holam
 noback pass4 @23a @23  # Atnakh/Etnahta
 noback pass4 @2a @2 # Zaqef Qatan
 
-# Define vowel class (also includes Etnahta and zaqef qatan)
 attribute vowel \x05b0\x05b1\x05b2\x05b3\x05b4\x05b5\x05b6\x05b7\x05b8\x05b9\x05ba\x05bb\x05c7
+## Every vowel character also belongs to the vowelCant and vowelCantDagesh unions
+attribute vowelCant \x05b0\x05b1\x05b2\x05b3\x05b4\x05b5\x05b6\x05b7\x05b8\x05b9\x05ba\x05bb\x05c7
+attribute vowelCantDagesh \x05b0\x05b1\x05b2\x05b3\x05b4\x05b5\x05b6\x05b7\x05b8\x05b9\x05ba\x05bb\x05c7
 
 # Cantillation marksdefined in IHBC but seldom used in transcription
 ## Metheg
@@ -146,6 +148,9 @@ nofor sign \x05ae 46-1356  # Zinor
 
 # Defining class for extended cantillation (extcant)
 attribute extcant \x0592\x0593\x0595\x0596\x0597\x0598\x0599\x059a\x059b\x059c\x059d\x059e\x059f\x05a0\x05a1\x05a2\x05a3\x05a4\x05a5\x05a6\x05a7\x05a8\x05a9\x05aa\x05ab\x05ac\x05ad\x05ae\x05bd\x05bf
+## Every extcant character also belongs to the vowelCant and vowelCantDagesh unions
+attribute vowelCant \x0592\x0593\x0595\x0596\x0597\x0598\x0599\x059a\x059b\x059c\x059d\x059e\x059f\x05a0\x05a1\x05a2\x05a3\x05a4\x05a5\x05a6\x05a7\x05a8\x05a9\x05aa\x05ab\x05ac\x05ad\x05ae\x05bd\x05bf
+attribute vowelCantDagesh \x0592\x0593\x0595\x0596\x0597\x0598\x0599\x059a\x059b\x059c\x059d\x059e\x059f\x05a0\x05a1\x05a2\x05a3\x05a4\x05a5\x05a6\x05a7\x05a8\x05a9\x05aa\x05ab\x05ac\x05ad\x05ae\x05bd\x05bf
 
 # Clean up extended cantillation virtual dot
 noback pass4 @46a @46


### PR DESCRIPTION
> [!NOTE]
> Stacked on #2030 and #2060: I can rebase this (5ef31fe0) when these are merged.

Prompted by https://github.com/liblouis/louis-rs/pull/23#issuecomment-5326102766: liblouis plans to remove the `$w`/`$x`/`$y`/`$z` positional class references from multipass expressions (#948) because they mean "the Nth *declared* custom class" and silently depend on `attribute` rule order. The Hebrew tables were among the few still using them. Named references (`%vowel`) compile to the identical attribute test, so this is behavior-neutral.

Positional syntax could union classes in one operand (`$xy`, `$xyz`); a named reference carries a single class, so the unions become real classes:

- `vowelCant` = vowel + extcant
- `vowelCantDagesh` = vowelCant + dagesh and meteg

Their membership lines are declared directly next to the `vowel` and `extcant` declarations they mirror, so the lists stay in sync when a character is added. The `majCant` class only existed to be `$z` inside `$xyz` and is absorbed into `vowelCantDagesh`. The one `$lxy` test combined the predefined letter attribute with the union, which a single class cannot express; it is split into two rules with the same action.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)

