### PR TITLE
th-g2.ctb: fix missing dot pattern for ง in AfterAeSpell swapcd

### DIFF
--- a/tables/th-g2.ctb
+++ b/tables/th-g2.ctb
@@ -208,7 +208,7 @@ noback context ["\x0E40"%thaiconsinants]"\x0E47\x0E1A" @356*
 noback context ["\x0E40"%thaiconsinants%thaiconsinants]"\x0E47\x0E1A" @356*
 
 # สระ แอ และควบแท้
-swapcd AfterAeSpell \x0e01\x0e07\x0e14\x0e1A\x0e2D 1245,145,1236,135 #กงดบอ
+swapcd AfterAeSpell \x0e01\x0e07\x0e14\x0e1A\x0e2D 1245,12456,145,1236,135 #กงดบอ
 # แ-ไม้เอก ง
 noback context ["\x0E41"%thaiconsinants"\x0E48\x0E07"%AfterAeSpell]!%ToneAndVowels_ *  # หากมีตัวสะกดที่กำหนด ตามหลัง
 noback context ["\x0E41"%thaiconsinants]"\x0E48\x0E07"!%ToneAndVowels_ @4* 


### PR DESCRIPTION
- `swapcd AfterAeSpell` listed 5 characters (ก ง ด บ อ, per the trailing comment) but only 4 comma-separated dot patterns — ง's own base pattern was dropped between ก's and ด's.
- Cross-checked each character against its `letter` definition in `th-g1.uti`; the dots list is exactly the other four letters' own base patterns in order, with ง's `12456` missing. This isn't dead code: `%AfterAeSpell` is referenced 6 more times in the "แ" (ae) vowel-spelling `context` rules just below, so as written ง could never match any of them.

Fixes #2072