### PR TITLE
th-g1.uti: remove unused and invalid swapdd rule

### DIFF
--- a/tables/th-g1.uti
+++ b/tables/th-g1.uti
@@ -153,7 +153,6 @@ attribute ToneAndVowels \x0e30\x0e31\x0e47\x0e32\x0e34\x0e35\x0e38\x0e39\x0e36\x
 attribute 2 \x0e30\x0e31\x0e47\x0e32\x0e34\x0e35\x0e38\x0e39\x0e36\x0e37\x0e33\x0e48\x0e49\x0e4a\x0e4b # สระตามหลัง
 attribute ToneAndVowelsNoSaraAh \x0e31\x0e47\x0e32\x0e34\x0e35\x0e38\x0e39\x0e36\x0e37\x0e33\x0e48\x0e49\x0e4a\x0e4b # สระและวรรณยุกค์ที่ตามหลัง ยกเว้น สระอะ
 attribute Ahead \x0e44\x0e43\x0e42\x0e40 # สระนำหน้าทั้งหลาย
-swapdd Aheadbrl 156,156-2,24,124 156,156-2,24,124 # ไใโเ
 
 #ลดรูปสระเออมีตัวสะกด
 attribute leadcharacterSaraErSp \x0E01\x0E02\x0E04\x0E08\x0E17\x0E09\x0E16\x0E15\x0E1C\x0E1E\x0E2A\x0E2B


### PR DESCRIPTION
- The `Aheadbrl` swapdd rule in `th-g1.uti` used `156-2`, a two-cell dot pattern, in the search operand. The manual requires the search (second) operand of `swapdd` to use single cells only — multi-cell patterns there are ambiguous.
- The `Aheadbrl` swap class is not referenced anywhere else in `th-g1.uti`, in `th-g2.ctb` (which includes it), or via `%Aheadbrl`/`@Aheadbrl` elsewhere in the tree, so the rule is dead code. Removing it is the safe fix.

Fixes #2070