### PR TITLE
Document mode phrase opcodes and user-defined modes

### DIFF
--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -677,7 +677,8 @@ mode dots @samp{1} is to be interpreted as a capital ``A'' and not a
 small ``a''. In numeric mode dots @samp{1} is to be interpreted as a
 ``1''. The attribute operand identifies the mode and corresponds with
 the name of the character class that determines when the mode must be
-entered and exited.
+entered and exited. It may be @code{uppercase}, @code{digit} or the
+name of a user-defined character class (@pxopref{attribute}).
 
 @code{modeletter} is also used to mark every character when a mode
 must last for several characters but when there is no @code{begmode}
@@ -696,12 +697,8 @@ capsletter 6
 modeletter uppercase 6
 @end example
 
-The attribute operand may be @code{uppercase}, @code{digit} or the
-name of a user-defined character class (@pxopref{attribute}). A
-user-defined class defines a mode of its own: a character is in the
-mode when it belongs to the class, and the mode indicators are
-inserted in front of such characters. A typical use is a braille code
-that marks letters from another alphabet with an alphabet change
+A typical use of a user-defined mode is a braille code that marks
+letters from another alphabet with an alphabet change
 indicator. The following example puts some Greek letters in a class
 named @code{foreign} and defines a letter indicator, a word indicator
 and a phrase indicator for that mode (@pxopref{begmodeword} and
@@ -719,25 +716,6 @@ endmodephrase foreign before 56
 lenmodephrase foreign 4
 @end example
 
-Within a word, a user-defined mode is terminated by the first
-character that is not a letter, like uppercase mode. A letter that
-does not belong to the mode does not terminate it. A word can
-therefore contain both letters from the mode and other letters, and
-be marked with a single @code{begmodeword} indicator.
-
-A character that is linked to a character in the mode with the
-@opcoderef{base} does terminate the mode. This is what terminates
-uppercase mode at a lowercase letter. After @code{base uppercase A a},
-@code{A} and @code{a} have the same dot pattern, and only the
-indicator tells them apart. A lowercase letter that is not the base
-of an uppercase letter does not terminate uppercase mode.
-
-Use @code{base} to define the characters of a mode when they share
-the dot pattern of a character outside the mode. Use
-@code{lowercase} or @code{uppercase} rules together with
-@code{attribute} when the characters outside the mode must not
-terminate it.
-
 Note: back-translation does not currently recognize the indicators
 of user-defined modes.
 
@@ -749,6 +727,35 @@ of user-defined modes.
 The dot pattern which indicates that a certain mode is entered for the
 following word or remainder of the current word. The mode is
 automatically terminated by the first character that is not a letter.
+A letter also terminates the mode when a @opcoderef{base} links it to
+a character of the class. A letter that does not belong to the class
+and is not linked to it does not terminate the mode; the word is then
+still marked with a single indicator.
+
+The following two tables define the Greek letter @samp{α} in a
+class named @code{foreign} with a letter and a word indicator:
+
+@example
+lowercase α 246
+attribute foreign α
+modeletter foreign 56
+begmodeword foreign 56
+@end example
+
+@example
+lowercase a 1
+base foreign α a
+modeletter foreign 56
+begmodeword foreign 56
+@end example
+
+With the first table, @samp{a} does not terminate foreign mode, and a
+word that combines @samp{α} and @samp{a} is marked with a
+single word indicator. With the second table, @samp{α} is
+written with the dot pattern of @samp{a} and only the indicator tells
+them apart, so @samp{a} does terminate the mode, in the same way that
+a lowercase letter terminates uppercase mode; each @samp{α} in
+such a word is marked separately with the letter indicator.
 
 For uppercase mode, you can define a list of characters that can
 appear within a word in capitals without terminating the block. Do
@@ -826,17 +833,18 @@ endcaps 6-3
 @opcode{begmodephrase, attribute dots}
 @opcode{begcapsphrase, dots}
 The dot pattern which indicates that a mode is entered for a phrase.
-A phrase only contains whole words: words that are in the mode from
-their first to their last character, such as words without lowercase
-letters in uppercase mode. The phrase must have at least the number
+A phrase only contains whole words: words for which the mode lasts
+from the first to the last character, such as words without lowercase
+letters in the case of uppercase mode. The phrase must have at least the number
 of words specified with @code{lenmodephrase}
 (@pxopref{lenmodephrase}); shorter sequences are indicated word by
-word. A phrase indicator can only be used together with a word
-indicator (@pxopref{begmodeword}). The end of the phrase is indicated
+word. A @code{begmodephrase} rule requires a corresponding
+@code{begmodeword} rule to be defined as well (@pxopref{begmodeword}). The end of the phrase is indicated
 with @code{endmodephrase} (@pxopref{endmodephrase before} and
 @opref{endmodephrase after}). If no @code{endmodephrase} rule is
-defined, the @code{endmode} indicator (@pxopref{endmode}), if any, is
-inserted after the last word of the phrase.
+defined, the @code{endmode} indicator (@pxopref{endmode}) is inserted
+after the last word of the phrase. Either @code{endmodephrase} or
+@code{endmode} must be defined.
 
 Example:
 
@@ -1890,8 +1898,7 @@ used in @code{match} rules (@pxref{match
 opcode,match,@code{match}}). Named classes can be used with the
 @code{before} and @code{after} opcodes and in @code{context} and
 multipass rules (@pxref{The Context and Multipass Opcodes}). A named
-class can also define a mode for braille indicators
-(@pxopref{modeletter}).
+class can also define a mode (@pxopref{modeletter}).
 
 @opcode{after, class opcode ...}
 The specified opcode is further constrained in that the matched

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -696,6 +696,40 @@ capsletter 6
 modeletter uppercase 6
 @end example
 
+The attribute operand may be @code{uppercase}, @code{digit} or the
+name of a user-defined character class (@pxopref{attribute}). A
+user-defined class defines a mode of its own: a character is in the
+mode when it belongs to the class, and the mode indicators are
+inserted in front of such characters. A typical use is a braille code
+that marks letters from another alphabet with an alphabet change
+indicator. The following example puts some Greek letters in a class
+named @code{foreign} and defines a letter indicator, a word indicator
+and a phrase indicator for that mode (@pxopref{begmodeword} and
+@opref{begmodephrase}):
+
+@example
+lowercase α 1
+lowercase β 12
+lowercase γ 1245
+attribute foreign αβγ
+modeletter foreign 56
+begmodeword foreign 56
+begmodephrase foreign 56-56
+endmodephrase foreign before 56
+lenmodephrase foreign 4
+@end example
+
+Letters that do not belong to a user-defined mode do not end the
+mode within a word, unless they are linked with the @opcoderef{base}
+to a character that belongs to the mode. For that reason the
+characters of such a mode are usually defined with @code{lowercase}
+and @code{uppercase} rules and then added to the class with
+@code{attribute}, rather than with @code{base}.
+
+Apart from @code{uppercase}, at most 5 modes can be defined in a
+table. Back-translation does not recognize the indicators of
+user-defined modes.
+
 @code{emphletter} (@pxopref{emphletter}) is the counterpart of
 @code{modeletter} for indication of emphasis.
 
@@ -777,6 +811,90 @@ endcaps 6-3
 
 @code{endemph} (@pxopref{endemph}) is the counterpart of
 @code{endmode} for indication of emphasis.
+
+@opcode{begmodephrase, attribute dots}
+@opcode{begcapsphrase, dots}
+The dot pattern which indicates that a mode is entered for a phrase.
+A phrase only contains whole words: words that are in the mode from
+their first to their last character, such as words without lowercase
+letters in uppercase mode. The phrase must have at least the number
+of words specified with @code{lenmodephrase}
+(@pxopref{lenmodephrase}); shorter sequences are indicated word by
+word. A phrase indicator can only be used together with a word
+indicator (@pxopref{begmodeword}). The end of the phrase is indicated
+with @code{endmodephrase} (@pxopref{endmodephrase before} and
+@opref{endmodephrase after}). If no @code{endmodephrase} rule is
+defined, the @code{endmode} indicator (@pxopref{endmode}), if any, is
+inserted after the last word of the phrase.
+
+Example:
+
+@example
+begcapsphrase 6-6-6
+@end example
+
+@code{begemphphrase} (@pxopref{begemphphrase}) is the counterpart of
+@code{begmodephrase} for indication of emphasis.
+
+@c define a special opcode macro that can handle the two-word nature
+@c of the endmodephrase and endcapsphrase opcodes
+@macro endmodephraseopcode{where}
+@opcodeindex endmodephrase \where\
+@anchor{endmodephrase \where\ opcode}
+@item endmodephrase attribute \where\ dots
+@opcodeindex endcapsphrase \where\
+@anchor{endcapsphrase \where\ opcode}
+@item endcapsphrase \where\ dots
+@end macro
+
+@endmodephraseopcode{before}
+The dot pattern which terminates a phrase. The indicator is placed
+before the last word of the phrase.
+
+Example:
+
+@example
+endcapsphrase before 6
+@end example
+
+@endmodephraseopcode{after}
+The dot pattern which terminates a phrase. The indicator is placed
+after the last word of the phrase. @code{endmodephrase before} and
+@code{endmodephrase after} can not both be defined for the same mode.
+
+Example:
+
+@example
+endcapsphrase after 6-3
+@end example
+
+If an @code{endmode} indicator is defined for the mode, it is used to
+close the phrase after the last word, also when @code{endmodephrase
+before} is defined.
+
+@code{endemphphrase} (@pxref{endemphphrase before opcode,endemphphrase
+before,@code{endemphphrase before}} and @ref{endemphphrase after
+opcode,endemphphrase after,@code{endemphphrase after}}) is the
+counterpart of @code{endmodephrase} for indication of emphasis.
+
+@opcode{lenmodephrase, attribute number}
+@opcode{lencapsphrase, number}
+The minimum number of words that a sequence of words must have to be
+indicated as a phrase. Phrases are only formed when this rule is
+defined.
+
+Example:
+
+@example
+lencapsphrase 3
+@end example
+
+With the above rule, two consecutive capitalized words are indicated
+with @code{begcapsword} each, while three or more are indicated with
+@code{begcapsphrase} and @code{endcapsphrase}.
+
+@code{lenemphphrase} (@pxopref{lenemphphrase}) is the counterpart of
+@code{lenmodephrase} for indication of emphasis.
 
 @opcode{letsign, dots}
 This indicator is needed in Grade 2 to show that a single letter is
@@ -1764,7 +1882,9 @@ has been created with an @code{attribute} rule. Numbered classes can be
 used in @code{match} rules (@pxref{match
 opcode,match,@code{match}}). Named classes can be used with the
 @code{before} and @code{after} opcodes and in @code{context} and
-multipass rules (@pxref{The Context and Multipass Opcodes}).
+multipass rules (@pxref{The Context and Multipass Opcodes}). A named
+class can also define a mode for braille indicators
+(@pxopref{modeletter}).
 
 @opcode{after, class opcode ...}
 The specified opcode is further constrained in that the matched

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -719,19 +719,27 @@ endmodephrase foreign before 56
 lenmodephrase foreign 4
 @end example
 
-Within a word, a user-defined mode behaves like uppercase mode. Just
-as a letter that is neither uppercase nor lowercase does not end
-uppercase mode, a letter outside the mode does not end the mode. The
-mode ends at a character that is not a letter, or at a character
-that is linked with the @opcoderef{base} to a character in the mode
-(the counterpart of a lowercase letter in uppercase mode). Define the
-characters of a mode with @code{lowercase} and @code{uppercase} rules
-and add them to the class with @code{attribute}. Defining them with
-@code{base} would link them to characters outside the mode, which
-would then end the mode.
+Within a word, a user-defined mode is terminated by the first
+character that is not a letter, like uppercase mode. A letter that
+does not belong to the mode does not terminate it. A word can
+therefore contain both letters from the mode and other letters, and
+be marked with a single @code{begmodeword} indicator.
 
-Back-translation does not recognize the indicators of user-defined
-modes.
+A character that is linked to a character in the mode with the
+@opcoderef{base} does terminate the mode. This is what terminates
+uppercase mode at a lowercase letter. After @code{base uppercase A a},
+@code{A} and @code{a} have the same dot pattern, and only the
+indicator tells them apart. A lowercase letter that is not the base
+of an uppercase letter does not terminate uppercase mode.
+
+Use @code{base} to define the characters of a mode when they share
+the dot pattern of a character outside the mode. Use
+@code{lowercase} or @code{uppercase} rules together with
+@code{attribute} when the characters outside the mode must not
+terminate it.
+
+Note: back-translation does not currently recognize the indicators
+of user-defined modes.
 
 @code{emphletter} (@pxopref{emphletter}) is the counterpart of
 @code{modeletter} for indication of emphasis.
@@ -870,10 +878,6 @@ Example:
 @example
 endcapsphrase after 6-3
 @end example
-
-If an @code{endmode} indicator is defined for the mode, it is used to
-close the phrase after the last word, also when @code{endmodephrase
-before} is defined.
 
 @code{endemphphrase} (@pxref{endemphphrase before opcode,endemphphrase
 before,@code{endemphphrase before}} and @ref{endemphphrase after

--- a/doc/liblouis.texi
+++ b/doc/liblouis.texi
@@ -719,16 +719,19 @@ endmodephrase foreign before 56
 lenmodephrase foreign 4
 @end example
 
-Letters that do not belong to a user-defined mode do not end the
-mode within a word, unless they are linked with the @opcoderef{base}
-to a character that belongs to the mode. For that reason the
-characters of such a mode are usually defined with @code{lowercase}
-and @code{uppercase} rules and then added to the class with
-@code{attribute}, rather than with @code{base}.
+Within a word, a user-defined mode behaves like uppercase mode. Just
+as a letter that is neither uppercase nor lowercase does not end
+uppercase mode, a letter outside the mode does not end the mode. The
+mode ends at a character that is not a letter, or at a character
+that is linked with the @opcoderef{base} to a character in the mode
+(the counterpart of a lowercase letter in uppercase mode). Define the
+characters of a mode with @code{lowercase} and @code{uppercase} rules
+and add them to the class with @code{attribute}. Defining them with
+@code{base} would link them to characters outside the mode, which
+would then end the mode.
 
-Apart from @code{uppercase}, at most 5 modes can be defined in a
-table. Back-translation does not recognize the indicators of
-user-defined modes.
+Back-translation does not recognize the indicators of user-defined
+modes.
 
 @code{emphletter} (@pxopref{emphletter}) is the counterpart of
 @code{modeletter} for indication of emphasis.


### PR DESCRIPTION
The manual documents the mode indicator opcodes `modeletter`, `begmodeword`, `endmodeword`, `begmode` and `endmode`. It does not document the three phrase-level ones: `begmodephrase`, `endmodephrase` and `lenmodephrase`. Their uppercase aliases `begcapsphrase`, `endcapsphrase` and `lencapsphrase` are undocumented as well. All mode opcodes were added in #1123 (released in 3.20.0). The documentation commit in that PR covered the other mode opcodes only.

The manual also does not say that the attribute operand of the mode opcodes can be a user-defined character class. That is how the Dutch table implements its alphabet change indicator (#1137): it puts letters from other alphabets in a class named `foreign` and defines mode indicators for that class.

This PR updates `doc/liblouis.texi`.
<!--
This PR changes `doc/liblouis.texi` in three places:

- Under `modeletter`, it explains that a user-defined class defines a mode of its own, with an alphabet change indicator as example. It also describes which letters end such a mode within a word (letters outside the mode do not, unless they are linked to a mode character with `base`), that at most five modes can be defined besides `uppercase`, and that back-translation does not recognize the indicators of user-defined modes.
- After `endmode`, it adds entries for `begmodephrase`/`begcapsphrase`, `endmodephrase`/`endcapsphrase` (`before` and `after`) and `lenmodephrase`/`lencapsphrase`. They state that phrases are only formed when a word indicator and a phrase length are defined, and how the phrase is closed when no `endmodephrase` rule exists: the `endmode` indicator is inserted after the last word, and it also takes precedence over `endmodephrase before`.
- Under `attribute`, it mentions that a named class can define a mode.
-->

The described behavior was checked against the translator with small test tables and with the Dutch table.

## Checklist

### Assistance from artificial intelligence

Additional boxes to check if you created this contribution with the help of AI:

- [x] I have reviewed the code myself and understand it
