### PR TITLE
Declare direction only once in en_US-comp8-ext.tbl

### DIFF
--- a/tables/en_US-comp8-ext.tbl
+++ b/tables/en_US-comp8-ext.tbl
@@ -6,10 +6,9 @@
 #+region:en-US
 #+type:computer
 #+dots:8
-#+direction:both
-#+system:ebae
 # Marked as "direction:both" by Bue Vester-Andersen
 # as it is a computer Braille table.
 #+direction:both
+#+system:ebae
 
 include en-us-comp8-ext.utb


### PR DESCRIPTION
`tables/en_US-comp8-ext.tbl` declares `#+direction:both` twice:

```
#+language:en
#+region:en-US
#+type:computer
#+dots:8
#+direction:both          <- added 2017 (7bdc9f80a)
#+system:ebae
# Marked as "direction:both" by Bue Vester-Andersen
# as it is a computer Braille table.
#+direction:both          <- added 2021 (b67b3daa4)
```

The field was first set by Davy Kager in 2017. The direction-flag pass of 2021 (#1019) then added the explanatory comment together with a second, identical field rather than annotating the existing one. That pass set out to leave already-marked tables alone — *"If a table has already been marked by its author, nothing further is done"* — so the duplicate looks accidental. It is the only table in the tree with a repeated `direction`.

Repeating a key is allowed, and two identical values are harmless to `lou_findTable`, so this changes no behavior. It removes a discrepancy for anything that reads table metadata directly and reasonably expects one direction per table. I hit it writing a metadata parser for a .NET wrapper.

Bue's explanation is kept and moved directly above the field it describes, which is where every other table from that pass puts it (`Es-Es-G0.utb`, `bg.tbl`, `bo.tbl`, `cs-comp8.utb`, and the rest).
