### PR TITLE
Report the same version from the NMAKE build as from Autotools

### DIFF
--- a/windows/include/config.h
+++ b/windows/include/config.h
@@ -20,4 +20,4 @@ License along with liblouis. If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-#define PACKAGE_VERSION "liblouis-3.39.0"
+#define PACKAGE_VERSION "3.39.0"


### PR DESCRIPTION
`lou_version()` returns `PACKAGE_VERSION`. Autotools takes that from `AC_INIT` in `configure.ac`, so a MinGW, cross-compiled or Unix build of 3.39.0 reports:

```
3.39.0
```

The hand-written `windows/include/config.h` used by the NMAKE build spells it with a package-name prefix, so the same function on the same release reports:

```
liblouis-3.39.0
```

The result is that `lou_version()` returns a different string depending on how the library was built on Windows, and a caller that parses it as a version number works against the MinGW DLL and fails against the NMAKE one. I ran into this packaging liblouis for a .NET wrapper.

The prefix has been there since the Windows build files were added in 2011 (`0d954784`, then `liblouis-2.3.0`) and looks like an oversight rather than a decision: `HACKING` lists `windows/include/config.h` right next to `configure.ac` under "Set the version number", which implies the two are meant to agree. Nothing in the tree reads the prefix.

Verified by rebuilding with `nmake /f Makefile.nmake ARCH=x64 UCS=4` before and after: the resulting DLL embeds `3.39.0` only.
